### PR TITLE
feat(wireless): add wireless interface and security management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,3 +331,5 @@ _build/
 _static/
 _templates/
 .aider*
+
+mcp-config.json

--- a/README.md
+++ b/README.md
@@ -1267,6 +1267,12 @@ Add this to your `claude_desktop_config.json`:
 ```shell
 # Run the inspector against the mcp-server-mikrotik
 npx @modelcontextprotocol/inspector uvx mcp-server-mikrotik --host <HOST> --username <USERNAME> --password <PASSWORD> --port 22
+
+# Run the inspector against the mcp-config.json
+npm install -g @modelcontextprotocol/inspector
+cp mcp-config.json.example mcp-config.json
+nano mcp-config.json # Edit the values
+mcp-inspector --config mcp-config.json --server my-python-server
 ```
 
 ## UV

--- a/README.md
+++ b/README.md
@@ -1860,6 +1860,76 @@ uv run mcp-cli cmd --server mikrotik --tool mikrotik_enable_wireless_interface -
 uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_wireless_security_profile --tool-args '{"name": "old-profile"}'
 ```
 
+# Using MCPO with MikroTik MCP Server
+
+This guide shows how to expose your MikroTik MCP server as a RESTful API using MCPO (MCP-to-OpenAPI proxy).
+
+## Prerequisites
+
+- Python 3.8+
+- MikroTik MCP server already set up
+- `uv` package manager (recommended) or `pip`
+
+## Installation
+
+Install MCPO using one of these methods:
+
+```bash
+# Option 1: Using uvx (recommended - no installation needed)
+uvx mcpo --help
+
+# Option 2: Using pip
+pip install mcpo
+```
+
+## Configuration
+
+Create a `mcp-config.json` file in your project directory:
+
+```json
+{
+  "mcpServers": {
+    "my-python-server": {
+      "command": "python",
+      "args": [
+        "src/mcp_mikrotik/server.py",
+        "--password", "admin",
+        "--host", "192.168.1.1",
+        "--port", "22",
+        "--username", "admin"
+      ],
+      "env": {}
+    }
+  }
+}
+```
+
+**Note:** Adjust the MikroTik connection parameters (`host`, `username`, `password`, `port`) according to your setup.
+
+## Starting the MCPO Server
+
+```bash
+# Start MCPO with API key authentication
+uvx mcpo --port 8000 --api-key "your-secret-key" --config ./mcp-config.json
+
+# Or without authentication (not recommended for production)
+uvx mcpo --port 8000 --config ./mcp-config.json
+```
+
+The server will start and display:
+- Server running on `http://0.0.0.0:8000`
+- Interactive API docs available at `http://localhost:8000/docs`
+
+### cURL Examples
+
+**List IP Addresses:**
+```bash
+curl -X POST http://localhost:8000/my-python-server/mikrotik_list_ip_addresses \
+  -H "Authorization: Bearer your-secret-key" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
 ## License
 
 This MCP server is licensed under the MIT License. This means you are free to use, modify, and distribute the software, subject to the terms and conditions of the MIT License. For more details, please see the LICENSE file in the project repository.

--- a/README.md
+++ b/README.md
@@ -1616,6 +1616,244 @@ uv run mcp-cli cmd --server mikrotik --tool mikrotik_export_section --tool-args 
 uv run mcp-cli cmd --server mikrotik --tool mikrotik_export_section --tool-args '{"section": "/ip/firewall/nat", "name": "nat_backup"}'
 ```
 
+### Create Wireless Interface
+```bash
+# Create basic AP interface
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_interface --tool-args '{"name": "wlan1", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "MyNetwork", "comment": "Main WiFi Network"}'
+
+# Create station interface
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_interface --tool-args '{"name": "wlan-sta", "radio_name": "wlan2", "mode": "station", "ssid": "UpstreamWiFi"}'
+
+# Create with specific frequency and band
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_interface --tool-args '{"name": "wlan-5g", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "MyNetwork-5G", "frequency": "5180", "band": "5ghz-a/n/ac", "channel_width": "80mhz"}'
+```
+
+### List and Manage Wireless Interfaces
+```bash
+# List all wireless interfaces
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_interfaces --tool-args '{}'
+
+# List only AP interfaces
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_interfaces --tool-args '{"mode_filter": "ap-bridge"}'
+
+# List only running interfaces
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_interfaces --tool-args '{"running_only": true}'
+
+# Get specific interface details
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_wireless_interface --tool-args '{"name": "wlan1"}'
+
+# Update wireless interface
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_update_wireless_interface --tool-args '{"name": "wlan1", "ssid": "UpdatedNetworkName", "comment": "Updated main network"}'
+
+# Enable/Disable wireless interface
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_disable_wireless_interface --tool-args '{"name": "wlan1"}'
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_enable_wireless_interface --tool-args '{"name": "wlan1"}'
+
+# Remove wireless interface
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_wireless_interface --tool-args '{"name": "wlan-guest"}'
+```
+
+## Wireless Security Profile Management
+
+### Create Security Profiles
+```bash
+# Create WPA2-PSK security profile
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_security_profile --tool-args '{"name": "wpa2-security", "mode": "dynamic-keys", "authentication_types": ["wpa2-psk"], "unicast_ciphers": ["aes-ccm"], "group_ciphers": ["aes-ccm"], "wpa2_pre_shared_key": "SecurePassword123"}'
+
+# Create mixed WPA/WPA2 profile
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_security_profile --tool-args '{"name": "mixed-security", "mode": "dynamic-keys", "authentication_types": ["wpa-psk", "wpa2-psk"], "unicast_ciphers": ["tkip", "aes-ccm"], "group_ciphers": ["tkip"], "wpa_pre_shared_key": "Password123", "wpa2_pre_shared_key": "Password123"}'
+
+# Create WPA2-Enterprise profile
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_security_profile --tool-args '{"name": "enterprise-security", "mode": "dynamic-keys", "authentication_types": ["wpa2-eap"], "unicast_ciphers": ["aes-ccm"], "group_ciphers": ["aes-ccm"], "eap_methods": "peap,tls"}'
+
+# Create open network profile
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_security_profile --tool-args '{"name": "open-network", "mode": "none", "comment": "Guest network - no security"}'
+```
+
+### Manage Security Profiles
+```bash
+# List all security profiles
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_security_profiles --tool-args '{}'
+
+# List WPA2 profiles only
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_security_profiles --tool-args '{"mode_filter": "dynamic-keys"}'
+
+# Get specific profile details
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_wireless_security_profile --tool-args '{"name": "wpa2-security"}'
+
+# Apply security profile to interface
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_set_wireless_security_profile --tool-args '{"interface_name": "wlan1", "security_profile": "wpa2-security"}'
+
+# Remove security profile
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_wireless_security_profile --tool-args '{"name": "old-profile"}'
+```
+
+## Wireless Network Operations
+
+### Network Scanning and Monitoring
+```bash
+# Scan for available networks
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_scan_wireless_networks --tool-args '{"interface": "wlan1", "duration": 10}'
+
+# Quick scan (5 seconds)
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_scan_wireless_networks --tool-args '{"interface": "wlan2"}'
+
+# Get connected clients (all interfaces)
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_wireless_registration_table --tool-args '{}'
+
+# Get clients for specific interface
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_wireless_registration_table --tool-args '{"interface": "wlan1"}'
+```
+
+## Wireless Access List Management
+
+### Create Access List Entries
+```bash
+# Allow specific MAC address
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_access_list --tool-args '{"interface": "wlan1", "mac_address": "AA:BB:CC:DD:EE:FF", "action": "accept", "comment": "Trusted device"}'
+
+# Block specific MAC address
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_access_list --tool-args '{"interface": "wlan1", "mac_address": "11:22:33:44:55:66", "action": "reject", "comment": "Blocked device"}'
+
+# Allow with signal strength requirement
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_access_list --tool-args '{"interface": "wlan1", "mac_address": "AA:BB:CC:DD:EE:FF", "action": "accept", "signal_range": "-80..-50", "comment": "Strong signal only"}'
+
+# Time-based access control
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_access_list --tool-args '{"interface": "wlan1", "mac_address": "AA:BB:CC:DD:EE:FF", "action": "accept", "time": "8h-18h,mon,tue,wed,thu,fri", "comment": "Work hours only"}'
+```
+
+### Manage Access Lists
+```bash
+# List all access list entries
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_access_list --tool-args '{}'
+
+# List entries for specific interface
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_access_list --tool-args '{"interface_filter": "wlan1"}'
+
+# List only blocked entries
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_access_list --tool-args '{"action_filter": "reject"}'
+
+# Remove access list entry
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_wireless_access_list_entry --tool-args '{"entry_id": "*1"}'
+```
+
+## Complete WiFi Network Setup Examples
+
+### Basic Home Network Setup
+```bash
+# 1. Create security profile
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_security_profile --tool-args '{"name": "home-security", "mode": "dynamic-keys", "authentication_types": ["wpa2-psk"], "unicast_ciphers": ["aes-ccm"], "group_ciphers": ["aes-ccm"], "wpa2_pre_shared_key": "MyHomePassword123"}'
+
+# 2. Create wireless interface
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_interface --tool-args '{"name": "home-wifi", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "HomeNetwork", "band": "2ghz-b/g/n", "comment": "Main home network"}'
+
+# 3. Apply security profile
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_set_wireless_security_profile --tool-args '{"interface_name": "home-wifi", "security_profile": "home-security"}'
+
+# 4. Enable the interface
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_enable_wireless_interface --tool-args '{"name": "home-wifi"}'
+```
+
+### Guest Network Setup
+```bash
+# 1. Create open security profile for guests
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_security_profile --tool-args '{"name": "guest-open", "mode": "none", "comment": "Open guest network"}'
+
+# 2. Create guest wireless interface
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_interface --tool-args '{"name": "guest-wifi", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "GuestNetwork", "comment": "Guest access network"}'
+
+# 3. Apply open security profile
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_set_wireless_security_profile --tool-args '{"interface_name": "guest-wifi", "security_profile": "guest-open"}'
+
+# 4. Enable guest network
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_enable_wireless_interface --tool-args '{"name": "guest-wifi"}'
+```
+
+### Enterprise Network Setup
+```bash
+# 1. Create WPA2-Enterprise security profile
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_security_profile --tool-args '{"name": "corp-security", "mode": "dynamic-keys", "authentication_types": ["wpa2-eap"], "unicast_ciphers": ["aes-ccm"], "group_ciphers": ["aes-ccm"], "eap_methods": "peap", "comment": "Corporate WPA2-Enterprise"}'
+
+# 2. Create corporate wireless interface
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_interface --tool-args '{"name": "corp-wifi", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "CorpNetwork", "band": "5ghz-a/n/ac", "channel_width": "80mhz", "comment": "Corporate network"}'
+
+# 3. Apply enterprise security
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_set_wireless_security_profile --tool-args '{"interface_name": "corp-wifi", "security_profile": "corp-security"}'
+
+# 4. Create access control for specific devices
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_access_list --tool-args '{"interface": "corp-wifi", "mac_address": "00:11:22:33:44:55", "action": "accept", "comment": "Corporate laptop"}'
+```
+
+### Dual-Band Setup (2.4GHz + 5GHz)
+```bash
+# 1. Create security profile
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_security_profile --tool-args '{"name": "dual-band-security", "mode": "dynamic-keys", "authentication_types": ["wpa2-psk"], "unicast_ciphers": ["aes-ccm"], "group_ciphers": ["aes-ccm"], "wpa2_pre_shared_key": "DualBandPassword123"}'
+
+# 2. Create 2.4GHz interface
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_interface --tool-args '{"name": "wifi-2g", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "MyNetwork", "band": "2ghz-b/g/n", "channel_width": "20mhz", "comment": "2.4GHz network"}'
+
+# 3. Create 5GHz interface  
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_interface --tool-args '{"name": "wifi-5g", "radio_name": "wlan2", "mode": "ap-bridge", "ssid": "MyNetwork-5G", "band": "5ghz-a/n/ac", "channel_width": "80mhz", "comment": "5GHz network"}'
+
+# 4. Apply security to both interfaces
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_set_wireless_security_profile --tool-args '{"interface_name": "wifi-2g", "security_profile": "dual-band-security"}'
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_set_wireless_security_profile --tool-args '{"interface_name": "wifi-5g", "security_profile": "dual-band-security"}'
+
+# 5. Enable both interfaces
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_enable_wireless_interface --tool-args '{"name": "wifi-2g"}'
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_enable_wireless_interface --tool-args '{"name": "wifi-5g"}'
+```
+
+### Point-to-Point Wireless Link
+```bash
+# On first device (Station)
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_interface --tool-args '{"name": "p2p-station", "radio_name": "wlan1", "mode": "station", "ssid": "P2P-Link", "frequency": "5180", "band": "5ghz-a/n"}'
+
+# On second device (AP)  
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_interface --tool-args '{"name": "p2p-ap", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "P2P-Link", "frequency": "5180", "band": "5ghz-a/n"}'
+
+# Create security for P2P link
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_security_profile --tool-args '{"name": "p2p-security", "mode": "dynamic-keys", "authentication_types": ["wpa2-psk"], "unicast_ciphers": ["aes-ccm"], "group_ciphers": ["aes-ccm"], "wpa2_pre_shared_key": "P2PLinkPassword123"}'
+
+# Apply security to both ends
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_set_wireless_security_profile --tool-args '{"interface_name": "p2p-station", "security_profile": "p2p-security"}'
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_set_wireless_security_profile --tool-args '{"interface_name": "p2p-ap", "security_profile": "p2p-security"}'
+```
+
+## Monitoring and Troubleshooting
+
+### Network Analysis
+```bash
+# Scan for interference and available channels
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_scan_wireless_networks --tool-args '{"interface": "wlan1", "duration": 30}'
+
+# Monitor connected clients
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_wireless_registration_table --tool-args '{"interface": "wlan1"}'
+
+# Check interface status
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_wireless_interface --tool-args '{"name": "wlan1"}'
+
+# List all wireless configurations
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_interfaces --tool-args '{}'
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_security_profiles --tool-args '{}'
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_access_list --tool-args '{}'
+```
+
+### Maintenance Operations
+```bash
+# Disable interface for maintenance
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_disable_wireless_interface --tool-args '{"name": "wlan1"}'
+
+# Update configuration
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_update_wireless_interface --tool-args '{"name": "wlan1", "channel_width": "40mhz", "comment": "Updated for better performance"}'
+
+# Re-enable interface
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_enable_wireless_interface --tool-args '{"name": "wlan1"}'
+
+# Clean up unused profiles
+uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_wireless_security_profile --tool-args '{"name": "old-profile"}'
+```
+
 ## License
 
 This MCP server is licensed under the MIT License. This means you are free to use, modify, and distribute the software, subject to the terms and conditions of the MIT License. For more details, please see the LICENSE file in the project repository.

--- a/mcp-config.json.example
+++ b/mcp-config.json.example
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "my-python-server": {
+      "command": "${PATH_TO_PYTHON_EXECUTE_ABLE_FILE}:-python",
+      "args": [
+          "${PATH_TO_SERVER_PY}:-mikrotik-mcp/src/mcp_mikrotik/server.py",
+          "--password", "${PASSWORD}:-admin",
+          "--host", "${HOST}:-127.0.0.1",
+          "--port", "${SSH_PORT}:-22",
+          "--username", "${USERNAME}:-admin"
+      ],
+      "env": {}
+    }
+  }
+}

--- a/src/mcp_mikrotik/scope/wireless.py
+++ b/src/mcp_mikrotik/scope/wireless.py
@@ -1,0 +1,640 @@
+from typing import List, Optional, Dict, Any
+
+from ..connector import execute_mikrotik_command
+from ..logger import app_logger
+
+
+def mikrotik_create_wireless_interface(
+        name: str,
+        radio_name: str,
+        mode: str = "ap-bridge",
+        ssid: Optional[str] = None,
+        frequency: Optional[str] = None,
+        band: Optional[str] = None,
+        channel_width: Optional[str] = None,
+        disabled: bool = False,
+        comment: Optional[str] = None
+) -> str:
+    """
+    Creates a wireless interface on MikroTik device.
+
+    Args:
+        name: Name of the wireless interface
+        radio_name: Name of the radio interface (e.g., "wlan1")
+        mode: Wireless mode (ap-bridge, station, bridge, etc.)
+        ssid: Network SSID name
+        frequency: Operating frequency
+        band: Frequency band (2ghz-b/g/n, 5ghz-a/n/ac, etc.)
+        channel_width: Channel width (20mhz, 40mhz, 80mhz, etc.)
+        disabled: Whether to disable the interface
+        comment: Optional comment
+
+    Returns:
+        Command output or error message
+    """
+    app_logger.info(f"Creating wireless interface: name={name}, radio={radio_name}, mode={mode}")
+
+    # Build the command
+    cmd = f"/interface wireless add name={name} radio-name={radio_name} mode={mode}"
+
+    # Add optional parameters
+    if ssid:
+        cmd += f' ssid="{ssid}"'
+
+    if frequency:
+        cmd += f" frequency={frequency}"
+
+    if band:
+        cmd += f" band={band}"
+
+    if channel_width:
+        cmd += f" channel-width={channel_width}"
+
+    if disabled:
+        cmd += " disabled=yes"
+
+    if comment:
+        cmd += f' comment="{comment}"'
+
+    result = execute_mikrotik_command(cmd)
+
+    if "failure:" in result.lower() or "error" in result.lower():
+        return f"Failed to create wireless interface: {result}"
+
+    # Get the created interface details
+    details_cmd = f'/interface wireless print detail where name="{name}"'
+    details = execute_mikrotik_command(details_cmd)
+
+    return f"Wireless interface created successfully:\n\n{details}"
+
+
+def mikrotik_list_wireless_interfaces(
+        name_filter: Optional[str] = None,
+        mode_filter: Optional[str] = None,
+        disabled_only: bool = False,
+        running_only: bool = False
+) -> str:
+    """
+    Lists wireless interfaces on MikroTik device.
+
+    Args:
+        name_filter: Filter by interface name
+        mode_filter: Filter by wireless mode
+        disabled_only: Show only disabled interfaces
+        running_only: Show only running interfaces
+
+    Returns:
+        List of wireless interfaces
+    """
+    app_logger.info(f"Listing wireless interfaces with filters: name={name_filter}, mode={mode_filter}")
+
+    # Build the command
+    cmd = "/interface wireless print"
+
+    # Add filters
+    filters = []
+    if name_filter:
+        filters.append(f'name~"{name_filter}"')
+    if mode_filter:
+        filters.append(f'mode="{mode_filter}"')
+    if disabled_only:
+        filters.append("disabled=yes")
+    if running_only:
+        filters.append("running=yes")
+
+    if filters:
+        cmd += " where " + " and ".join(filters)
+
+    result = execute_mikrotik_command(cmd)
+
+    if not result or result.strip() == "":
+        return "No wireless interfaces found matching the criteria."
+
+    return f"WIRELESS INTERFACES:\n\n{result}"
+
+
+def mikrotik_get_wireless_interface(name: str) -> str:
+    """
+    Gets detailed information about a specific wireless interface.
+
+    Args:
+        name: Name of the wireless interface
+
+    Returns:
+        Detailed information about the wireless interface
+    """
+    app_logger.info(f"Getting wireless interface details: name={name}")
+
+    cmd = f'/interface wireless print detail where name="{name}"'
+    result = execute_mikrotik_command(cmd)
+
+    if not result or result.strip() == "":
+        return f"Wireless interface '{name}' not found."
+
+    return f"WIRELESS INTERFACE DETAILS:\n\n{result}"
+
+
+def mikrotik_update_wireless_interface(
+        name: str,
+        new_name: Optional[str] = None,
+        ssid: Optional[str] = None,
+        frequency: Optional[str] = None,
+        band: Optional[str] = None,
+        channel_width: Optional[str] = None,
+        mode: Optional[str] = None,
+        disabled: Optional[bool] = None,
+        comment: Optional[str] = None
+) -> str:
+    """
+    Updates an existing wireless interface.
+
+    Args:
+        name: Current name of the wireless interface
+        new_name: New name for the interface
+        ssid: New SSID name
+        frequency: New operating frequency
+        band: New frequency band
+        channel_width: New channel width
+        mode: New wireless mode
+        disabled: Enable/disable interface
+        comment: New comment
+
+    Returns:
+        Command output or error message
+    """
+    app_logger.info(f"Updating wireless interface: name={name}")
+
+    # Check if interface exists
+    check_cmd = f'/interface wireless print count-only where name="{name}"'
+    count = execute_mikrotik_command(check_cmd)
+
+    if count.strip() == "0":
+        return f"Wireless interface '{name}' not found."
+
+    # Build update command
+    updates = []
+
+    if new_name:
+        updates.append(f"name={new_name}")
+    if ssid:
+        updates.append(f'ssid="{ssid}"')
+    if frequency:
+        updates.append(f"frequency={frequency}")
+    if band:
+        updates.append(f"band={band}")
+    if channel_width:
+        updates.append(f"channel-width={channel_width}")
+    if mode:
+        updates.append(f"mode={mode}")
+    if disabled is not None:
+        updates.append(f"disabled={'yes' if disabled else 'no'}")
+    if comment:
+        updates.append(f'comment="{comment}"')
+
+    if not updates:
+        return "No updates specified."
+
+    cmd = f'/interface wireless set [find name="{name}"] {" ".join(updates)}'
+    result = execute_mikrotik_command(cmd)
+
+    if "failure:" in result.lower() or "error" in result.lower():
+        return f"Failed to update wireless interface: {result}"
+
+    # Get updated details
+    target_name = new_name if new_name else name
+    details_cmd = f'/interface wireless print detail where name="{target_name}"'
+    details = execute_mikrotik_command(details_cmd)
+
+    return f"Wireless interface updated successfully:\n\n{details}"
+
+
+def mikrotik_remove_wireless_interface(name: str) -> str:
+    """
+    Removes a wireless interface from MikroTik device.
+
+    Args:
+        name: Name of the wireless interface to remove
+
+    Returns:
+        Command output or error message
+    """
+    app_logger.info(f"Removing wireless interface: name={name}")
+
+    # Check if interface exists
+    check_cmd = f'/interface wireless print count-only where name="{name}"'
+    count = execute_mikrotik_command(check_cmd)
+
+    if count.strip() == "0":
+        return f"Wireless interface '{name}' not found."
+
+    # Remove the interface
+    cmd = f'/interface wireless remove [find name="{name}"]'
+    result = execute_mikrotik_command(cmd)
+
+    if "failure:" in result.lower() or "error" in result.lower():
+        return f"Failed to remove wireless interface: {result}"
+
+    return f"Wireless interface '{name}' removed successfully."
+
+
+def mikrotik_create_wireless_security_profile(
+        name: str,
+        mode: str = "dynamic-keys",
+        authentication_types: Optional[List[str]] = None,
+        unicast_ciphers: Optional[List[str]] = None,
+        group_ciphers: Optional[List[str]] = None,
+        wpa_pre_shared_key: Optional[str] = None,
+        wpa2_pre_shared_key: Optional[str] = None,
+        supplicant_identity: Optional[str] = None,
+        eap_methods: Optional[str] = None,
+        tls_mode: Optional[str] = None,
+        tls_certificate: Optional[str] = None,
+        comment: Optional[str] = None
+) -> str:
+    """
+    Creates a wireless security profile on MikroTik device.
+
+    Args:
+        name: Name of the security profile
+        mode: Security mode (none, static-keys-required, dynamic-keys, etc.)
+        authentication_types: List of authentication types (wpa-psk, wpa2-psk, wpa-eap, wpa2-eap)
+        unicast_ciphers: List of unicast ciphers (tkip, aes-ccm)
+        group_ciphers: List of group ciphers (tkip, aes-ccm)
+        wpa_pre_shared_key: WPA pre-shared key
+        wpa2_pre_shared_key: WPA2 pre-shared key
+        supplicant_identity: Supplicant identity for EAP
+        eap_methods: EAP methods
+        tls_mode: TLS mode
+        tls_certificate: TLS certificate
+        comment: Optional comment
+
+    Returns:
+        Command output or error message
+    """
+    app_logger.info(f"Creating wireless security profile: name={name}, mode={mode}")
+
+    # Build the command
+    cmd = f'/interface wireless security-profiles add name={name} mode={mode}'
+
+    # Add optional parameters
+    if authentication_types:
+        cmd += f" authentication-types={','.join(authentication_types)}"
+
+    if unicast_ciphers:
+        cmd += f" unicast-ciphers={','.join(unicast_ciphers)}"
+
+    if group_ciphers:
+        cmd += f" group-ciphers={','.join(group_ciphers)}"
+
+    if wpa_pre_shared_key:
+        cmd += f' wpa-pre-shared-key="{wpa_pre_shared_key}"'
+
+    if wpa2_pre_shared_key:
+        cmd += f' wpa2-pre-shared-key="{wpa2_pre_shared_key}"'
+
+    if supplicant_identity:
+        cmd += f' supplicant-identity="{supplicant_identity}"'
+
+    if eap_methods:
+        cmd += f" eap-methods={eap_methods}"
+
+    if tls_mode:
+        cmd += f" tls-mode={tls_mode}"
+
+    if tls_certificate:
+        cmd += f" tls-certificate={tls_certificate}"
+
+    if comment:
+        cmd += f' comment="{comment}"'
+
+    result = execute_mikrotik_command(cmd)
+
+    if "failure:" in result.lower() or "error" in result.lower():
+        return f"Failed to create wireless security profile: {result}"
+
+    # Get the created profile details
+    details_cmd = f'/interface wireless security-profiles print detail where name="{name}"'
+    details = execute_mikrotik_command(details_cmd)
+
+    return f"Wireless security profile created successfully:\n\n{details}"
+
+
+def mikrotik_list_wireless_security_profiles(
+        name_filter: Optional[str] = None,
+        mode_filter: Optional[str] = None
+) -> str:
+    """
+    Lists wireless security profiles on MikroTik device.
+
+    Args:
+        name_filter: Filter by profile name
+        mode_filter: Filter by security mode
+
+    Returns:
+        List of wireless security profiles
+    """
+    app_logger.info(f"Listing wireless security profiles with filters: name={name_filter}, mode={mode_filter}")
+
+    # Build the command
+    cmd = "/interface wireless security-profiles print"
+
+    # Add filters
+    filters = []
+    if name_filter:
+        filters.append(f'name~"{name_filter}"')
+    if mode_filter:
+        filters.append(f'mode="{mode_filter}"')
+
+    if filters:
+        cmd += " where " + " and ".join(filters)
+
+    result = execute_mikrotik_command(cmd)
+
+    if not result or result.strip() == "":
+        return "No wireless security profiles found matching the criteria."
+
+    return f"WIRELESS SECURITY PROFILES:\n\n{result}"
+
+
+def mikrotik_get_wireless_security_profile(name: str) -> str:
+    """
+    Gets detailed information about a specific wireless security profile.
+
+    Args:
+        name: Name of the security profile
+
+    Returns:
+        Detailed information about the security profile
+    """
+    app_logger.info(f"Getting wireless security profile details: name={name}")
+
+    cmd = f'/interface wireless security-profiles print detail where name="{name}"'
+    result = execute_mikrotik_command(cmd)
+
+    if not result or result.strip() == "":
+        return f"Wireless security profile '{name}' not found."
+
+    return f"WIRELESS SECURITY PROFILE DETAILS:\n\n{result}"
+
+
+def mikrotik_remove_wireless_security_profile(name: str) -> str:
+    """
+    Removes a wireless security profile from MikroTik device.
+
+    Args:
+        name: Name of the security profile to remove
+
+    Returns:
+        Command output or error message
+    """
+    app_logger.info(f"Removing wireless security profile: name={name}")
+
+    # Check if profile exists
+    check_cmd = f'/interface wireless security-profiles print count-only where name="{name}"'
+    count = execute_mikrotik_command(check_cmd)
+
+    if count.strip() == "0":
+        return f"Wireless security profile '{name}' not found."
+
+    # Remove the profile
+    cmd = f'/interface wireless security-profiles remove [find name="{name}"]'
+    result = execute_mikrotik_command(cmd)
+
+    if "failure:" in result.lower() or "error" in result.lower():
+        return f"Failed to remove wireless security profile: {result}"
+
+    return f"Wireless security profile '{name}' removed successfully."
+
+
+def mikrotik_set_wireless_security_profile(
+        interface_name: str,
+        security_profile: str
+) -> str:
+    """
+    Sets the security profile for a wireless interface.
+
+    Args:
+        interface_name: Name of the wireless interface
+        security_profile: Name of the security profile to apply
+
+    Returns:
+        Command output or error message
+    """
+    app_logger.info(f"Setting security profile for interface: {interface_name} -> {security_profile}")
+
+    # Check if interface exists
+    check_cmd = f'/interface wireless print count-only where name="{interface_name}"'
+    count = execute_mikrotik_command(check_cmd)
+
+    if count.strip() == "0":
+        return f"Wireless interface '{interface_name}' not found."
+
+    # Set the security profile
+    cmd = f'/interface wireless set [find name="{interface_name}"] security-profile={security_profile}'
+    result = execute_mikrotik_command(cmd)
+
+    if "failure:" in result.lower() or "error" in result.lower():
+        return f"Failed to set security profile: {result}"
+
+    return f"Security profile '{security_profile}' applied to interface '{interface_name}' successfully."
+
+
+def mikrotik_scan_wireless_networks(
+        interface: str,
+        duration: int = 5
+) -> str:
+    """
+    Scans for wireless networks using specified interface.
+
+    Args:
+        interface: Wireless interface to use for scanning
+        duration: Scan duration in seconds
+
+    Returns:
+        List of discovered wireless networks
+    """
+    app_logger.info(f"Scanning wireless networks on interface: {interface}")
+
+    # Start scan
+    scan_cmd = f'/interface wireless scan {interface} duration={duration}'
+    result = execute_mikrotik_command(scan_cmd)
+
+    if "failure:" in result.lower() or "error" in result.lower():
+        return f"Failed to scan wireless networks: {result}"
+
+    return f"WIRELESS NETWORK SCAN RESULTS:\n\n{result}"
+
+
+def mikrotik_get_wireless_registration_table(
+        interface: Optional[str] = None
+) -> str:
+    """
+    Gets the wireless registration table (connected clients).
+
+    Args:
+        interface: Filter by specific wireless interface
+
+    Returns:
+        List of registered wireless clients
+    """
+    app_logger.info(f"Getting wireless registration table for interface: {interface}")
+
+    # Build command
+    cmd = "/interface wireless registration-table print"
+
+    if interface:
+        cmd += f' where interface="{interface}"'
+
+    result = execute_mikrotik_command(cmd)
+
+    if not result or result.strip() == "":
+        return "No wireless clients registered."
+
+    return f"WIRELESS REGISTRATION TABLE:\n\n{result}"
+
+
+def mikrotik_create_wireless_access_list(
+        interface: str,
+        mac_address: str,
+        action: str = "accept",
+        signal_range: Optional[str] = None,
+        time: Optional[str] = None,
+        comment: Optional[str] = None
+) -> str:
+    """
+    Creates a wireless access list entry.
+
+    Args:
+        interface: Wireless interface
+        mac_address: MAC address to control
+        action: Action (accept, reject, query)
+        signal_range: Signal strength range
+        time: Time schedule
+        comment: Optional comment
+
+    Returns:
+        Command output or error message
+    """
+    app_logger.info(f"Creating wireless access list entry: {mac_address} -> {action}")
+
+    # Build command
+    cmd = f'/interface wireless access-list add interface={interface} mac-address={mac_address} action={action}'
+
+    # Add optional parameters
+    if signal_range:
+        cmd += f" signal-range={signal_range}"
+
+    if time:
+        cmd += f" time={time}"
+
+    if comment:
+        cmd += f' comment="{comment}"'
+
+    result = execute_mikrotik_command(cmd)
+
+    if "failure:" in result.lower() or "error" in result.lower():
+        return f"Failed to create wireless access list entry: {result}"
+
+    return f"Wireless access list entry created successfully."
+
+
+def mikrotik_list_wireless_access_list(
+        interface_filter: Optional[str] = None,
+        action_filter: Optional[str] = None
+) -> str:
+    """
+    Lists wireless access list entries.
+
+    Args:
+        interface_filter: Filter by interface
+        action_filter: Filter by action
+
+    Returns:
+        List of wireless access list entries
+    """
+    app_logger.info(f"Listing wireless access list entries")
+
+    # Build command
+    cmd = "/interface wireless access-list print"
+
+    # Add filters
+    filters = []
+    if interface_filter:
+        filters.append(f'interface="{interface_filter}"')
+    if action_filter:
+        filters.append(f'action="{action_filter}"')
+
+    if filters:
+        cmd += " where " + " and ".join(filters)
+
+    result = execute_mikrotik_command(cmd)
+
+    if not result or result.strip() == "":
+        return "No wireless access list entries found."
+
+    return f"WIRELESS ACCESS LIST:\n\n{result}"
+
+
+def mikrotik_remove_wireless_access_list_entry(
+        entry_id: str
+) -> str:
+    """
+    Removes a wireless access list entry.
+
+    Args:
+        entry_id: ID of the access list entry to remove
+
+    Returns:
+        Command output or error message
+    """
+    app_logger.info(f"Removing wireless access list entry: {entry_id}")
+
+    cmd = f'/interface wireless access-list remove {entry_id}'
+    result = execute_mikrotik_command(cmd)
+
+    if "failure:" in result.lower() or "error" in result.lower():
+        return f"Failed to remove wireless access list entry: {result}"
+
+    return f"Wireless access list entry '{entry_id}' removed successfully."
+
+
+def mikrotik_enable_wireless_interface(name: str) -> str:
+    """
+    Enables a wireless interface.
+
+    Args:
+        name: Name of the wireless interface
+
+    Returns:
+        Command output or error message
+    """
+    app_logger.info(f"Enabling wireless interface: {name}")
+
+    cmd = f'/interface wireless enable [find name="{name}"]'
+    result = execute_mikrotik_command(cmd)
+
+    if "failure:" in result.lower() or "error" in result.lower():
+        return f"Failed to enable wireless interface: {result}"
+
+    return f"Wireless interface '{name}' enabled successfully."
+
+
+def mikrotik_disable_wireless_interface(name: str) -> str:
+    """
+    Disables a wireless interface.
+
+    Args:
+        name: Name of the wireless interface
+
+    Returns:
+        Command output or error message
+    """
+    app_logger.info(f"Disabling wireless interface: {name}")
+
+    cmd = f'/interface wireless disable [find name="{name}"]'
+    result = execute_mikrotik_command(cmd)
+
+    if "failure:" in result.lower() or "error" in result.lower():
+        return f"Failed to disable wireless interface: {result}"
+
+    return f"Wireless interface '{name}' disabled successfully."

--- a/src/mcp_mikrotik/tools/tool_registry.py
+++ b/src/mcp_mikrotik/tools/tool_registry.py
@@ -4,12 +4,15 @@ from mcp.types import Tool
 from .vlan_tools import get_vlan_tools, get_vlan_handlers
 from .ip_tools import get_ip_address_tools, get_ip_pool_tools, get_ip_address_handlers, get_ip_pool_handlers
 from .dhcp_tools import get_dhcp_tools, get_dhcp_handlers
-from .firewall_tools import get_firewall_filter_tools, get_firewall_nat_tools, get_firewall_filter_handlers, get_firewall_nat_handlers
+from .firewall_tools import get_firewall_filter_tools, get_firewall_nat_tools, get_firewall_filter_handlers, \
+    get_firewall_nat_handlers
 from .dns_tools import get_dns_tools, get_dns_handlers
 from .route_tools import get_route_tools, get_route_handlers
 from .user_tools import get_user_tools, get_user_handlers
 from .backup_tools import get_backup_tools, get_backup_handlers
 from .log_tools import get_log_tools, get_log_handlers
+from .wireless_tools import get_wireless_tools, get_wireless_handlers
+
 
 def get_all_tools() -> List[Tool]:
     """Return all available tools."""
@@ -17,66 +20,73 @@ def get_all_tools() -> List[Tool]:
 
     # VLAN tools
     tools.extend(get_vlan_tools())
-    
+
+    # Wireless tools
+    tools.extend(get_wireless_tools())
+
     # IP tools
     tools.extend(get_ip_address_tools())
     tools.extend(get_ip_pool_tools())
-    
+
     # DHCP tools
     tools.extend(get_dhcp_tools())
-    
+
     # Firewall tools
     tools.extend(get_firewall_filter_tools())
     tools.extend(get_firewall_nat_tools())
-    
+
     # DNS tools
     tools.extend(get_dns_tools())
-    
+
     # Route tools
     tools.extend(get_route_tools())
-    
+
     # User tools
     tools.extend(get_user_tools())
-    
+
     # Backup tools
     tools.extend(get_backup_tools())
-    
+
     # Log tools
     tools.extend(get_log_tools())
-    
+
     return tools
+
 
 def get_all_handlers() -> Dict[str, Callable]:
     """Return all command handlers."""
     handlers = {}
-    
+
     # VLAN handlers
     handlers.update(get_vlan_handlers())
-    
+
+    # Wireless Handler
+    handlers.update(get_wireless_handlers())
+
     # IP handlers
     handlers.update(get_ip_address_handlers())
     handlers.update(get_ip_pool_handlers())
-    
+
     # DHCP handlers
     handlers.update(get_dhcp_handlers())
-    
+
     # Firewall handlers
     handlers.update(get_firewall_filter_handlers())
     handlers.update(get_firewall_nat_handlers())
-    
+
     # DNS handlers
     handlers.update(get_dns_handlers())
-    
+
     # Route handlers
     handlers.update(get_route_handlers())
-    
+
     # User handlers
     handlers.update(get_user_handlers())
-    
+
     # Backup handlers
     handlers.update(get_backup_handlers())
-    
+
     # Log handlers
     handlers.update(get_log_handlers())
-    
+
     return handlers

--- a/src/mcp_mikrotik/tools/wireless_tools.py
+++ b/src/mcp_mikrotik/tools/wireless_tools.py
@@ -1,0 +1,369 @@
+from typing import Dict, Any, List, Callable
+from ..scope.wireless import (
+    mikrotik_create_wireless_interface, mikrotik_list_wireless_interfaces,
+    mikrotik_get_wireless_interface, mikrotik_update_wireless_interface,
+    mikrotik_remove_wireless_interface, mikrotik_create_wireless_security_profile,
+    mikrotik_list_wireless_security_profiles, mikrotik_get_wireless_security_profile,
+    mikrotik_remove_wireless_security_profile, mikrotik_set_wireless_security_profile,
+    mikrotik_scan_wireless_networks, mikrotik_get_wireless_registration_table,
+    mikrotik_create_wireless_access_list, mikrotik_list_wireless_access_list,
+    mikrotik_remove_wireless_access_list_entry, mikrotik_enable_wireless_interface,
+    mikrotik_disable_wireless_interface
+)
+from mcp.types import Tool
+
+
+def get_wireless_tools() -> List[Tool]:
+    """Return the list of wireless management tools."""
+    return [
+        # Wireless Interface Management
+        Tool(
+            name="mikrotik_create_wireless_interface",
+            description="Creates a wireless interface on MikroTik device",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Name of the wireless interface"},
+                    "radio_name": {"type": "string", "description": "Name of the radio interface (e.g., wlan1)"},
+                    "mode": {"type": "string",
+                             "enum": ["ap-bridge", "bridge", "station", "station-pseudobridge", "station-bridge",
+                                      "station-wds", "ap-bridge-wds", "alignment-only"],
+                             "description": "Wireless mode"},
+                    "ssid": {"type": "string", "description": "Network SSID name"},
+                    "frequency": {"type": "string", "description": "Operating frequency"},
+                    "band": {"type": "string",
+                             "enum": ["2ghz-b", "2ghz-b/g", "2ghz-b/g/n", "5ghz-a", "5ghz-a/n", "5ghz-a/n/ac", "2ghz-g",
+                                      "2ghz-n", "5ghz-n", "5ghz-ac"], "description": "Frequency band"},
+                    "channel_width": {"type": "string",
+                                      "enum": ["20mhz", "40mhz", "80mhz", "160mhz", "20/40mhz-eC", "20/40mhz-Ce"],
+                                      "description": "Channel width"},
+                    "disabled": {"type": "boolean", "description": "Whether to disable the interface"},
+                    "comment": {"type": "string", "description": "Optional comment"}
+                },
+                "required": ["name", "radio_name"]
+            },
+        ),
+        Tool(
+            name="mikrotik_list_wireless_interfaces",
+            description="Lists wireless interfaces on MikroTik device",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name_filter": {"type": "string", "description": "Filter by interface name"},
+                    "mode_filter": {"type": "string", "description": "Filter by wireless mode"},
+                    "disabled_only": {"type": "boolean", "description": "Show only disabled interfaces"},
+                    "running_only": {"type": "boolean", "description": "Show only running interfaces"}
+                },
+                "required": []
+            },
+        ),
+        Tool(
+            name="mikrotik_get_wireless_interface",
+            description="Gets detailed information about a specific wireless interface",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Name of the wireless interface"}
+                },
+                "required": ["name"]
+            },
+        ),
+        Tool(
+            name="mikrotik_update_wireless_interface",
+            description="Updates an existing wireless interface",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Current name of the wireless interface"},
+                    "new_name": {"type": "string", "description": "New name for the interface"},
+                    "ssid": {"type": "string", "description": "New SSID name"},
+                    "frequency": {"type": "string", "description": "New operating frequency"},
+                    "band": {"type": "string", "description": "New frequency band"},
+                    "channel_width": {"type": "string", "description": "New channel width"},
+                    "mode": {"type": "string", "description": "New wireless mode"},
+                    "disabled": {"type": "boolean", "description": "Enable/disable interface"},
+                    "comment": {"type": "string", "description": "New comment"}
+                },
+                "required": ["name"]
+            },
+        ),
+        Tool(
+            name="mikrotik_remove_wireless_interface",
+            description="Removes a wireless interface from MikroTik device",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Name of the wireless interface to remove"}
+                },
+                "required": ["name"]
+            },
+        ),
+        Tool(
+            name="mikrotik_enable_wireless_interface",
+            description="Enables a wireless interface",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Name of the wireless interface"}
+                },
+                "required": ["name"]
+            },
+        ),
+        Tool(
+            name="mikrotik_disable_wireless_interface",
+            description="Disables a wireless interface",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Name of the wireless interface"}
+                },
+                "required": ["name"]
+            },
+        ),
+
+        # Wireless Security Profile Management
+        Tool(
+            name="mikrotik_create_wireless_security_profile",
+            description="Creates a wireless security profile on MikroTik device",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Name of the security profile"},
+                    "mode": {"type": "string", "enum": ["none", "static-keys-required", "dynamic-keys"],
+                             "description": "Security mode"},
+                    "authentication_types": {"type": "array", "items": {"type": "string",
+                                                                        "enum": ["wpa-psk", "wpa2-psk", "wpa-eap",
+                                                                                 "wpa2-eap"]},
+                                             "description": "Authentication types"},
+                    "unicast_ciphers": {"type": "array", "items": {"type": "string", "enum": ["tkip", "aes-ccm"]},
+                                        "description": "Unicast ciphers"},
+                    "group_ciphers": {"type": "array", "items": {"type": "string", "enum": ["tkip", "aes-ccm"]},
+                                      "description": "Group ciphers"},
+                    "wpa_pre_shared_key": {"type": "string", "description": "WPA pre-shared key"},
+                    "wpa2_pre_shared_key": {"type": "string", "description": "WPA2 pre-shared key"},
+                    "supplicant_identity": {"type": "string", "description": "Supplicant identity for EAP"},
+                    "eap_methods": {"type": "string", "description": "EAP methods"},
+                    "tls_mode": {"type": "string", "description": "TLS mode"},
+                    "tls_certificate": {"type": "string", "description": "TLS certificate"},
+                    "comment": {"type": "string", "description": "Optional comment"}
+                },
+                "required": ["name"]
+            },
+        ),
+        Tool(
+            name="mikrotik_list_wireless_security_profiles",
+            description="Lists wireless security profiles on MikroTik device",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name_filter": {"type": "string", "description": "Filter by profile name"},
+                    "mode_filter": {"type": "string", "description": "Filter by security mode"}
+                },
+                "required": []
+            },
+        ),
+        Tool(
+            name="mikrotik_get_wireless_security_profile",
+            description="Gets detailed information about a specific wireless security profile",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Name of the security profile"}
+                },
+                "required": ["name"]
+            },
+        ),
+        Tool(
+            name="mikrotik_remove_wireless_security_profile",
+            description="Removes a wireless security profile from MikroTik device",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Name of the security profile to remove"}
+                },
+                "required": ["name"]
+            },
+        ),
+        Tool(
+            name="mikrotik_set_wireless_security_profile",
+            description="Sets the security profile for a wireless interface",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "interface_name": {"type": "string", "description": "Name of the wireless interface"},
+                    "security_profile": {"type": "string", "description": "Name of the security profile to apply"}
+                },
+                "required": ["interface_name", "security_profile"]
+            },
+        ),
+
+        # Wireless Network Operations
+        Tool(
+            name="mikrotik_scan_wireless_networks",
+            description="Scans for wireless networks using specified interface",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "interface": {"type": "string", "description": "Wireless interface to use for scanning"},
+                    "duration": {"type": "integer", "description": "Scan duration in seconds", "default": 5}
+                },
+                "required": ["interface"]
+            },
+        ),
+        Tool(
+            name="mikrotik_get_wireless_registration_table",
+            description="Gets the wireless registration table (connected clients)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "interface": {"type": "string", "description": "Filter by specific wireless interface"}
+                },
+                "required": []
+            },
+        ),
+
+        # Wireless Access List Management
+        Tool(
+            name="mikrotik_create_wireless_access_list",
+            description="Creates a wireless access list entry",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "interface": {"type": "string", "description": "Wireless interface"},
+                    "mac_address": {"type": "string", "description": "MAC address to control"},
+                    "action": {"type": "string", "enum": ["accept", "reject", "query"],
+                               "description": "Action to take"},
+                    "signal_range": {"type": "string", "description": "Signal strength range"},
+                    "time": {"type": "string", "description": "Time schedule"},
+                    "comment": {"type": "string", "description": "Optional comment"}
+                },
+                "required": ["interface", "mac_address"]
+            },
+        ),
+        Tool(
+            name="mikrotik_list_wireless_access_list",
+            description="Lists wireless access list entries",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "interface_filter": {"type": "string", "description": "Filter by interface"},
+                    "action_filter": {"type": "string", "description": "Filter by action"}
+                },
+                "required": []
+            },
+        ),
+        Tool(
+            name="mikrotik_remove_wireless_access_list_entry",
+            description="Removes a wireless access list entry",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "entry_id": {"type": "string", "description": "ID of the access list entry to remove"}
+                },
+                "required": ["entry_id"]
+            },
+        ),
+    ]
+
+
+def get_wireless_handlers() -> Dict[str, Callable]:
+    """Return the handlers for wireless management tools."""
+    return {
+        # Wireless Interface Management
+        "mikrotik_create_wireless_interface": lambda args: mikrotik_create_wireless_interface(
+            args["name"],
+            args["radio_name"],
+            args.get("mode", "ap-bridge"),
+            args.get("ssid"),
+            args.get("frequency"),
+            args.get("band"),
+            args.get("channel_width"),
+            args.get("disabled", False),
+            args.get("comment")
+        ),
+        "mikrotik_list_wireless_interfaces": lambda args: mikrotik_list_wireless_interfaces(
+            args.get("name_filter"),
+            args.get("mode_filter"),
+            args.get("disabled_only", False),
+            args.get("running_only", False)
+        ),
+        "mikrotik_get_wireless_interface": lambda args: mikrotik_get_wireless_interface(
+            args["name"]
+        ),
+        "mikrotik_update_wireless_interface": lambda args: mikrotik_update_wireless_interface(
+            args["name"],
+            args.get("new_name"),
+            args.get("ssid"),
+            args.get("frequency"),
+            args.get("band"),
+            args.get("channel_width"),
+            args.get("mode"),
+            args.get("disabled"),
+            args.get("comment")
+        ),
+        "mikrotik_remove_wireless_interface": lambda args: mikrotik_remove_wireless_interface(
+            args["name"]
+        ),
+        "mikrotik_enable_wireless_interface": lambda args: mikrotik_enable_wireless_interface(
+            args["name"]
+        ),
+        "mikrotik_disable_wireless_interface": lambda args: mikrotik_disable_wireless_interface(
+            args["name"]
+        ),
+
+        # Wireless Security Profile Management
+        "mikrotik_create_wireless_security_profile": lambda args: mikrotik_create_wireless_security_profile(
+            args["name"],
+            args.get("mode", "dynamic-keys"),
+            args.get("authentication_types"),
+            args.get("unicast_ciphers"),
+            args.get("group_ciphers"),
+            args.get("wpa_pre_shared_key"),
+            args.get("wpa2_pre_shared_key"),
+            args.get("supplicant_identity"),
+            args.get("eap_methods"),
+            args.get("tls_mode"),
+            args.get("tls_certificate"),
+            args.get("comment")
+        ),
+        "mikrotik_list_wireless_security_profiles": lambda args: mikrotik_list_wireless_security_profiles(
+            args.get("name_filter"),
+            args.get("mode_filter")
+        ),
+        "mikrotik_get_wireless_security_profile": lambda args: mikrotik_get_wireless_security_profile(
+            args["name"]
+        ),
+        "mikrotik_remove_wireless_security_profile": lambda args: mikrotik_remove_wireless_security_profile(
+            args["name"]
+        ),
+        "mikrotik_set_wireless_security_profile": lambda args: mikrotik_set_wireless_security_profile(
+            args["interface_name"],
+            args["security_profile"]
+        ),
+
+        # Wireless Network Operations
+        "mikrotik_scan_wireless_networks": lambda args: mikrotik_scan_wireless_networks(
+            args["interface"],
+            args.get("duration", 5)
+        ),
+        "mikrotik_get_wireless_registration_table": lambda args: mikrotik_get_wireless_registration_table(
+            args.get("interface")
+        ),
+
+        # Wireless Access List Management
+        "mikrotik_create_wireless_access_list": lambda args: mikrotik_create_wireless_access_list(
+            args["interface"],
+            args["mac_address"],
+            args.get("action", "accept"),
+            args.get("signal_range"),
+            args.get("time"),
+            args.get("comment")
+        ),
+        "mikrotik_list_wireless_access_list": lambda args: mikrotik_list_wireless_access_list(
+            args.get("interface_filter"),
+            args.get("action_filter")
+        ),
+        "mikrotik_remove_wireless_access_list_entry": lambda args: mikrotik_remove_wireless_access_list_entry(
+            args["entry_id"]
+        ),
+    }

--- a/src/mcp_mikrotik/tools/wireless_tools.py
+++ b/src/mcp_mikrotik/tools/wireless_tools.py
@@ -8,7 +8,7 @@ from ..scope.wireless import (
     mikrotik_scan_wireless_networks, mikrotik_get_wireless_registration_table,
     mikrotik_create_wireless_access_list, mikrotik_list_wireless_access_list,
     mikrotik_remove_wireless_access_list_entry, mikrotik_enable_wireless_interface,
-    mikrotik_disable_wireless_interface
+    mikrotik_disable_wireless_interface, mikrotik_check_wireless_support
 )
 from mcp.types import Tool
 
@@ -24,23 +24,27 @@ def get_wireless_tools() -> List[Tool]:
                 "type": "object",
                 "properties": {
                     "name": {"type": "string", "description": "Name of the wireless interface"},
-                    "radio_name": {"type": "string", "description": "Name of the radio interface (e.g., wlan1)"},
+                    "ssid": {"type": "string", "description": "Network SSID name"},
+                    "disabled": {"type": "boolean", "description": "Whether to disable the interface"},
+                    "comment": {"type": "string", "description": "Optional comment"},
+                    # Legacy parameters for backward compatibility
+                    "radio_name": {"type": "string",
+                                   "description": "Name of the radio interface (legacy systems only)"},
                     "mode": {"type": "string",
                              "enum": ["ap-bridge", "bridge", "station", "station-pseudobridge", "station-bridge",
                                       "station-wds", "ap-bridge-wds", "alignment-only"],
-                             "description": "Wireless mode"},
-                    "ssid": {"type": "string", "description": "Network SSID name"},
-                    "frequency": {"type": "string", "description": "Operating frequency"},
+                             "description": "Wireless mode (legacy systems only)"},
+                    "frequency": {"type": "string", "description": "Operating frequency (legacy systems only)"},
                     "band": {"type": "string",
                              "enum": ["2ghz-b", "2ghz-b/g", "2ghz-b/g/n", "5ghz-a", "5ghz-a/n", "5ghz-a/n/ac", "2ghz-g",
-                                      "2ghz-n", "5ghz-n", "5ghz-ac"], "description": "Frequency band"},
+                                      "2ghz-n", "5ghz-n", "5ghz-ac"],
+                             "description": "Frequency band (legacy systems only)"},
                     "channel_width": {"type": "string",
                                       "enum": ["20mhz", "40mhz", "80mhz", "160mhz", "20/40mhz-eC", "20/40mhz-Ce"],
-                                      "description": "Channel width"},
-                    "disabled": {"type": "boolean", "description": "Whether to disable the interface"},
-                    "comment": {"type": "string", "description": "Optional comment"}
+                                      "description": "Channel width (legacy systems only)"},
+                    "security_profile": {"type": "string", "description": "Security profile name (legacy systems only)"}
                 },
-                "required": ["name", "radio_name"]
+                "required": ["name"]
             },
         ),
         Tool(
@@ -50,7 +54,6 @@ def get_wireless_tools() -> List[Tool]:
                 "type": "object",
                 "properties": {
                     "name_filter": {"type": "string", "description": "Filter by interface name"},
-                    "mode_filter": {"type": "string", "description": "Filter by wireless mode"},
                     "disabled_only": {"type": "boolean", "description": "Show only disabled interfaces"},
                     "running_only": {"type": "boolean", "description": "Show only running interfaces"}
                 },
@@ -77,10 +80,6 @@ def get_wireless_tools() -> List[Tool]:
                     "name": {"type": "string", "description": "Current name of the wireless interface"},
                     "new_name": {"type": "string", "description": "New name for the interface"},
                     "ssid": {"type": "string", "description": "New SSID name"},
-                    "frequency": {"type": "string", "description": "New operating frequency"},
-                    "band": {"type": "string", "description": "New frequency band"},
-                    "channel_width": {"type": "string", "description": "New channel width"},
-                    "mode": {"type": "string", "description": "New wireless mode"},
                     "disabled": {"type": "boolean", "description": "Enable/disable interface"},
                     "comment": {"type": "string", "description": "New comment"}
                 },
@@ -121,50 +120,30 @@ def get_wireless_tools() -> List[Tool]:
             },
         ),
 
-        # Wireless Security Profile Management
+        # Wireless Security Profile Management (Legacy)
         Tool(
             name="mikrotik_create_wireless_security_profile",
-            description="Creates a wireless security profile on MikroTik device",
+            description="Creates a wireless security profile (legacy systems only)",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "name": {"type": "string", "description": "Name of the security profile"},
-                    "mode": {"type": "string", "enum": ["none", "static-keys-required", "dynamic-keys"],
-                             "description": "Security mode"},
-                    "authentication_types": {"type": "array", "items": {"type": "string",
-                                                                        "enum": ["wpa-psk", "wpa2-psk", "wpa-eap",
-                                                                                 "wpa2-eap"]},
-                                             "description": "Authentication types"},
-                    "unicast_ciphers": {"type": "array", "items": {"type": "string", "enum": ["tkip", "aes-ccm"]},
-                                        "description": "Unicast ciphers"},
-                    "group_ciphers": {"type": "array", "items": {"type": "string", "enum": ["tkip", "aes-ccm"]},
-                                      "description": "Group ciphers"},
-                    "wpa_pre_shared_key": {"type": "string", "description": "WPA pre-shared key"},
-                    "wpa2_pre_shared_key": {"type": "string", "description": "WPA2 pre-shared key"},
-                    "supplicant_identity": {"type": "string", "description": "Supplicant identity for EAP"},
-                    "eap_methods": {"type": "string", "description": "EAP methods"},
-                    "tls_mode": {"type": "string", "description": "TLS mode"},
-                    "tls_certificate": {"type": "string", "description": "TLS certificate"},
-                    "comment": {"type": "string", "description": "Optional comment"}
+                    "name": {"type": "string", "description": "Name of the security profile"}
                 },
                 "required": ["name"]
             },
         ),
         Tool(
             name="mikrotik_list_wireless_security_profiles",
-            description="Lists wireless security profiles on MikroTik device",
+            description="Lists wireless security profiles (legacy systems only)",
             inputSchema={
                 "type": "object",
-                "properties": {
-                    "name_filter": {"type": "string", "description": "Filter by profile name"},
-                    "mode_filter": {"type": "string", "description": "Filter by security mode"}
-                },
+                "properties": {},
                 "required": []
             },
         ),
         Tool(
             name="mikrotik_get_wireless_security_profile",
-            description="Gets detailed information about a specific wireless security profile",
+            description="Gets wireless security profile details (legacy systems only)",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -175,7 +154,7 @@ def get_wireless_tools() -> List[Tool]:
         ),
         Tool(
             name="mikrotik_remove_wireless_security_profile",
-            description="Removes a wireless security profile from MikroTik device",
+            description="Removes a wireless security profile (legacy systems only)",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -186,7 +165,7 @@ def get_wireless_tools() -> List[Tool]:
         ),
         Tool(
             name="mikrotik_set_wireless_security_profile",
-            description="Sets the security profile for a wireless interface",
+            description="Sets security profile for interface (legacy systems only)",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -222,39 +201,28 @@ def get_wireless_tools() -> List[Tool]:
             },
         ),
 
-        # Wireless Access List Management
+        # Wireless Access List Management (Legacy)
         Tool(
             name="mikrotik_create_wireless_access_list",
-            description="Creates a wireless access list entry",
+            description="Creates a wireless access list entry (legacy systems only)",
             inputSchema={
                 "type": "object",
-                "properties": {
-                    "interface": {"type": "string", "description": "Wireless interface"},
-                    "mac_address": {"type": "string", "description": "MAC address to control"},
-                    "action": {"type": "string", "enum": ["accept", "reject", "query"],
-                               "description": "Action to take"},
-                    "signal_range": {"type": "string", "description": "Signal strength range"},
-                    "time": {"type": "string", "description": "Time schedule"},
-                    "comment": {"type": "string", "description": "Optional comment"}
-                },
-                "required": ["interface", "mac_address"]
+                "properties": {},
+                "required": []
             },
         ),
         Tool(
             name="mikrotik_list_wireless_access_list",
-            description="Lists wireless access list entries",
+            description="Lists wireless access list entries (legacy systems only)",
             inputSchema={
                 "type": "object",
-                "properties": {
-                    "interface_filter": {"type": "string", "description": "Filter by interface"},
-                    "action_filter": {"type": "string", "description": "Filter by action"}
-                },
+                "properties": {},
                 "required": []
             },
         ),
         Tool(
             name="mikrotik_remove_wireless_access_list_entry",
-            description="Removes a wireless access list entry",
+            description="Removes a wireless access list entry (legacy systems only)",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -263,27 +231,33 @@ def get_wireless_tools() -> List[Tool]:
                 "required": ["entry_id"]
             },
         ),
+        # Wireless Support Check
+        Tool(
+            name="mikrotik_check_wireless_support",
+            description="Checks if the device supports wireless functionality",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": []
+            },
+        ),
     ]
 
 
 def get_wireless_handlers() -> Dict[str, Callable]:
     """Return the handlers for wireless management tools."""
     return {
-        # Wireless Interface Management
+        # Wireless Interface Management - Updated to match new function signatures
         "mikrotik_create_wireless_interface": lambda args: mikrotik_create_wireless_interface(
-            args["name"],
-            args["radio_name"],
-            args.get("mode", "ap-bridge"),
-            args.get("ssid"),
-            args.get("frequency"),
-            args.get("band"),
-            args.get("channel_width"),
-            args.get("disabled", False),
-            args.get("comment")
+            name=args["name"],
+            ssid=args.get("ssid"),
+            disabled=args.get("disabled", False),
+            comment=args.get("comment"),
+            # Pass all other args as kwargs for legacy compatibility
+            **{k: v for k, v in args.items() if k not in ["name", "ssid", "disabled", "comment"]}
         ),
         "mikrotik_list_wireless_interfaces": lambda args: mikrotik_list_wireless_interfaces(
             args.get("name_filter"),
-            args.get("mode_filter"),
             args.get("disabled_only", False),
             args.get("running_only", False)
         ),
@@ -291,15 +265,8 @@ def get_wireless_handlers() -> Dict[str, Callable]:
             args["name"]
         ),
         "mikrotik_update_wireless_interface": lambda args: mikrotik_update_wireless_interface(
-            args["name"],
-            args.get("new_name"),
-            args.get("ssid"),
-            args.get("frequency"),
-            args.get("band"),
-            args.get("channel_width"),
-            args.get("mode"),
-            args.get("disabled"),
-            args.get("comment")
+            name=args["name"],
+            **{k: v for k, v in args.items() if k != "name"}
         ),
         "mikrotik_remove_wireless_interface": lambda args: mikrotik_remove_wireless_interface(
             args["name"]
@@ -311,24 +278,13 @@ def get_wireless_handlers() -> Dict[str, Callable]:
             args["name"]
         ),
 
-        # Wireless Security Profile Management
+        # Wireless Security Profile Management - Simplified for new system
         "mikrotik_create_wireless_security_profile": lambda args: mikrotik_create_wireless_security_profile(
-            args["name"],
-            args.get("mode", "dynamic-keys"),
-            args.get("authentication_types"),
-            args.get("unicast_ciphers"),
-            args.get("group_ciphers"),
-            args.get("wpa_pre_shared_key"),
-            args.get("wpa2_pre_shared_key"),
-            args.get("supplicant_identity"),
-            args.get("eap_methods"),
-            args.get("tls_mode"),
-            args.get("tls_certificate"),
-            args.get("comment")
+            name=args["name"],
+            **{k: v for k, v in args.items() if k != "name"}
         ),
         "mikrotik_list_wireless_security_profiles": lambda args: mikrotik_list_wireless_security_profiles(
-            args.get("name_filter"),
-            args.get("mode_filter")
+            **args
         ),
         "mikrotik_get_wireless_security_profile": lambda args: mikrotik_get_wireless_security_profile(
             args["name"]
@@ -350,20 +306,17 @@ def get_wireless_handlers() -> Dict[str, Callable]:
             args.get("interface")
         ),
 
-        # Wireless Access List Management
+        # Wireless Access List Management - Simplified for new system
         "mikrotik_create_wireless_access_list": lambda args: mikrotik_create_wireless_access_list(
-            args["interface"],
-            args["mac_address"],
-            args.get("action", "accept"),
-            args.get("signal_range"),
-            args.get("time"),
-            args.get("comment")
+            **args
         ),
         "mikrotik_list_wireless_access_list": lambda args: mikrotik_list_wireless_access_list(
-            args.get("interface_filter"),
-            args.get("action_filter")
+            **args
         ),
         "mikrotik_remove_wireless_access_list_entry": lambda args: mikrotik_remove_wireless_access_list_entry(
             args["entry_id"]
         ),
+
+        # Wireless Support Check
+        "mikrotik_check_wireless_support": lambda args: mikrotik_check_wireless_support(),
     }


### PR DESCRIPTION
Add comprehensive wireless management functionality including:
- Wireless interface creation, listing, and management
- Security profile management
- Access list control
- Network scanning and monitoring
- Support for multiple wireless modes (AP, station, bridge)
- Dual-band (2.4GHz + 5GHz) configuration support


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced comprehensive wireless management capabilities for MikroTik devices, including creating, updating, enabling/disabling, and removing wireless interfaces.
  - Added support for wireless security profile management and access list controls.
  - Enabled wireless network scanning, monitoring connected clients, and managing MAC address access lists.
- **Documentation**
  - Expanded the README with detailed usage examples and step-by-step guides for wireless network management using the CLI tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->