### PR TITLE
fix: remove redundant mikrotik_ prefix from MCP tool names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Navigate to `src/mcp_mikrotik/scope/` and create a new Python file for your feat
 Your scope file should:
 - Import necessary dependencies: `execute_mikrotik_command`, `app_logger`
 - Implement functions that execute MikroTik commands
-- Follow the existing naming convention: `mikrotik_<action>_<resource>`
+- Follow the existing naming convention: `mikrotik_<action>_<resource>` for Python functions in `scope/`
 - Include comprehensive docstrings with parameter descriptions
 - Handle errors gracefully and return meaningful messages
 
@@ -86,6 +86,7 @@ Your tools file should:
 - Import the scope functions you created
 - Import `Tool` from `mcp.types`
 - Define MCP tool schemas with proper validation
+- Use the `<action>_<resource>` naming convention for tool names (without the `mikrotik_` prefix)
 - Provide handler functions that map arguments to scope functions
 
 **Example structure** (based on `dhcp_tools.py`):
@@ -101,7 +102,7 @@ def get_my_feature_tools() -> List[Tool]:
     """Return the list of my feature tools."""
     return [
         Tool(
-            name="mikrotik_create_my_resource",
+            name="create_my_resource",
             description="Creates a new resource on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -120,7 +121,7 @@ def get_my_feature_tools() -> List[Tool]:
 def get_my_feature_handlers() -> Dict[str, Callable]:
     """Return the handlers for my feature tools."""
     return {
-        "mikrotik_create_my_resource": lambda args: mikrotik_create_my_resource(
+        "create_my_resource": lambda args: mikrotik_create_my_resource(
             args["name"],
             args["required_param"],
             args.get("optional_param"),

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -32,7 +32,7 @@ Navigate to `src/mcp_mikrotik/scope/` and create a new Python file for your feat
 Your scope file should:
 - Import necessary dependencies: `execute_mikrotik_command`, `app_logger`
 - Implement functions that execute MikroTik commands
-- Follow the existing naming convention: `mikrotik_<action>_<resource>`
+- Follow the existing naming convention: `mikrotik_<action>_<resource>` for Python functions in `scope/`
 - Include comprehensive docstrings with parameter descriptions
 - Handle errors gracefully and return meaningful messages
 
@@ -86,6 +86,7 @@ Your tools file should:
 - Import the scope functions you created
 - Import `Tool` from `mcp.types`
 - Define MCP tool schemas with proper validation
+- Use the `<action>_<resource>` naming convention for tool names (without the `mikrotik_` prefix)
 - Provide handler functions that map arguments to scope functions
 
 **Example structure** (based on `dhcp_tools.py`):
@@ -101,7 +102,7 @@ def get_my_feature_tools() -> List[Tool]:
     """Return the list of my feature tools."""
     return [
         Tool(
-            name="mikrotik_create_my_resource",
+            name="create_my_resource",
             description="Creates a new resource on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -120,7 +121,7 @@ def get_my_feature_tools() -> List[Tool]:
 def get_my_feature_handlers() -> Dict[str, Callable]:
     """Return the handlers for my feature tools."""
     return {
-        "mikrotik_create_my_resource": lambda args: mikrotik_create_my_resource(
+        "create_my_resource": lambda args: mikrotik_create_my_resource(
             args["name"],
             args["required_param"],
             args.get("optional_param"),

--- a/docs/examples/usage-examples.md
+++ b/docs/examples/usage-examples.md
@@ -3,380 +3,380 @@
 ### VLAN Interface Operations
 ```bash
 # Create a VLAN interface
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_vlan_interface --tool-args '{"name": "vlan100", "vlan_id": 100, "interface": "ether1", "comment": "Production VLAN"}'
+uv run mcp-cli cmd --server mikrotik --tool create_vlan_interface --tool-args '{"name": "vlan100", "vlan_id": 100, "interface": "ether1", "comment": "Production VLAN"}'
 
 # List all VLANs
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_vlan_interfaces --tool-args '{}'
+uv run mcp-cli cmd --server mikrotik --tool list_vlan_interfaces --tool-args '{}'
 
 # Get specific VLAN details
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_vlan_interface --tool-args '{"name": "vlan100"}'
+uv run mcp-cli cmd --server mikrotik --tool get_vlan_interface --tool-args '{"name": "vlan100"}'
 
 # Update VLAN interface
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_update_vlan_interface --tool-args '{"name": "vlan100", "comment": "Updated Production VLAN"}'
+uv run mcp-cli cmd --server mikrotik --tool update_vlan_interface --tool-args '{"name": "vlan100", "comment": "Updated Production VLAN"}'
 
 # Remove VLAN interface
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_vlan_interface --tool-args '{"name": "vlan100"}'
+uv run mcp-cli cmd --server mikrotik --tool remove_vlan_interface --tool-args '{"name": "vlan100"}'
 ```
 
 ### IP Address Management
 ```bash
 # Add IP address to interface
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_add_ip_address --tool-args '{"address": "192.168.100.1/24", "interface": "vlan100", "comment": "Gateway address"}'
+uv run mcp-cli cmd --server mikrotik --tool add_ip_address --tool-args '{"address": "192.168.100.1/24", "interface": "vlan100", "comment": "Gateway address"}'
 
 # List IP addresses
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_ip_addresses --tool-args '{"interface_filter": "vlan100"}'
+uv run mcp-cli cmd --server mikrotik --tool list_ip_addresses --tool-args '{"interface_filter": "vlan100"}'
 
 # Get specific IP address
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_ip_address --tool-args '{"address_id": "*1"}'
+uv run mcp-cli cmd --server mikrotik --tool get_ip_address --tool-args '{"address_id": "*1"}'
 
 # Remove IP address
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_ip_address --tool-args '{"address_id": "*1"}'
+uv run mcp-cli cmd --server mikrotik --tool remove_ip_address --tool-args '{"address_id": "*1"}'
 ```
 
 ### DHCP Server Configuration
 ```bash
 # Create DHCP pool
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_dhcp_pool --tool-args '{"name": "pool-vlan100", "ranges": "192.168.100.10-192.168.100.200"}'
+uv run mcp-cli cmd --server mikrotik --tool create_dhcp_pool --tool-args '{"name": "pool-vlan100", "ranges": "192.168.100.10-192.168.100.200"}'
 
 # Create DHCP network
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_dhcp_network --tool-args '{"network": "192.168.100.0/24", "gateway": "192.168.100.1", "dns_servers": ["8.8.8.8", "8.8.4.4"]}'
+uv run mcp-cli cmd --server mikrotik --tool create_dhcp_network --tool-args '{"network": "192.168.100.0/24", "gateway": "192.168.100.1", "dns_servers": ["8.8.8.8", "8.8.4.4"]}'
 
 # Create DHCP server
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_dhcp_server --tool-args '{"name": "dhcp-vlan100", "interface": "vlan100", "address_pool": "pool-vlan100"}'
+uv run mcp-cli cmd --server mikrotik --tool create_dhcp_server --tool-args '{"name": "dhcp-vlan100", "interface": "vlan100", "address_pool": "pool-vlan100"}'
 
 # List DHCP servers
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_dhcp_servers --tool-args '{}'
+uv run mcp-cli cmd --server mikrotik --tool list_dhcp_servers --tool-args '{}'
 
 # Get DHCP server details
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_dhcp_server --tool-args '{"name": "dhcp-vlan100"}'
+uv run mcp-cli cmd --server mikrotik --tool get_dhcp_server --tool-args '{"name": "dhcp-vlan100"}'
 
 # Remove DHCP server
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_dhcp_server --tool-args '{"name": "dhcp-vlan100"}'
+uv run mcp-cli cmd --server mikrotik --tool remove_dhcp_server --tool-args '{"name": "dhcp-vlan100"}'
 ```
 
 ### NAT Rule Management
 ```bash
 # Create masquerade rule
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_nat_rule --tool-args '{"chain": "srcnat", "action": "masquerade", "out_interface": "ether1", "comment": "Internet access"}'
+uv run mcp-cli cmd --server mikrotik --tool create_nat_rule --tool-args '{"chain": "srcnat", "action": "masquerade", "out_interface": "ether1", "comment": "Internet access"}'
 
 # Create port forwarding rule
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_nat_rule --tool-args '{"chain": "dstnat", "action": "dst-nat", "dst_port": "80", "protocol": "tcp", "to_addresses": "192.168.100.10", "to_ports": "80", "comment": "Web server"}'
+uv run mcp-cli cmd --server mikrotik --tool create_nat_rule --tool-args '{"chain": "dstnat", "action": "dst-nat", "dst_port": "80", "protocol": "tcp", "to_addresses": "192.168.100.10", "to_ports": "80", "comment": "Web server"}'
 
 # List NAT rules
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_nat_rules --tool-args '{"chain_filter": "srcnat"}'
+uv run mcp-cli cmd --server mikrotik --tool list_nat_rules --tool-args '{"chain_filter": "srcnat"}'
 
 # Get NAT rule details
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_nat_rule --tool-args '{"rule_id": "*1"}'
+uv run mcp-cli cmd --server mikrotik --tool get_nat_rule --tool-args '{"rule_id": "*1"}'
 
 # Move NAT rule
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_move_nat_rule --tool-args '{"rule_id": "*1", "destination": 0}'
+uv run mcp-cli cmd --server mikrotik --tool move_nat_rule --tool-args '{"rule_id": "*1", "destination": 0}'
 
 # Enable/Disable NAT rule
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_disable_nat_rule --tool-args '{"rule_id": "*1"}'
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_enable_nat_rule --tool-args '{"rule_id": "*1"}'
+uv run mcp-cli cmd --server mikrotik --tool disable_nat_rule --tool-args '{"rule_id": "*1"}'
+uv run mcp-cli cmd --server mikrotik --tool enable_nat_rule --tool-args '{"rule_id": "*1"}'
 
 # Remove NAT rule
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_nat_rule --tool-args '{"rule_id": "*1"}'
+uv run mcp-cli cmd --server mikrotik --tool remove_nat_rule --tool-args '{"rule_id": "*1"}'
 ```
 
 ### IP Pool Management
 ```bash
 # Create IP pool
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_ip_pool --tool-args '{"name": "main-pool", "ranges": "192.168.1.100-192.168.1.200"}'
+uv run mcp-cli cmd --server mikrotik --tool create_ip_pool --tool-args '{"name": "main-pool", "ranges": "192.168.1.100-192.168.1.200"}'
 
 # List IP pools
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_ip_pools --tool-args '{"include_used": true}'
+uv run mcp-cli cmd --server mikrotik --tool list_ip_pools --tool-args '{"include_used": true}'
 
 # Get IP pool details
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_ip_pool --tool-args '{"name": "main-pool"}'
+uv run mcp-cli cmd --server mikrotik --tool get_ip_pool --tool-args '{"name": "main-pool"}'
 
 # List used addresses in pool
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_ip_pool_used --tool-args '{"pool_name": "main-pool"}'
+uv run mcp-cli cmd --server mikrotik --tool list_ip_pool_used --tool-args '{"pool_name": "main-pool"}'
 
 # Expand IP pool
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_expand_ip_pool --tool-args '{"name": "main-pool", "additional_ranges": "192.168.1.201-192.168.1.250"}'
+uv run mcp-cli cmd --server mikrotik --tool expand_ip_pool --tool-args '{"name": "main-pool", "additional_ranges": "192.168.1.201-192.168.1.250"}'
 
 # Remove IP pool
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_ip_pool --tool-args '{"name": "main-pool"}'
+uv run mcp-cli cmd --server mikrotik --tool remove_ip_pool --tool-args '{"name": "main-pool"}'
 ```
 
 ### Backup and Export
 ```bash
 # Create system backup
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_backup --tool-args '{"name": "full_backup", "include_password": true}'
+uv run mcp-cli cmd --server mikrotik --tool create_backup --tool-args '{"name": "full_backup", "include_password": true}'
 
 # Create configuration export
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_export --tool-args '{"name": "config_export", "file_format": "rsc", "export_type": "full"}'
+uv run mcp-cli cmd --server mikrotik --tool create_export --tool-args '{"name": "config_export", "file_format": "rsc", "export_type": "full"}'
 
 # Export specific section
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_export_section --tool-args '{"section": "/ip/firewall", "name": "firewall_export"}'
+uv run mcp-cli cmd --server mikrotik --tool export_section --tool-args '{"section": "/ip/firewall", "name": "firewall_export"}'
 
 # List backups
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_backups --tool-args '{"include_exports": true}'
+uv run mcp-cli cmd --server mikrotik --tool list_backups --tool-args '{"include_exports": true}'
 
 # Download file
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_download_file --tool-args '{"filename": "full_backup.backup"}'
+uv run mcp-cli cmd --server mikrotik --tool download_file --tool-args '{"filename": "full_backup.backup"}'
 
 # Upload file
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_upload_file --tool-args '{"filename": "config.rsc", "content_base64": "base64_encoded_content"}'
+uv run mcp-cli cmd --server mikrotik --tool upload_file --tool-args '{"filename": "config.rsc", "content_base64": "base64_encoded_content"}'
 
 # Restore backup
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_restore_backup --tool-args '{"filename": "full_backup.backup"}'
+uv run mcp-cli cmd --server mikrotik --tool restore_backup --tool-args '{"filename": "full_backup.backup"}'
 
 # Import configuration
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_import_configuration --tool-args '{"filename": "config.rsc"}'
+uv run mcp-cli cmd --server mikrotik --tool import_configuration --tool-args '{"filename": "config.rsc"}'
 
 # Remove file
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_file --tool-args '{"filename": "old_backup.backup"}'
+uv run mcp-cli cmd --server mikrotik --tool remove_file --tool-args '{"filename": "old_backup.backup"}'
 ```
 
 ### Log Management
 ```bash
 # Get logs
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_logs --tool-args '{"topics": "firewall", "limit": 100}'
+uv run mcp-cli cmd --server mikrotik --tool get_logs --tool-args '{"topics": "firewall", "limit": 100}'
 
 # Get logs by severity
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_logs_by_severity --tool-args '{"severity": "error", "limit": 50}'
+uv run mcp-cli cmd --server mikrotik --tool get_logs_by_severity --tool-args '{"severity": "error", "limit": 50}'
 
 # Search logs
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_search_logs --tool-args '{"search_term": "login failed", "case_sensitive": false}'
+uv run mcp-cli cmd --server mikrotik --tool search_logs --tool-args '{"search_term": "login failed", "case_sensitive": false}'
 
 # Get security logs
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_security_logs --tool-args '{"limit": 100}'
+uv run mcp-cli cmd --server mikrotik --tool get_security_logs --tool-args '{"limit": 100}'
 
 # Get log statistics
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_log_statistics --tool-args '{}'
+uv run mcp-cli cmd --server mikrotik --tool get_log_statistics --tool-args '{}'
 
 # Export logs
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_export_logs --tool-args '{"filename": "firewall_logs", "topics": "firewall", "format": "csv"}'
+uv run mcp-cli cmd --server mikrotik --tool export_logs --tool-args '{"filename": "firewall_logs", "topics": "firewall", "format": "csv"}'
 
 # Monitor logs
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_monitor_logs --tool-args '{"topics": "firewall", "duration": 30}'
+uv run mcp-cli cmd --server mikrotik --tool monitor_logs --tool-args '{"topics": "firewall", "duration": 30}'
 
 # Clear logs
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_clear_logs --tool-args '{}'
+uv run mcp-cli cmd --server mikrotik --tool clear_logs --tool-args '{}'
 ```
 
 ### Firewall Filter Rules
 ```bash
 # Create basic firewall rules
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_filter_rule --tool-args '{"chain": "input", "action": "accept", "connection_state": "established,related", "comment": "Accept established"}'
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_filter_rule --tool-args '{"chain": "input", "action": "drop", "connection_state": "invalid", "comment": "Drop invalid"}'
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_filter_rule --tool-args '{"chain": "input", "action": "accept", "protocol": "icmp", "comment": "Accept ICMP"}'
+uv run mcp-cli cmd --server mikrotik --tool create_filter_rule --tool-args '{"chain": "input", "action": "accept", "connection_state": "established,related", "comment": "Accept established"}'
+uv run mcp-cli cmd --server mikrotik --tool create_filter_rule --tool-args '{"chain": "input", "action": "drop", "connection_state": "invalid", "comment": "Drop invalid"}'
+uv run mcp-cli cmd --server mikrotik --tool create_filter_rule --tool-args '{"chain": "input", "action": "accept", "protocol": "icmp", "comment": "Accept ICMP"}'
 
 # List firewall rules
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_filter_rules --tool-args '{"chain_filter": "input"}'
+uv run mcp-cli cmd --server mikrotik --tool list_filter_rules --tool-args '{"chain_filter": "input"}'
 
 # Get firewall rule details
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_filter_rule --tool-args '{"rule_id": "*1"}'
+uv run mcp-cli cmd --server mikrotik --tool get_filter_rule --tool-args '{"rule_id": "*1"}'
 
 # Move firewall rule
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_move_filter_rule --tool-args '{"rule_id": "*1", "destination": 0}'
+uv run mcp-cli cmd --server mikrotik --tool move_filter_rule --tool-args '{"rule_id": "*1", "destination": 0}'
 
 # Enable/Disable firewall rule
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_disable_filter_rule --tool-args '{"rule_id": "*1"}'
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_enable_filter_rule --tool-args '{"rule_id": "*1"}'
+uv run mcp-cli cmd --server mikrotik --tool disable_filter_rule --tool-args '{"rule_id": "*1"}'
+uv run mcp-cli cmd --server mikrotik --tool enable_filter_rule --tool-args '{"rule_id": "*1"}'
 
 # Create basic firewall setup
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_basic_firewall_setup --tool-args '{}'
+uv run mcp-cli cmd --server mikrotik --tool create_basic_firewall_setup --tool-args '{}'
 
 # Remove firewall rule
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_filter_rule --tool-args '{"rule_id": "*1"}'
+uv run mcp-cli cmd --server mikrotik --tool remove_filter_rule --tool-args '{"rule_id": "*1"}'
 ```
 
 ### Route Management
 ```bash
 # Add route
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_add_route --tool-args '{"dst_address": "10.0.0.0/8", "gateway": "192.168.1.1", "comment": "Corporate network"}'
+uv run mcp-cli cmd --server mikrotik --tool add_route --tool-args '{"dst_address": "10.0.0.0/8", "gateway": "192.168.1.1", "comment": "Corporate network"}'
 
 # Add default route
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_add_default_route --tool-args '{"gateway": "192.168.1.1", "distance": 1}'
+uv run mcp-cli cmd --server mikrotik --tool add_default_route --tool-args '{"gateway": "192.168.1.1", "distance": 1}'
 
 # Add blackhole route
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_add_blackhole_route --tool-args '{"dst_address": "192.168.99.0/24", "comment": "Block subnet"}'
+uv run mcp-cli cmd --server mikrotik --tool add_blackhole_route --tool-args '{"dst_address": "192.168.99.0/24", "comment": "Block subnet"}'
 
 # List routes
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_routes --tool-args '{"active_only": true}'
+uv run mcp-cli cmd --server mikrotik --tool list_routes --tool-args '{"active_only": true}'
 
 # Get route details
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_route --tool-args '{"route_id": "*1"}'
+uv run mcp-cli cmd --server mikrotik --tool get_route --tool-args '{"route_id": "*1"}'
 
 # Check route path
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_check_route_path --tool-args '{"destination": "8.8.8.8"}'
+uv run mcp-cli cmd --server mikrotik --tool check_route_path --tool-args '{"destination": "8.8.8.8"}'
 
 # Get routing table
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_routing_table --tool-args '{"table_name": "main"}'
+uv run mcp-cli cmd --server mikrotik --tool get_routing_table --tool-args '{"table_name": "main"}'
 
 # Get route statistics
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_route_statistics --tool-args '{}'
+uv run mcp-cli cmd --server mikrotik --tool get_route_statistics --tool-args '{}'
 
 # Enable/Disable route
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_disable_route --tool-args '{"route_id": "*1"}'
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_enable_route --tool-args '{"route_id": "*1"}'
+uv run mcp-cli cmd --server mikrotik --tool disable_route --tool-args '{"route_id": "*1"}'
+uv run mcp-cli cmd --server mikrotik --tool enable_route --tool-args '{"route_id": "*1"}'
 
 # Remove route
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_route --tool-args '{"route_id": "*1"}'
+uv run mcp-cli cmd --server mikrotik --tool remove_route --tool-args '{"route_id": "*1"}'
 ```
 
 ### DNS Configuration
 ```bash
 # Set DNS servers
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_set_dns_servers --tool-args '{"servers": ["8.8.8.8", "8.8.4.4"], "allow_remote_requests": true}'
+uv run mcp-cli cmd --server mikrotik --tool set_dns_servers --tool-args '{"servers": ["8.8.8.8", "8.8.4.4"], "allow_remote_requests": true}'
 
 # Get DNS settings
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_dns_settings --tool-args '{}'
+uv run mcp-cli cmd --server mikrotik --tool get_dns_settings --tool-args '{}'
 
 # Add static DNS entry
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_add_dns_static --tool-args '{"name": "router.local", "address": "192.168.1.1", "comment": "Local router"}'
+uv run mcp-cli cmd --server mikrotik --tool add_dns_static --tool-args '{"name": "router.local", "address": "192.168.1.1", "comment": "Local router"}'
 
 # Add CNAME record
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_add_dns_static --tool-args '{"name": "www.example.com", "cname": "example.com"}'
+uv run mcp-cli cmd --server mikrotik --tool add_dns_static --tool-args '{"name": "www.example.com", "cname": "example.com"}'
 
 # List static DNS entries
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_dns_static --tool-args '{"name_filter": "local"}'
+uv run mcp-cli cmd --server mikrotik --tool list_dns_static --tool-args '{"name_filter": "local"}'
 
 # Update DNS entry
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_update_dns_static --tool-args '{"entry_id": "*1", "address": "192.168.1.2"}'
+uv run mcp-cli cmd --server mikrotik --tool update_dns_static --tool-args '{"entry_id": "*1", "address": "192.168.1.2"}'
 
 # Add DNS regexp
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_add_dns_regexp --tool-args '{"regexp": ".*\\.ads\\..*", "address": "0.0.0.0", "comment": "Block ads"}'
+uv run mcp-cli cmd --server mikrotik --tool add_dns_regexp --tool-args '{"regexp": ".*\\.ads\\..*", "address": "0.0.0.0", "comment": "Block ads"}'
 
 # Test DNS query
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_test_dns_query --tool-args '{"name": "google.com"}'
+uv run mcp-cli cmd --server mikrotik --tool test_dns_query --tool-args '{"name": "google.com"}'
 
 # Get DNS cache
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_dns_cache --tool-args '{}'
+uv run mcp-cli cmd --server mikrotik --tool get_dns_cache --tool-args '{}'
 
 # Flush DNS cache
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_flush_dns_cache --tool-args '{}'
+uv run mcp-cli cmd --server mikrotik --tool flush_dns_cache --tool-args '{}'
 
 # Export DNS config
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_export_dns_config --tool-args '{"filename": "dns_config"}'
+uv run mcp-cli cmd --server mikrotik --tool export_dns_config --tool-args '{"filename": "dns_config"}'
 
 # Remove DNS entry
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_dns_static --tool-args '{"entry_id": "*1"}'
+uv run mcp-cli cmd --server mikrotik --tool remove_dns_static --tool-args '{"entry_id": "*1"}'
 ```
 
 ### User Management
 ```bash
 # Add user
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_add_user --tool-args '{"name": "newuser", "password": "SecurePass123", "group": "write", "comment": "New operator"}'
+uv run mcp-cli cmd --server mikrotik --tool add_user --tool-args '{"name": "newuser", "password": "SecurePass123", "group": "write", "comment": "New operator"}'
 
 # List users
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_users --tool-args '{"group_filter": "write"}'
+uv run mcp-cli cmd --server mikrotik --tool list_users --tool-args '{"group_filter": "write"}'
 
 # Get user details
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_user --tool-args '{"name": "newuser"}'
+uv run mcp-cli cmd --server mikrotik --tool get_user --tool-args '{"name": "newuser"}'
 
 # Update user
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_update_user --tool-args '{"name": "newuser", "password": "NewSecurePass456"}'
+uv run mcp-cli cmd --server mikrotik --tool update_user --tool-args '{"name": "newuser", "password": "NewSecurePass456"}'
 
 # Enable/Disable user
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_disable_user --tool-args '{"name": "newuser"}'
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_enable_user --tool-args '{"name": "newuser"}'
+uv run mcp-cli cmd --server mikrotik --tool disable_user --tool-args '{"name": "newuser"}'
+uv run mcp-cli cmd --server mikrotik --tool enable_user --tool-args '{"name": "newuser"}'
 
 # Add user group
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_add_user_group --tool-args '{"name": "operators", "policy": ["read", "write", "test"], "comment": "Operator group"}'
+uv run mcp-cli cmd --server mikrotik --tool add_user_group --tool-args '{"name": "operators", "policy": ["read", "write", "test"], "comment": "Operator group"}'
 
 # List user groups
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_user_groups --tool-args '{}'
+uv run mcp-cli cmd --server mikrotik --tool list_user_groups --tool-args '{}'
 
 # Get active users
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_active_users --tool-args '{}'
+uv run mcp-cli cmd --server mikrotik --tool get_active_users --tool-args '{}'
 
 # Export user config
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_export_user_config --tool-args '{"filename": "user_config"}'
+uv run mcp-cli cmd --server mikrotik --tool export_user_config --tool-args '{"filename": "user_config"}'
 
 # Remove user
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_user --tool-args '{"name": "newuser"}'
+uv run mcp-cli cmd --server mikrotik --tool remove_user --tool-args '{"name": "newuser"}'
 ```
 
 #### Setting Up a New Network Segment
 ```bash
 # Create VLAN
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_vlan_interface --tool-args '{"name": "vlan200", "vlan_id": 200, "interface": "ether1", "comment": "Guest Network"}'
+uv run mcp-cli cmd --server mikrotik --tool create_vlan_interface --tool-args '{"name": "vlan200", "vlan_id": 200, "interface": "ether1", "comment": "Guest Network"}'
 
 # Add IP address
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_add_ip_address --tool-args '{"address": "192.168.200.1/24", "interface": "vlan200"}'
+uv run mcp-cli cmd --server mikrotik --tool add_ip_address --tool-args '{"address": "192.168.200.1/24", "interface": "vlan200"}'
 
 # Create DHCP pool
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_dhcp_pool --tool-args '{"name": "pool-200", "ranges": "192.168.200.10-192.168.200.100"}'
+uv run mcp-cli cmd --server mikrotik --tool create_dhcp_pool --tool-args '{"name": "pool-200", "ranges": "192.168.200.10-192.168.200.100"}'
 
 # Create DHCP network
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_dhcp_network --tool-args '{"network": "192.168.200.0/24", "gateway": "192.168.200.1", "dns_servers": ["8.8.8.8", "8.8.4.4"]}'
+uv run mcp-cli cmd --server mikrotik --tool create_dhcp_network --tool-args '{"network": "192.168.200.0/24", "gateway": "192.168.200.1", "dns_servers": ["8.8.8.8", "8.8.4.4"]}'
 
 # Create DHCP server
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_dhcp_server --tool-args '{"name": "dhcp-200", "interface": "vlan200", "address_pool": "pool-200"}'
+uv run mcp-cli cmd --server mikrotik --tool create_dhcp_server --tool-args '{"name": "dhcp-200", "interface": "vlan200", "address_pool": "pool-200"}'
 
 # Create NAT rule
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_nat_rule --tool-args '{"chain": "srcnat", "action": "masquerade", "out_interface": "ether1", "comment": "Internet access for VLAN 200"}'
+uv run mcp-cli cmd --server mikrotik --tool create_nat_rule --tool-args '{"chain": "srcnat", "action": "masquerade", "out_interface": "ether1", "comment": "Internet access for VLAN 200"}'
 ```
 
 #### Port Forwarding Setup
 ```bash
 # Forward HTTP traffic
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_nat_rule --tool-args '{"chain": "dstnat", "action": "dst-nat", "dst_address": "203.0.113.1", "dst_port": "80", "protocol": "tcp", "to_addresses": "192.168.100.10", "to_ports": "80", "comment": "Web server"}'
+uv run mcp-cli cmd --server mikrotik --tool create_nat_rule --tool-args '{"chain": "dstnat", "action": "dst-nat", "dst_address": "203.0.113.1", "dst_port": "80", "protocol": "tcp", "to_addresses": "192.168.100.10", "to_ports": "80", "comment": "Web server"}'
 
 # Forward HTTPS traffic
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_nat_rule --tool-args '{"chain": "dstnat", "action": "dst-nat", "dst_address": "203.0.113.1", "dst_port": "443", "protocol": "tcp", "to_addresses": "192.168.100.10", "to_ports": "443", "comment": "HTTPS server"}'
+uv run mcp-cli cmd --server mikrotik --tool create_nat_rule --tool-args '{"chain": "dstnat", "action": "dst-nat", "dst_address": "203.0.113.1", "dst_port": "443", "protocol": "tcp", "to_addresses": "192.168.100.10", "to_ports": "443", "comment": "HTTPS server"}'
 
 # Forward custom SSH port
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_nat_rule --tool-args '{"chain": "dstnat", "action": "dst-nat", "dst_address": "203.0.113.1", "dst_port": "2222", "protocol": "tcp", "to_addresses": "192.168.100.10", "to_ports": "22", "comment": "SSH server"}'
+uv run mcp-cli cmd --server mikrotik --tool create_nat_rule --tool-args '{"chain": "dstnat", "action": "dst-nat", "dst_address": "203.0.113.1", "dst_port": "2222", "protocol": "tcp", "to_addresses": "192.168.100.10", "to_ports": "22", "comment": "SSH server"}'
 ```
 
 #### Backup and Restore Process
 ```bash
 # Create backup user
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_add_user --tool-args '{"name": "backup_user", "password": "BackupPass123", "group": "read", "comment": "Backup account"}'
+uv run mcp-cli cmd --server mikrotik --tool add_user --tool-args '{"name": "backup_user", "password": "BackupPass123", "group": "read", "comment": "Backup account"}'
 
 # Create full backup
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_backup --tool-args '{"name": "daily_backup", "include_password": true}'
+uv run mcp-cli cmd --server mikrotik --tool create_backup --tool-args '{"name": "daily_backup", "include_password": true}'
 
 # Export configuration
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_export --tool-args '{"name": "config_export", "file_format": "rsc", "export_type": "full"}'
+uv run mcp-cli cmd --server mikrotik --tool create_export --tool-args '{"name": "config_export", "file_format": "rsc", "export_type": "full"}'
 
 # Export firewall rules
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_export_section --tool-args '{"section": "/ip/firewall/filter", "name": "firewall_backup"}'
+uv run mcp-cli cmd --server mikrotik --tool export_section --tool-args '{"section": "/ip/firewall/filter", "name": "firewall_backup"}'
 
 # Export NAT rules
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_export_section --tool-args '{"section": "/ip/firewall/nat", "name": "nat_backup"}'
+uv run mcp-cli cmd --server mikrotik --tool export_section --tool-args '{"section": "/ip/firewall/nat", "name": "nat_backup"}'
 ```
 
 ### Create Wireless Interface
 ```bash
 # Create basic AP interface
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_interface --tool-args '{"name": "wlan1", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "MyNetwork", "comment": "Main WiFi Network"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_interface --tool-args '{"name": "wlan1", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "MyNetwork", "comment": "Main WiFi Network"}'
 
 # Create station interface
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_interface --tool-args '{"name": "wlan-sta", "radio_name": "wlan2", "mode": "station", "ssid": "UpstreamWiFi"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_interface --tool-args '{"name": "wlan-sta", "radio_name": "wlan2", "mode": "station", "ssid": "UpstreamWiFi"}'
 
 # Create with specific frequency and band
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_interface --tool-args '{"name": "wlan-5g", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "MyNetwork-5G", "frequency": "5180", "band": "5ghz-a/n/ac", "channel_width": "80mhz"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_interface --tool-args '{"name": "wlan-5g", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "MyNetwork-5G", "frequency": "5180", "band": "5ghz-a/n/ac", "channel_width": "80mhz"}'
 ```
 
 ### List and Manage Wireless Interfaces
 ```bash
 # List all wireless interfaces
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_interfaces --tool-args '{}'
+uv run mcp-cli cmd --server mikrotik --tool list_wireless_interfaces --tool-args '{}'
 
 # List only AP interfaces
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_interfaces --tool-args '{"mode_filter": "ap-bridge"}'
+uv run mcp-cli cmd --server mikrotik --tool list_wireless_interfaces --tool-args '{"mode_filter": "ap-bridge"}'
 
 # List only running interfaces
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_interfaces --tool-args '{"running_only": true}'
+uv run mcp-cli cmd --server mikrotik --tool list_wireless_interfaces --tool-args '{"running_only": true}'
 
 # Get specific interface details
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_wireless_interface --tool-args '{"name": "wlan1"}'
+uv run mcp-cli cmd --server mikrotik --tool get_wireless_interface --tool-args '{"name": "wlan1"}'
 
 # Update wireless interface
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_update_wireless_interface --tool-args '{"name": "wlan1", "ssid": "UpdatedNetworkName", "comment": "Updated main network"}'
+uv run mcp-cli cmd --server mikrotik --tool update_wireless_interface --tool-args '{"name": "wlan1", "ssid": "UpdatedNetworkName", "comment": "Updated main network"}'
 
 # Enable/Disable wireless interface
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_disable_wireless_interface --tool-args '{"name": "wlan1"}'
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_enable_wireless_interface --tool-args '{"name": "wlan1"}'
+uv run mcp-cli cmd --server mikrotik --tool disable_wireless_interface --tool-args '{"name": "wlan1"}'
+uv run mcp-cli cmd --server mikrotik --tool enable_wireless_interface --tool-args '{"name": "wlan1"}'
 
 # Remove wireless interface
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_wireless_interface --tool-args '{"name": "wlan-guest"}'
+uv run mcp-cli cmd --server mikrotik --tool remove_wireless_interface --tool-args '{"name": "wlan-guest"}'
 ```
 
 ## Wireless Security Profile Management
@@ -384,34 +384,34 @@ uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_wireless_interface -
 ### Create Security Profiles
 ```bash
 # Create WPA2-PSK security profile
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_security_profile --tool-args '{"name": "wpa2-security", "mode": "dynamic-keys", "authentication_types": ["wpa2-psk"], "unicast_ciphers": ["aes-ccm"], "group_ciphers": ["aes-ccm"], "wpa2_pre_shared_key": "SecurePassword123"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_security_profile --tool-args '{"name": "wpa2-security", "mode": "dynamic-keys", "authentication_types": ["wpa2-psk"], "unicast_ciphers": ["aes-ccm"], "group_ciphers": ["aes-ccm"], "wpa2_pre_shared_key": "SecurePassword123"}'
 
 # Create mixed WPA/WPA2 profile
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_security_profile --tool-args '{"name": "mixed-security", "mode": "dynamic-keys", "authentication_types": ["wpa-psk", "wpa2-psk"], "unicast_ciphers": ["tkip", "aes-ccm"], "group_ciphers": ["tkip"], "wpa_pre_shared_key": "Password123", "wpa2_pre_shared_key": "Password123"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_security_profile --tool-args '{"name": "mixed-security", "mode": "dynamic-keys", "authentication_types": ["wpa-psk", "wpa2-psk"], "unicast_ciphers": ["tkip", "aes-ccm"], "group_ciphers": ["tkip"], "wpa_pre_shared_key": "Password123", "wpa2_pre_shared_key": "Password123"}'
 
 # Create WPA2-Enterprise profile
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_security_profile --tool-args '{"name": "enterprise-security", "mode": "dynamic-keys", "authentication_types": ["wpa2-eap"], "unicast_ciphers": ["aes-ccm"], "group_ciphers": ["aes-ccm"], "eap_methods": "peap,tls"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_security_profile --tool-args '{"name": "enterprise-security", "mode": "dynamic-keys", "authentication_types": ["wpa2-eap"], "unicast_ciphers": ["aes-ccm"], "group_ciphers": ["aes-ccm"], "eap_methods": "peap,tls"}'
 
 # Create open network profile
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_security_profile --tool-args '{"name": "open-network", "mode": "none", "comment": "Guest network - no security"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_security_profile --tool-args '{"name": "open-network", "mode": "none", "comment": "Guest network - no security"}'
 ```
 
 ### Manage Security Profiles
 ```bash
 # List all security profiles
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_security_profiles --tool-args '{}'
+uv run mcp-cli cmd --server mikrotik --tool list_wireless_security_profiles --tool-args '{}'
 
 # List WPA2 profiles only
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_security_profiles --tool-args '{"mode_filter": "dynamic-keys"}'
+uv run mcp-cli cmd --server mikrotik --tool list_wireless_security_profiles --tool-args '{"mode_filter": "dynamic-keys"}'
 
 # Get specific profile details
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_wireless_security_profile --tool-args '{"name": "wpa2-security"}'
+uv run mcp-cli cmd --server mikrotik --tool get_wireless_security_profile --tool-args '{"name": "wpa2-security"}'
 
 # Apply security profile to interface
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_set_wireless_security_profile --tool-args '{"interface_name": "wlan1", "security_profile": "wpa2-security"}'
+uv run mcp-cli cmd --server mikrotik --tool set_wireless_security_profile --tool-args '{"interface_name": "wlan1", "security_profile": "wpa2-security"}'
 
 # Remove security profile
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_wireless_security_profile --tool-args '{"name": "old-profile"}'
+uv run mcp-cli cmd --server mikrotik --tool remove_wireless_security_profile --tool-args '{"name": "old-profile"}'
 ```
 
 ## Wireless Network Operations
@@ -419,16 +419,16 @@ uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_wireless_security_pr
 ### Network Scanning and Monitoring
 ```bash
 # Scan for available networks
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_scan_wireless_networks --tool-args '{"interface": "wlan1", "duration": 10}'
+uv run mcp-cli cmd --server mikrotik --tool scan_wireless_networks --tool-args '{"interface": "wlan1", "duration": 10}'
 
 # Quick scan (5 seconds)
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_scan_wireless_networks --tool-args '{"interface": "wlan2"}'
+uv run mcp-cli cmd --server mikrotik --tool scan_wireless_networks --tool-args '{"interface": "wlan2"}'
 
 # Get connected clients (all interfaces)
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_wireless_registration_table --tool-args '{}'
+uv run mcp-cli cmd --server mikrotik --tool get_wireless_registration_table --tool-args '{}'
 
 # Get clients for specific interface
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_wireless_registration_table --tool-args '{"interface": "wlan1"}'
+uv run mcp-cli cmd --server mikrotik --tool get_wireless_registration_table --tool-args '{"interface": "wlan1"}'
 ```
 
 ## Wireless Access List Management
@@ -436,31 +436,31 @@ uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_wireless_registration_t
 ### Create Access List Entries
 ```bash
 # Allow specific MAC address
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_access_list --tool-args '{"interface": "wlan1", "mac_address": "AA:BB:CC:DD:EE:FF", "action": "accept", "comment": "Trusted device"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_access_list --tool-args '{"interface": "wlan1", "mac_address": "AA:BB:CC:DD:EE:FF", "action": "accept", "comment": "Trusted device"}'
 
 # Block specific MAC address
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_access_list --tool-args '{"interface": "wlan1", "mac_address": "11:22:33:44:55:66", "action": "reject", "comment": "Blocked device"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_access_list --tool-args '{"interface": "wlan1", "mac_address": "11:22:33:44:55:66", "action": "reject", "comment": "Blocked device"}'
 
 # Allow with signal strength requirement
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_access_list --tool-args '{"interface": "wlan1", "mac_address": "AA:BB:CC:DD:EE:FF", "action": "accept", "signal_range": "-80..-50", "comment": "Strong signal only"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_access_list --tool-args '{"interface": "wlan1", "mac_address": "AA:BB:CC:DD:EE:FF", "action": "accept", "signal_range": "-80..-50", "comment": "Strong signal only"}'
 
 # Time-based access control
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_access_list --tool-args '{"interface": "wlan1", "mac_address": "AA:BB:CC:DD:EE:FF", "action": "accept", "time": "8h-18h,mon,tue,wed,thu,fri", "comment": "Work hours only"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_access_list --tool-args '{"interface": "wlan1", "mac_address": "AA:BB:CC:DD:EE:FF", "action": "accept", "time": "8h-18h,mon,tue,wed,thu,fri", "comment": "Work hours only"}'
 ```
 
 ### Manage Access Lists
 ```bash
 # List all access list entries
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_access_list --tool-args '{}'
+uv run mcp-cli cmd --server mikrotik --tool list_wireless_access_list --tool-args '{}'
 
 # List entries for specific interface
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_access_list --tool-args '{"interface_filter": "wlan1"}'
+uv run mcp-cli cmd --server mikrotik --tool list_wireless_access_list --tool-args '{"interface_filter": "wlan1"}'
 
 # List only blocked entries
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_access_list --tool-args '{"action_filter": "reject"}'
+uv run mcp-cli cmd --server mikrotik --tool list_wireless_access_list --tool-args '{"action_filter": "reject"}'
 
 # Remove access list entry
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_wireless_access_list_entry --tool-args '{"entry_id": "*1"}'
+uv run mcp-cli cmd --server mikrotik --tool remove_wireless_access_list_entry --tool-args '{"entry_id": "*1"}'
 ```
 
 ## Complete WiFi Network Setup Examples
@@ -468,82 +468,82 @@ uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_wireless_access_list
 ### Basic Home Network Setup
 ```bash
 # 1. Create security profile
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_security_profile --tool-args '{"name": "home-security", "mode": "dynamic-keys", "authentication_types": ["wpa2-psk"], "unicast_ciphers": ["aes-ccm"], "group_ciphers": ["aes-ccm"], "wpa2_pre_shared_key": "MyHomePassword123"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_security_profile --tool-args '{"name": "home-security", "mode": "dynamic-keys", "authentication_types": ["wpa2-psk"], "unicast_ciphers": ["aes-ccm"], "group_ciphers": ["aes-ccm"], "wpa2_pre_shared_key": "MyHomePassword123"}'
 
 # 2. Create wireless interface
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_interface --tool-args '{"name": "home-wifi", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "HomeNetwork", "band": "2ghz-b/g/n", "comment": "Main home network"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_interface --tool-args '{"name": "home-wifi", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "HomeNetwork", "band": "2ghz-b/g/n", "comment": "Main home network"}'
 
 # 3. Apply security profile
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_set_wireless_security_profile --tool-args '{"interface_name": "home-wifi", "security_profile": "home-security"}'
+uv run mcp-cli cmd --server mikrotik --tool set_wireless_security_profile --tool-args '{"interface_name": "home-wifi", "security_profile": "home-security"}'
 
 # 4. Enable the interface
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_enable_wireless_interface --tool-args '{"name": "home-wifi"}'
+uv run mcp-cli cmd --server mikrotik --tool enable_wireless_interface --tool-args '{"name": "home-wifi"}'
 ```
 
 ### Guest Network Setup
 ```bash
 # 1. Create open security profile for guests
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_security_profile --tool-args '{"name": "guest-open", "mode": "none", "comment": "Open guest network"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_security_profile --tool-args '{"name": "guest-open", "mode": "none", "comment": "Open guest network"}'
 
 # 2. Create guest wireless interface
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_interface --tool-args '{"name": "guest-wifi", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "GuestNetwork", "comment": "Guest access network"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_interface --tool-args '{"name": "guest-wifi", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "GuestNetwork", "comment": "Guest access network"}'
 
 # 3. Apply open security profile
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_set_wireless_security_profile --tool-args '{"interface_name": "guest-wifi", "security_profile": "guest-open"}'
+uv run mcp-cli cmd --server mikrotik --tool set_wireless_security_profile --tool-args '{"interface_name": "guest-wifi", "security_profile": "guest-open"}'
 
 # 4. Enable guest network
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_enable_wireless_interface --tool-args '{"name": "guest-wifi"}'
+uv run mcp-cli cmd --server mikrotik --tool enable_wireless_interface --tool-args '{"name": "guest-wifi"}'
 ```
 
 ### Enterprise Network Setup
 ```bash
 # 1. Create WPA2-Enterprise security profile
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_security_profile --tool-args '{"name": "corp-security", "mode": "dynamic-keys", "authentication_types": ["wpa2-eap"], "unicast_ciphers": ["aes-ccm"], "group_ciphers": ["aes-ccm"], "eap_methods": "peap", "comment": "Corporate WPA2-Enterprise"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_security_profile --tool-args '{"name": "corp-security", "mode": "dynamic-keys", "authentication_types": ["wpa2-eap"], "unicast_ciphers": ["aes-ccm"], "group_ciphers": ["aes-ccm"], "eap_methods": "peap", "comment": "Corporate WPA2-Enterprise"}'
 
 # 2. Create corporate wireless interface
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_interface --tool-args '{"name": "corp-wifi", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "CorpNetwork", "band": "5ghz-a/n/ac", "channel_width": "80mhz", "comment": "Corporate network"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_interface --tool-args '{"name": "corp-wifi", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "CorpNetwork", "band": "5ghz-a/n/ac", "channel_width": "80mhz", "comment": "Corporate network"}'
 
 # 3. Apply enterprise security
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_set_wireless_security_profile --tool-args '{"interface_name": "corp-wifi", "security_profile": "corp-security"}'
+uv run mcp-cli cmd --server mikrotik --tool set_wireless_security_profile --tool-args '{"interface_name": "corp-wifi", "security_profile": "corp-security"}'
 
 # 4. Create access control for specific devices
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_access_list --tool-args '{"interface": "corp-wifi", "mac_address": "00:11:22:33:44:55", "action": "accept", "comment": "Corporate laptop"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_access_list --tool-args '{"interface": "corp-wifi", "mac_address": "00:11:22:33:44:55", "action": "accept", "comment": "Corporate laptop"}'
 ```
 
 ### Dual-Band Setup (2.4GHz + 5GHz)
 ```bash
 # 1. Create security profile
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_security_profile --tool-args '{"name": "dual-band-security", "mode": "dynamic-keys", "authentication_types": ["wpa2-psk"], "unicast_ciphers": ["aes-ccm"], "group_ciphers": ["aes-ccm"], "wpa2_pre_shared_key": "DualBandPassword123"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_security_profile --tool-args '{"name": "dual-band-security", "mode": "dynamic-keys", "authentication_types": ["wpa2-psk"], "unicast_ciphers": ["aes-ccm"], "group_ciphers": ["aes-ccm"], "wpa2_pre_shared_key": "DualBandPassword123"}'
 
 # 2. Create 2.4GHz interface
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_interface --tool-args '{"name": "wifi-2g", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "MyNetwork", "band": "2ghz-b/g/n", "channel_width": "20mhz", "comment": "2.4GHz network"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_interface --tool-args '{"name": "wifi-2g", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "MyNetwork", "band": "2ghz-b/g/n", "channel_width": "20mhz", "comment": "2.4GHz network"}'
 
 # 3. Create 5GHz interface  
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_interface --tool-args '{"name": "wifi-5g", "radio_name": "wlan2", "mode": "ap-bridge", "ssid": "MyNetwork-5G", "band": "5ghz-a/n/ac", "channel_width": "80mhz", "comment": "5GHz network"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_interface --tool-args '{"name": "wifi-5g", "radio_name": "wlan2", "mode": "ap-bridge", "ssid": "MyNetwork-5G", "band": "5ghz-a/n/ac", "channel_width": "80mhz", "comment": "5GHz network"}'
 
 # 4. Apply security to both interfaces
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_set_wireless_security_profile --tool-args '{"interface_name": "wifi-2g", "security_profile": "dual-band-security"}'
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_set_wireless_security_profile --tool-args '{"interface_name": "wifi-5g", "security_profile": "dual-band-security"}'
+uv run mcp-cli cmd --server mikrotik --tool set_wireless_security_profile --tool-args '{"interface_name": "wifi-2g", "security_profile": "dual-band-security"}'
+uv run mcp-cli cmd --server mikrotik --tool set_wireless_security_profile --tool-args '{"interface_name": "wifi-5g", "security_profile": "dual-band-security"}'
 
 # 5. Enable both interfaces
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_enable_wireless_interface --tool-args '{"name": "wifi-2g"}'
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_enable_wireless_interface --tool-args '{"name": "wifi-5g"}'
+uv run mcp-cli cmd --server mikrotik --tool enable_wireless_interface --tool-args '{"name": "wifi-2g"}'
+uv run mcp-cli cmd --server mikrotik --tool enable_wireless_interface --tool-args '{"name": "wifi-5g"}'
 ```
 
 ### Point-to-Point Wireless Link
 ```bash
 # On first device (Station)
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_interface --tool-args '{"name": "p2p-station", "radio_name": "wlan1", "mode": "station", "ssid": "P2P-Link", "frequency": "5180", "band": "5ghz-a/n"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_interface --tool-args '{"name": "p2p-station", "radio_name": "wlan1", "mode": "station", "ssid": "P2P-Link", "frequency": "5180", "band": "5ghz-a/n"}'
 
 # On second device (AP)  
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_interface --tool-args '{"name": "p2p-ap", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "P2P-Link", "frequency": "5180", "band": "5ghz-a/n"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_interface --tool-args '{"name": "p2p-ap", "radio_name": "wlan1", "mode": "ap-bridge", "ssid": "P2P-Link", "frequency": "5180", "band": "5ghz-a/n"}'
 
 # Create security for P2P link
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_create_wireless_security_profile --tool-args '{"name": "p2p-security", "mode": "dynamic-keys", "authentication_types": ["wpa2-psk"], "unicast_ciphers": ["aes-ccm"], "group_ciphers": ["aes-ccm"], "wpa2_pre_shared_key": "P2PLinkPassword123"}'
+uv run mcp-cli cmd --server mikrotik --tool create_wireless_security_profile --tool-args '{"name": "p2p-security", "mode": "dynamic-keys", "authentication_types": ["wpa2-psk"], "unicast_ciphers": ["aes-ccm"], "group_ciphers": ["aes-ccm"], "wpa2_pre_shared_key": "P2PLinkPassword123"}'
 
 # Apply security to both ends
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_set_wireless_security_profile --tool-args '{"interface_name": "p2p-station", "security_profile": "p2p-security"}'
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_set_wireless_security_profile --tool-args '{"interface_name": "p2p-ap", "security_profile": "p2p-security"}'
+uv run mcp-cli cmd --server mikrotik --tool set_wireless_security_profile --tool-args '{"interface_name": "p2p-station", "security_profile": "p2p-security"}'
+uv run mcp-cli cmd --server mikrotik --tool set_wireless_security_profile --tool-args '{"interface_name": "p2p-ap", "security_profile": "p2p-security"}'
 ```
 
 ## Monitoring and Troubleshooting
@@ -551,33 +551,33 @@ uv run mcp-cli cmd --server mikrotik --tool mikrotik_set_wireless_security_profi
 ### Network Analysis
 ```bash
 # Scan for interference and available channels
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_scan_wireless_networks --tool-args '{"interface": "wlan1", "duration": 30}'
+uv run mcp-cli cmd --server mikrotik --tool scan_wireless_networks --tool-args '{"interface": "wlan1", "duration": 30}'
 
 # Monitor connected clients
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_wireless_registration_table --tool-args '{"interface": "wlan1"}'
+uv run mcp-cli cmd --server mikrotik --tool get_wireless_registration_table --tool-args '{"interface": "wlan1"}'
 
 # Check interface status
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_get_wireless_interface --tool-args '{"name": "wlan1"}'
+uv run mcp-cli cmd --server mikrotik --tool get_wireless_interface --tool-args '{"name": "wlan1"}'
 
 # List all wireless configurations
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_interfaces --tool-args '{}'
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_security_profiles --tool-args '{}'
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_list_wireless_access_list --tool-args '{}'
+uv run mcp-cli cmd --server mikrotik --tool list_wireless_interfaces --tool-args '{}'
+uv run mcp-cli cmd --server mikrotik --tool list_wireless_security_profiles --tool-args '{}'
+uv run mcp-cli cmd --server mikrotik --tool list_wireless_access_list --tool-args '{}'
 ```
 
 ### Maintenance Operations
 ```bash
 # Disable interface for maintenance
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_disable_wireless_interface --tool-args '{"name": "wlan1"}'
+uv run mcp-cli cmd --server mikrotik --tool disable_wireless_interface --tool-args '{"name": "wlan1"}'
 
 # Update configuration
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_update_wireless_interface --tool-args '{"name": "wlan1", "channel_width": "40mhz", "comment": "Updated for better performance"}'
+uv run mcp-cli cmd --server mikrotik --tool update_wireless_interface --tool-args '{"name": "wlan1", "channel_width": "40mhz", "comment": "Updated for better performance"}'
 
 # Re-enable interface
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_enable_wireless_interface --tool-args '{"name": "wlan1"}'
+uv run mcp-cli cmd --server mikrotik --tool enable_wireless_interface --tool-args '{"name": "wlan1"}'
 
 # Clean up unused profiles
-uv run mcp-cli cmd --server mikrotik --tool mikrotik_remove_wireless_security_profile --tool-args '{"name": "old-profile"}'
+uv run mcp-cli cmd --server mikrotik --tool remove_wireless_security_profile --tool-args '{"name": "old-profile"}'
 ```
 
 # Using MCPO with MikroTik MCP Server

--- a/docs/integrations/mcpo.md
+++ b/docs/integrations/mcpo.md
@@ -62,7 +62,7 @@ The server will start and display:
 
 **List IP Addresses:**
 ```bash
-curl -X POST http://localhost:8000/mikrotik-mcp-server/mikrotik_list_ip_addresses \
+curl -X POST http://localhost:8000/mikrotik-mcp-server/list_ip_addresses \
   -H "Authorization: Bearer your-secret-key" \
   -H "Content-Type: application/json" \
   -d '{}'

--- a/docs/reference/backup/README.md
+++ b/docs/reference/backup/README.md
@@ -1,6 +1,6 @@
 # Backup and Export Management
 
-## `mikrotik_create_backup`
+## `create_backup`
 Creates a system backup on MikroTik device.
 - Parameters:
   - `name` (optional): Backup filename
@@ -9,20 +9,20 @@ Creates a system backup on MikroTik device.
   - `comment` (optional): Description
 - Example:
   ```
-  mikrotik_create_backup(name="backup-2024-01-01")
+  create_backup(name="backup-2024-01-01")
   ```
 
-## `mikrotik_list_backups`
+## `list_backups`
 Lists backup files on MikroTik device.
 - Parameters:
   - `name_filter` (optional): Filter by name
   - `include_exports` (optional): Include export files
 - Example:
   ```
-  mikrotik_list_backups()
+  list_backups()
   ```
 
-## `mikrotik_create_export`
+## `create_export`
 Creates a configuration export on MikroTik device.
 - Parameters:
   - `name` (optional): Export filename
@@ -34,10 +34,10 @@ Creates a configuration export on MikroTik device.
   - `comment` (optional): Description
 - Example:
   ```
-  mikrotik_create_export(name="config-export", file_format="rsc")
+  create_export(name="config-export", file_format="rsc")
   ```
 
-## `mikrotik_export_section`
+## `export_section`
 Exports a specific configuration section.
 - Parameters:
   - `section` (required): Section to export
@@ -46,40 +46,40 @@ Exports a specific configuration section.
   - `compact` (optional): Compact output
 - Example:
   ```
-  mikrotik_export_section(section="/ip/firewall", name="firewall-config")
+  export_section(section="/ip/firewall", name="firewall-config")
   ```
 
-## `mikrotik_download_file`
+## `download_file`
 Downloads a file from MikroTik device.
 - Parameters:
   - `filename` (required): Filename to download
   - `file_type` (optional): File type ("backup" or "export")
 - Example:
   ```
-  mikrotik_download_file(filename="backup-2024-01-01.backup")
+  download_file(filename="backup-2024-01-01.backup")
   ```
 
-## `mikrotik_upload_file`
+## `upload_file`
 Uploads a file to MikroTik device.
 - Parameters:
   - `filename` (required): Filename
   - `content_base64` (required): Base64 encoded content
 - Example:
   ```
-  mikrotik_upload_file(filename="config.rsc", content_base64="...")
+  upload_file(filename="config.rsc", content_base64="...")
   ```
 
-## `mikrotik_restore_backup`
+## `restore_backup`
 Restores a system backup on MikroTik device.
 - Parameters:
   - `filename` (required): Backup filename
   - `password` (optional): Backup password
 - Example:
   ```
-  mikrotik_restore_backup(filename="backup-2024-01-01.backup")
+  restore_backup(filename="backup-2024-01-01.backup")
   ```
 
-## `mikrotik_import_configuration`
+## `import_configuration`
 Imports a configuration script file.
 - Parameters:
   - `filename` (required): Script filename
@@ -87,23 +87,23 @@ Imports a configuration script file.
   - `verbose` (optional): Verbose output
 - Example:
   ```
-  mikrotik_import_configuration(filename="config.rsc")
+  import_configuration(filename="config.rsc")
   ```
 
-## `mikrotik_remove_file`
+## `remove_file`
 Removes a file from MikroTik device.
 - Parameters:
   - `filename` (required): Filename to remove
 - Example:
   ```
-  mikrotik_remove_file(filename="old-backup.backup")
+  remove_file(filename="old-backup.backup")
   ```
 
-## `mikrotik_backup_info`
+## `backup_info`
 Gets detailed information about a backup file.
 - Parameters:
   - `filename` (required): Backup filename
 - Example:
   ```
-  mikrotik_backup_info(filename="backup-2024-01-01.backup")
+  backup_info(filename="backup-2024-01-01.backup")
   ```

--- a/docs/reference/dhcp/README.md
+++ b/docs/reference/dhcp/README.md
@@ -1,6 +1,6 @@
 # DHCP Server Management
 
-## `mikrotik_create_dhcp_server`
+## `create_dhcp_server`
 Creates a DHCP server on MikroTik device.
 - Parameters:
   - `name` (required): DHCP server name
@@ -13,10 +13,10 @@ Creates a DHCP server on MikroTik device.
   - `comment` (optional): Description
 - Example:
   ```
-  mikrotik_create_dhcp_server(name="dhcp-vlan100", interface="vlan100", address_pool="pool-vlan100")
+  create_dhcp_server(name="dhcp-vlan100", interface="vlan100", address_pool="pool-vlan100")
   ```
 
-## `mikrotik_list_dhcp_servers`
+## `list_dhcp_servers`
 Lists DHCP servers on MikroTik device.
 - Parameters:
   - `name_filter` (optional): Filter by name
@@ -25,19 +25,19 @@ Lists DHCP servers on MikroTik device.
   - `invalid_only` (optional): Show only invalid servers
 - Example:
   ```
-  mikrotik_list_dhcp_servers()
+  list_dhcp_servers()
   ```
 
-## `mikrotik_get_dhcp_server`
+## `get_dhcp_server`
 Gets detailed information about a specific DHCP server.
 - Parameters:
   - `name` (required): DHCP server name
 - Example:
   ```
-  mikrotik_get_dhcp_server(name="dhcp-vlan100")
+  get_dhcp_server(name="dhcp-vlan100")
   ```
 
-## `mikrotik_create_dhcp_network`
+## `create_dhcp_network`
 Creates a DHCP network configuration.
 - Parameters:
   - `network` (required): Network address
@@ -51,10 +51,10 @@ Creates a DHCP network configuration.
   - `comment` (optional): Description
 - Example:
   ```
-  mikrotik_create_dhcp_network(network="192.168.1.0/24", gateway="192.168.1.1", dns_servers=["8.8.8.8", "8.8.4.4"])
+  create_dhcp_network(network="192.168.1.0/24", gateway="192.168.1.1", dns_servers=["8.8.8.8", "8.8.4.4"])
   ```
 
-## `mikrotik_create_dhcp_pool`
+## `create_dhcp_pool`
 Creates a DHCP address pool.
 - Parameters:
   - `name` (required): Pool name
@@ -63,14 +63,14 @@ Creates a DHCP address pool.
   - `comment` (optional): Description
 - Example:
   ```
-  mikrotik_create_dhcp_pool(name="pool-vlan100", ranges="192.168.1.10-192.168.1.250")
+  create_dhcp_pool(name="pool-vlan100", ranges="192.168.1.10-192.168.1.250")
   ```
 
-## `mikrotik_remove_dhcp_server`
+## `remove_dhcp_server`
 Removes a DHCP server from MikroTik device.
 - Parameters:
   - `name` (required): DHCP server name
 - Example:
   ```
-  mikrotik_remove_dhcp_server(name="dhcp-vlan100")
+  remove_dhcp_server(name="dhcp-vlan100")
   ```

--- a/docs/reference/dns/README.md
+++ b/docs/reference/dns/README.md
@@ -1,6 +1,6 @@
 ### DNS Management
 
-#### `mikrotik_set_dns_servers`
+#### `set_dns_servers`
 Sets DNS server configuration on MikroTik device.
 - Parameters:
   - `servers` (required): DNS server list
@@ -14,18 +14,18 @@ Sets DNS server configuration on MikroTik device.
   - `verify_doh_cert` (optional): Verify DoH certificate
 - Example:
   ```
-  mikrotik_set_dns_servers(servers=["8.8.8.8", "8.8.4.4"], allow_remote_requests=true)
+  set_dns_servers(servers=["8.8.8.8", "8.8.4.4"], allow_remote_requests=true)
   ```
 
-#### `mikrotik_get_dns_settings`
+#### `get_dns_settings`
 Gets current DNS configuration.
 - Parameters: None
 - Example:
   ```
-  mikrotik_get_dns_settings()
+  get_dns_settings()
   ```
 
-#### `mikrotik_add_dns_static`
+#### `add_dns_static`
 Adds a static DNS entry.
 - Parameters:
   - `name` (required): DNS name
@@ -44,10 +44,10 @@ Adds a static DNS entry.
   - `regexp` (optional): Regular expression
 - Example:
   ```
-  mikrotik_add_dns_static(name="router.local", address="192.168.1.1")
+  add_dns_static(name="router.local", address="192.168.1.1")
   ```
 
-#### `mikrotik_list_dns_static`
+#### `list_dns_static`
 Lists static DNS entries.
 - Parameters:
   - `name_filter` (optional): Filter by name
@@ -57,80 +57,80 @@ Lists static DNS entries.
   - `regexp_only` (optional): Show only regexp entries
 - Example:
   ```
-  mikrotik_list_dns_static()
+  list_dns_static()
   ```
 
-#### `mikrotik_get_dns_static`
+#### `get_dns_static`
 Gets details of a specific static DNS entry.
 - Parameters:
   - `entry_id` (required): Entry ID
 - Example:
   ```
-  mikrotik_get_dns_static(entry_id="*1")
+  get_dns_static(entry_id="*1")
   ```
 
-#### `mikrotik_update_dns_static`
+#### `update_dns_static`
 Updates an existing static DNS entry.
 - Parameters:
   - `entry_id` (required): Entry ID
   - All parameters from `add_dns_static` (optional)
 - Example:
   ```
-  mikrotik_update_dns_static(entry_id="*1", address="192.168.1.2")
+  update_dns_static(entry_id="*1", address="192.168.1.2")
   ```
 
-#### `mikrotik_remove_dns_static`
+#### `remove_dns_static`
 Removes a static DNS entry.
 - Parameters:
   - `entry_id` (required): Entry ID
 - Example:
   ```
-  mikrotik_remove_dns_static(entry_id="*1")
+  remove_dns_static(entry_id="*1")
   ```
 
-#### `mikrotik_enable_dns_static`
+#### `enable_dns_static`
 Enables a static DNS entry.
 - Parameters:
   - `entry_id` (required): Entry ID
 - Example:
   ```
-  mikrotik_enable_dns_static(entry_id="*1")
+  enable_dns_static(entry_id="*1")
   ```
 
-#### `mikrotik_disable_dns_static`
+#### `disable_dns_static`
 Disables a static DNS entry.
 - Parameters:
   - `entry_id` (required): Entry ID
 - Example:
   ```
-  mikrotik_disable_dns_static(entry_id="*1")
+  disable_dns_static(entry_id="*1")
   ```
 
-#### `mikrotik_get_dns_cache`
+#### `get_dns_cache`
 Gets the current DNS cache.
 - Parameters: None
 - Example:
   ```
-  mikrotik_get_dns_cache()
+  get_dns_cache()
   ```
 
-#### `mikrotik_flush_dns_cache`
+#### `flush_dns_cache`
 Flushes the DNS cache.
 - Parameters: None
 - Example:
   ```
-  mikrotik_flush_dns_cache()
+  flush_dns_cache()
   ```
 
-#### `mikrotik_get_dns_cache_statistics`
+#### `get_dns_cache_statistics`
 Gets DNS cache statistics.
 - Parameters: None
 - Example:
   ```
-  mikrotik_get_dns_cache_statistics()
+  get_dns_cache_statistics()
   ```
 
-#### `mikrotik_add_dns_regexp`
+#### `add_dns_regexp`
 Adds a DNS regexp entry for pattern matching.
 - Parameters:
   - `regexp` (required): Regular expression
@@ -140,10 +140,10 @@ Adds a DNS regexp entry for pattern matching.
   - `disabled` (optional): Disable entry
 - Example:
   ```
-  mikrotik_add_dns_regexp(regexp="^ad[0-9]*\\.doubleclick\\.net$", address="127.0.0.1")
+  add_dns_regexp(regexp="^ad[0-9]*\\.doubleclick\\.net$", address="127.0.0.1")
   ```
 
-#### `mikrotik_test_dns_query`
+#### `test_dns_query`
 Tests a DNS query.
 - Parameters:
   - `name` (required): DNS name to query
@@ -151,15 +151,14 @@ Tests a DNS query.
   - `type` (optional): Query type
 - Example:
   ```
-  mikrotik_test_dns_query(name="google.com")
+  test_dns_query(name="google.com")
   ```
 
-#### `mikrotik_export_dns_config`
+#### `export_dns_config`
 Exports DNS configuration to a file.
 - Parameters:
   - `filename` (optional): Export filename
 - Example:
   ```
-  mikrotik_export_dns_config(filename="dns-config.rsc")
+  export_dns_config(filename="dns-config.rsc")
   ```
-

--- a/docs/reference/firewall/README.md
+++ b/docs/reference/firewall/README.md
@@ -1,6 +1,6 @@
 ### Firewall Filter Rules Management
 
-#### `mikrotik_create_filter_rule`
+#### `create_filter_rule`
 Creates a firewall filter rule on MikroTik device.
 - Parameters:
   - `chain` (required): Chain type ("input", "forward", "output")
@@ -25,10 +25,10 @@ Creates a firewall filter rule on MikroTik device.
   - `place_before` (optional): Rule placement
 - Example:
   ```
-  mikrotik_create_filter_rule(chain="input", action="accept", protocol="tcp", dst_port="22", src_address="192.168.1.0/24")
+  create_filter_rule(chain="input", action="accept", protocol="tcp", dst_port="22", src_address="192.168.1.0/24")
   ```
 
-#### `mikrotik_list_filter_rules`
+#### `list_filter_rules`
 Lists firewall filter rules on MikroTik device.
 - Parameters:
   - `chain_filter` (optional): Filter by chain
@@ -42,70 +42,69 @@ Lists firewall filter rules on MikroTik device.
   - `dynamic_only` (optional): Show only dynamic rules
 - Example:
   ```
-  mikrotik_list_filter_rules(chain_filter="input")
+  list_filter_rules(chain_filter="input")
   ```
 
-#### `mikrotik_get_filter_rule`
+#### `get_filter_rule`
 Gets detailed information about a specific firewall filter rule.
 - Parameters:
   - `rule_id` (required): Rule ID
 - Example:
   ```
-  mikrotik_get_filter_rule(rule_id="*1")
+  get_filter_rule(rule_id="*1")
   ```
 
-#### `mikrotik_update_filter_rule`
+#### `update_filter_rule`
 Updates an existing firewall filter rule.
 - Parameters:
   - `rule_id` (required): Rule ID
   - All parameters from `create_filter_rule` (optional)
 - Example:
   ```
-  mikrotik_update_filter_rule(rule_id="*1", comment="Updated rule")
+  update_filter_rule(rule_id="*1", comment="Updated rule")
   ```
 
-#### `mikrotik_remove_filter_rule`
+#### `remove_filter_rule`
 Removes a firewall filter rule from MikroTik device.
 - Parameters:
   - `rule_id` (required): Rule ID
 - Example:
   ```
-  mikrotik_remove_filter_rule(rule_id="*1")
+  remove_filter_rule(rule_id="*1")
   ```
 
-#### `mikrotik_move_filter_rule`
+#### `move_filter_rule`
 Moves a firewall filter rule to a different position.
 - Parameters:
   - `rule_id` (required): Rule ID
   - `destination` (required): New position
 - Example:
   ```
-  mikrotik_move_filter_rule(rule_id="*1", destination=0)
+  move_filter_rule(rule_id="*1", destination=0)
   ```
 
-#### `mikrotik_enable_filter_rule`
+#### `enable_filter_rule`
 Enables a firewall filter rule.
 - Parameters:
   - `rule_id` (required): Rule ID
 - Example:
   ```
-  mikrotik_enable_filter_rule(rule_id="*1")
+  enable_filter_rule(rule_id="*1")
   ```
 
-#### `mikrotik_disable_filter_rule`
+#### `disable_filter_rule`
 Disables a firewall filter rule.
 - Parameters:
   - `rule_id` (required): Rule ID
 - Example:
   ```
-  mikrotik_disable_filter_rule(rule_id="*1")
+  disable_filter_rule(rule_id="*1")
   ```
 
-#### `mikrotik_create_basic_firewall_setup`
+#### `create_basic_firewall_setup`
 Creates a basic firewall setup with common security rules.
 - Parameters: None
 - Example:
   ```
-  mikrotik_create_basic_firewall_setup()
+  create_basic_firewall_setup()
   ```
-

--- a/docs/reference/ip-address/README.md
+++ b/docs/reference/ip-address/README.md
@@ -1,6 +1,6 @@
 # IP Address Management
 
-## `mikrotik_add_ip_address`
+## `add_ip_address`
 Adds an IP address to an interface.
 - Parameters:
   - `address` (required): IP address with CIDR notation
@@ -11,10 +11,10 @@ Adds an IP address to an interface.
   - `disabled` (optional): Disable address
 - Example:
   ```
-  mikrotik_add_ip_address(address="192.168.1.1/24", interface="vlan100")
+  add_ip_address(address="192.168.1.1/24", interface="vlan100")
   ```
 
-## `mikrotik_list_ip_addresses`
+## `list_ip_addresses`
 Lists IP addresses on MikroTik device.
 - Parameters:
   - `interface_filter` (optional): Filter by interface
@@ -24,23 +24,23 @@ Lists IP addresses on MikroTik device.
   - `dynamic_only` (optional): Show only dynamic addresses
 - Example:
   ```
-  mikrotik_list_ip_addresses(interface_filter="vlan100")
+  list_ip_addresses(interface_filter="vlan100")
   ```
 
-## `mikrotik_get_ip_address`
+## `get_ip_address`
 Gets detailed information about a specific IP address.
 - Parameters:
   - `address_id` (required): Address ID
 - Example:
   ```
-  mikrotik_get_ip_address(address_id="*1")
+  get_ip_address(address_id="*1")
   ```
 
-## `mikrotik_remove_ip_address`
+## `remove_ip_address`
 Removes an IP address from MikroTik device.
 - Parameters:
   - `address_id` (required): Address ID
 - Example:
   ```
-  mikrotik_remove_ip_address(address_id="*1")
+  remove_ip_address(address_id="*1")
   ```

--- a/docs/reference/ip-pool/README.md
+++ b/docs/reference/ip-pool/README.md
@@ -1,6 +1,6 @@
 # IP Pool Management
 
-## `mikrotik_create_ip_pool`
+## `create_ip_pool`
 Creates an IP pool on MikroTik device.
 - Parameters:
   - `name` (required): Pool name
@@ -9,10 +9,10 @@ Creates an IP pool on MikroTik device.
   - `comment` (optional): Description
 - Example:
   ```
-  mikrotik_create_ip_pool(name="pool1", ranges="192.168.1.100-192.168.1.200")
+  create_ip_pool(name="pool1", ranges="192.168.1.100-192.168.1.200")
   ```
 
-## `mikrotik_list_ip_pools`
+## `list_ip_pools`
 Lists IP pools on MikroTik device.
 - Parameters:
   - `name_filter` (optional): Filter by name
@@ -20,19 +20,19 @@ Lists IP pools on MikroTik device.
   - `include_used` (optional): Include used addresses
 - Example:
   ```
-  mikrotik_list_ip_pools()
+  list_ip_pools()
   ```
 
-## `mikrotik_get_ip_pool`
+## `get_ip_pool`
 Gets detailed information about a specific IP pool.
 - Parameters:
   - `name` (required): Pool name
 - Example:
   ```
-  mikrotik_get_ip_pool(name="pool1")
+  get_ip_pool(name="pool1")
   ```
 
-## `mikrotik_update_ip_pool`
+## `update_ip_pool`
 Updates an existing IP pool.
 - Parameters:
   - `name` (required): Current pool name
@@ -42,19 +42,19 @@ Updates an existing IP pool.
   - `comment` (optional): New description
 - Example:
   ```
-  mikrotik_update_ip_pool(name="pool1", ranges="192.168.1.100-192.168.1.250")
+  update_ip_pool(name="pool1", ranges="192.168.1.100-192.168.1.250")
   ```
 
-## `mikrotik_remove_ip_pool`
+## `remove_ip_pool`
 Removes an IP pool from MikroTik device.
 - Parameters:
   - `name` (required): Pool name
 - Example:
   ```
-  mikrotik_remove_ip_pool(name="pool1")
+  remove_ip_pool(name="pool1")
   ```
 
-## `mikrotik_list_ip_pool_used`
+## `list_ip_pool_used`
 Lists used addresses from IP pools.
 - Parameters:
   - `pool_name` (optional): Filter by pool name
@@ -63,15 +63,15 @@ Lists used addresses from IP pools.
   - `info_filter` (optional): Filter by info
 - Example:
   ```
-  mikrotik_list_ip_pool_used(pool_name="pool1")
+  list_ip_pool_used(pool_name="pool1")
   ```
 
-## `mikrotik_expand_ip_pool`
+## `expand_ip_pool`
 Expands an existing IP pool by adding more ranges.
 - Parameters:
   - `name` (required): Pool name
   - `additional_ranges` (required): Additional IP ranges
 - Example:
   ```
-  mikrotik_expand_ip_pool(name="pool1", additional_ranges="192.168.1.251-192.168.1.254")
+  expand_ip_pool(name="pool1", additional_ranges="192.168.1.251-192.168.1.254")
   ```

--- a/docs/reference/logs/README.md
+++ b/docs/reference/logs/README.md
@@ -1,6 +1,6 @@
 ### Log Management
 
-#### `mikrotik_get_logs`
+#### `get_logs`
 Gets logs from MikroTik device with filtering options.
 - Parameters:
   - `topics` (optional): Log topics
@@ -13,10 +13,10 @@ Gets logs from MikroTik device with filtering options.
   - `print_as` (optional): Output format
 - Example:
   ```
-  mikrotik_get_logs(topics="firewall", limit=100)
+  get_logs(topics="firewall", limit=100)
   ```
 
-#### `mikrotik_get_logs_by_severity`
+#### `get_logs_by_severity`
 Gets logs filtered by severity level.
 - Parameters:
   - `severity` (required): Severity level ("debug", "info", "warning", "error", "critical")
@@ -24,10 +24,10 @@ Gets logs filtered by severity level.
   - `limit` (optional): Result limit
 - Example:
   ```
-  mikrotik_get_logs_by_severity(severity="error", limit=50)
+  get_logs_by_severity(severity="error", limit=50)
   ```
 
-#### `mikrotik_get_logs_by_topic`
+#### `get_logs_by_topic`
 Gets logs for a specific topic/facility.
 - Parameters:
   - `topic` (required): Log topic
@@ -35,10 +35,10 @@ Gets logs for a specific topic/facility.
   - `limit` (optional): Result limit
 - Example:
   ```
-  mikrotik_get_logs_by_topic(topic="system")
+  get_logs_by_topic(topic="system")
   ```
 
-#### `mikrotik_search_logs`
+#### `search_logs`
 Searches logs for a specific term.
 - Parameters:
   - `search_term` (required): Search term
@@ -47,10 +47,10 @@ Searches logs for a specific term.
   - `limit` (optional): Result limit
 - Example:
   ```
-  mikrotik_search_logs(search_term="login failed")
+  search_logs(search_term="login failed")
   ```
 
-#### `mikrotik_get_system_events`
+#### `get_system_events`
 Gets system-related log events.
 - Parameters:
   - `event_type` (optional): Event type
@@ -58,36 +58,36 @@ Gets system-related log events.
   - `limit` (optional): Result limit
 - Example:
   ```
-  mikrotik_get_system_events(event_type="reboot")
+  get_system_events(event_type="reboot")
   ```
 
-#### `mikrotik_get_security_logs`
+#### `get_security_logs`
 Gets security-related log entries.
 - Parameters:
   - `time_filter` (optional): Time filter
   - `limit` (optional): Result limit
 - Example:
   ```
-  mikrotik_get_security_logs(limit=100)
+  get_security_logs(limit=100)
   ```
 
-#### `mikrotik_clear_logs`
+#### `clear_logs`
 Clears all logs from MikroTik device.
 - Parameters: None
 - Example:
   ```
-  mikrotik_clear_logs()
+  clear_logs()
   ```
 
-#### `mikrotik_get_log_statistics`
+#### `get_log_statistics`
 Gets statistics about log entries.
 - Parameters: None
 - Example:
   ```
-  mikrotik_get_log_statistics()
+  get_log_statistics()
   ```
 
-#### `mikrotik_export_logs`
+#### `export_logs`
 Exports logs to a file on the MikroTik device.
 - Parameters:
   - `filename` (optional): Export filename
@@ -96,10 +96,10 @@ Exports logs to a file on the MikroTik device.
   - `format` (optional): Export format ("plain" or "csv")
 - Example:
   ```
-  mikrotik_export_logs(filename="security-logs.txt", topics="firewall")
+  export_logs(filename="security-logs.txt", topics="firewall")
   ```
 
-#### `mikrotik_monitor_logs`
+#### `monitor_logs`
 Monitors logs in real-time for a specified duration.
 - Parameters:
   - `topics` (optional): Log topics
@@ -107,6 +107,5 @@ Monitors logs in real-time for a specified duration.
   - `duration` (optional): Monitor duration in seconds
 - Example:
   ```
-  mikrotik_monitor_logs(topics="firewall", duration=30)
+  monitor_logs(topics="firewall", duration=30)
   ```
-

--- a/docs/reference/nat/README.md
+++ b/docs/reference/nat/README.md
@@ -1,6 +1,6 @@
 # NAT Rules Management
 
-## `mikrotik_create_nat_rule`
+## `create_nat_rule`
 Creates a NAT rule on MikroTik device.
 - Parameters:
   - `chain` (required): Chain type ("srcnat" or "dstnat")
@@ -21,10 +21,10 @@ Creates a NAT rule on MikroTik device.
   - `place_before` (optional): Rule placement
 - Example:
   ```
-  mikrotik_create_nat_rule(chain="srcnat", action="masquerade", out_interface="ether1")
+  create_nat_rule(chain="srcnat", action="masquerade", out_interface="ether1")
   ```
 
-## `mikrotik_list_nat_rules`
+## `list_nat_rules`
 Lists NAT rules on MikroTik device.
 - Parameters:
   - `chain_filter` (optional): Filter by chain
@@ -37,61 +37,61 @@ Lists NAT rules on MikroTik device.
   - `invalid_only` (optional): Show only invalid rules
 - Example:
   ```
-  mikrotik_list_nat_rules(chain_filter="srcnat")
+  list_nat_rules(chain_filter="srcnat")
   ```
 
-## `mikrotik_get_nat_rule`
+## `get_nat_rule`
 Gets detailed information about a specific NAT rule.
 - Parameters:
   - `rule_id` (required): Rule ID
 - Example:
   ```
-  mikrotik_get_nat_rule(rule_id="*1")
+  get_nat_rule(rule_id="*1")
   ```
 
-## `mikrotik_update_nat_rule`
+## `update_nat_rule`
 Updates an existing NAT rule.
 - Parameters:
   - `rule_id` (required): Rule ID
   - All parameters from `create_nat_rule` (optional)
 - Example:
   ```
-  mikrotik_update_nat_rule(rule_id="*1", comment="Updated NAT rule")
+  update_nat_rule(rule_id="*1", comment="Updated NAT rule")
   ```
 
-## `mikrotik_remove_nat_rule`
+## `remove_nat_rule`
 Removes a NAT rule from MikroTik device.
 - Parameters:
   - `rule_id` (required): Rule ID
 - Example:
   ```
-  mikrotik_remove_nat_rule(rule_id="*1")
+  remove_nat_rule(rule_id="*1")
   ```
 
-## `mikrotik_move_nat_rule`
+## `move_nat_rule`
 Moves a NAT rule to a different position.
 - Parameters:
   - `rule_id` (required): Rule ID
   - `destination` (required): New position
 - Example:
   ```
-  mikrotik_move_nat_rule(rule_id="*1", destination=0)
+  move_nat_rule(rule_id="*1", destination=0)
   ```
 
-## `mikrotik_enable_nat_rule`
+## `enable_nat_rule`
 Enables a NAT rule.
 - Parameters:
   - `rule_id` (required): Rule ID
 - Example:
   ```
-  mikrotik_enable_nat_rule(rule_id="*1")
+  enable_nat_rule(rule_id="*1")
   ```
 
-## `mikrotik_disable_nat_rule`
+## `disable_nat_rule`
 Disables a NAT rule.
 - Parameters:
   - `rule_id` (required): Rule ID
 - Example:
   ```
-  mikrotik_disable_nat_rule(rule_id="*1")
+  disable_nat_rule(rule_id="*1")
   ```

--- a/docs/reference/routes/README.md
+++ b/docs/reference/routes/README.md
@@ -1,6 +1,6 @@
 ### Route Management
 
-#### `mikrotik_add_route`
+#### `add_route`
 Adds a route to MikroTik routing table.
 - Parameters:
   - `dst_address` (required): Destination address
@@ -16,10 +16,10 @@ Adds a route to MikroTik routing table.
   - `check_gateway` (optional): Gateway check method
 - Example:
   ```
-  mikrotik_add_route(dst_address="10.0.0.0/8", gateway="192.168.1.1")
+  add_route(dst_address="10.0.0.0/8", gateway="192.168.1.1")
   ```
 
-#### `mikrotik_list_routes`
+#### `list_routes`
 Lists routes in MikroTik routing table.
 - Parameters:
   - `dst_filter` (optional): Filter by destination
@@ -32,56 +32,56 @@ Lists routes in MikroTik routing table.
   - `static_only` (optional): Show only static routes
 - Example:
   ```
-  mikrotik_list_routes(active_only=true)
+  list_routes(active_only=true)
   ```
 
-#### `mikrotik_get_route`
+#### `get_route`
 Gets detailed information about a specific route.
 - Parameters:
   - `route_id` (required): Route ID
 - Example:
   ```
-  mikrotik_get_route(route_id="*1")
+  get_route(route_id="*1")
   ```
 
-#### `mikrotik_update_route`
+#### `update_route`
 Updates an existing route in MikroTik routing table.
 - Parameters:
   - `route_id` (required): Route ID
   - All parameters from `add_route` (optional)
 - Example:
   ```
-  mikrotik_update_route(route_id="*1", comment="Updated route")
+  update_route(route_id="*1", comment="Updated route")
   ```
 
-#### `mikrotik_remove_route`
+#### `remove_route`
 Removes a route from MikroTik routing table.
 - Parameters:
   - `route_id` (required): Route ID
 - Example:
   ```
-  mikrotik_remove_route(route_id="*1")
+  remove_route(route_id="*1")
   ```
 
-#### `mikrotik_enable_route`
+#### `enable_route`
 Enables a route.
 - Parameters:
   - `route_id` (required): Route ID
 - Example:
   ```
-  mikrotik_enable_route(route_id="*1")
+  enable_route(route_id="*1")
   ```
 
-#### `mikrotik_disable_route`
+#### `disable_route`
 Disables a route.
 - Parameters:
   - `route_id` (required): Route ID
 - Example:
   ```
-  mikrotik_disable_route(route_id="*1")
+  disable_route(route_id="*1")
   ```
 
-#### `mikrotik_get_routing_table`
+#### `get_routing_table`
 Gets a specific routing table.
 - Parameters:
   - `table_name` (optional): Table name (default: "main")
@@ -89,10 +89,10 @@ Gets a specific routing table.
   - `active_only` (optional): Show only active routes
 - Example:
   ```
-  mikrotik_get_routing_table(table_name="main")
+  get_routing_table(table_name="main")
   ```
 
-#### `mikrotik_check_route_path`
+#### `check_route_path`
 Checks the route path to a destination.
 - Parameters:
   - `destination` (required): Destination address
@@ -100,26 +100,26 @@ Checks the route path to a destination.
   - `routing_mark` (optional): Routing mark
 - Example:
   ```
-  mikrotik_check_route_path(destination="8.8.8.8")
+  check_route_path(destination="8.8.8.8")
   ```
 
-#### `mikrotik_get_route_cache`
+#### `get_route_cache`
 Gets the route cache.
 - Parameters: None
 - Example:
   ```
-  mikrotik_get_route_cache()
+  get_route_cache()
   ```
 
-#### `mikrotik_flush_route_cache`
+#### `flush_route_cache`
 Flushes the route cache.
 - Parameters: None
 - Example:
   ```
-  mikrotik_flush_route_cache()
+  flush_route_cache()
   ```
 
-#### `mikrotik_add_default_route`
+#### `add_default_route`
 Adds a default route (0.0.0.0/0).
 - Parameters:
   - `gateway` (required): Gateway address
@@ -128,10 +128,10 @@ Adds a default route (0.0.0.0/0).
   - `check_gateway` (optional): Gateway check method
 - Example:
   ```
-  mikrotik_add_default_route(gateway="192.168.1.1")
+  add_default_route(gateway="192.168.1.1")
   ```
 
-#### `mikrotik_add_blackhole_route`
+#### `add_blackhole_route`
 Adds a blackhole route.
 - Parameters:
   - `dst_address` (required): Destination address
@@ -139,14 +139,13 @@ Adds a blackhole route.
   - `comment` (optional): Description
 - Example:
   ```
-  mikrotik_add_blackhole_route(dst_address="10.0.0.0/8")
+  add_blackhole_route(dst_address="10.0.0.0/8")
   ```
 
-#### `mikrotik_get_route_statistics`
+#### `get_route_statistics`
 Gets routing table statistics.
 - Parameters: None
 - Example:
   ```
-  mikrotik_get_route_statistics()
+  get_route_statistics()
   ```
-

--- a/docs/reference/users/README.md
+++ b/docs/reference/users/README.md
@@ -1,6 +1,6 @@
 ### User Management
 
-#### `mikrotik_add_user`
+#### `add_user`
 Adds a new user to MikroTik device.
 - Parameters:
   - `name` (required): Username
@@ -11,10 +11,10 @@ Adds a new user to MikroTik device.
   - `disabled` (optional): Disable user
 - Example:
   ```
-  mikrotik_add_user(name="john", password="secure123", group="full")
+  add_user(name="john", password="secure123", group="full")
   ```
 
-#### `mikrotik_list_users`
+#### `list_users`
 Lists users on MikroTik device.
 - Parameters:
   - `name_filter` (optional): Filter by name
@@ -23,19 +23,19 @@ Lists users on MikroTik device.
   - `active_only` (optional): Show only active users
 - Example:
   ```
-  mikrotik_list_users(group_filter="full")
+  list_users(group_filter="full")
   ```
 
-#### `mikrotik_get_user`
+#### `get_user`
 Gets detailed information about a specific user.
 - Parameters:
   - `name` (required): Username
 - Example:
   ```
-  mikrotik_get_user(name="john")
+  get_user(name="john")
   ```
 
-#### `mikrotik_update_user`
+#### `update_user`
 Updates an existing user on MikroTik device.
 - Parameters:
   - `name` (required): Current username
@@ -47,37 +47,37 @@ Updates an existing user on MikroTik device.
   - `disabled` (optional): Enable/disable user
 - Example:
   ```
-  mikrotik_update_user(name="john", group="read")
+  update_user(name="john", group="read")
   ```
 
-#### `mikrotik_remove_user`
+#### `remove_user`
 Removes a user from MikroTik device.
 - Parameters:
   - `name` (required): Username
 - Example:
   ```
-  mikrotik_remove_user(name="john")
+  remove_user(name="john")
   ```
 
-#### `mikrotik_disable_user`
+#### `disable_user`
 Disables a user account.
 - Parameters:
   - `name` (required): Username
 - Example:
   ```
-  mikrotik_disable_user(name="john")
+  disable_user(name="john")
   ```
 
-#### `mikrotik_enable_user`
+#### `enable_user`
 Enables a user account.
 - Parameters:
   - `name` (required): Username
 - Example:
   ```
-  mikrotik_enable_user(name="john")
+  enable_user(name="john")
   ```
 
-#### `mikrotik_add_user_group`
+#### `add_user_group`
 Adds a new user group to MikroTik device.
 - Parameters:
   - `name` (required): Group name
@@ -86,29 +86,29 @@ Adds a new user group to MikroTik device.
   - `comment` (optional): Description
 - Example:
   ```
-  mikrotik_add_user_group(name="operators", policy=["read", "write", "reboot"])
+  add_user_group(name="operators", policy=["read", "write", "reboot"])
   ```
 
-#### `mikrotik_list_user_groups`
+#### `list_user_groups`
 Lists user groups on MikroTik device.
 - Parameters:
   - `name_filter` (optional): Filter by name
   - `policy_filter` (optional): Filter by policy
 - Example:
   ```
-  mikrotik_list_user_groups()
+  list_user_groups()
   ```
 
-#### `mikrotik_get_user_group`
+#### `get_user_group`
 Gets detailed information about a specific user group.
 - Parameters:
   - `name` (required): Group name
 - Example:
   ```
-  mikrotik_get_user_group(name="operators")
+  get_user_group(name="operators")
   ```
 
-#### `mikrotik_update_user_group`
+#### `update_user_group`
 Updates an existing user group on MikroTik device.
 - Parameters:
   - `name` (required): Current group name
@@ -118,69 +118,68 @@ Updates an existing user group on MikroTik device.
   - `comment` (optional): New description
 - Example:
   ```
-  mikrotik_update_user_group(name="operators", policy=["read", "write"])
+  update_user_group(name="operators", policy=["read", "write"])
   ```
 
-#### `mikrotik_remove_user_group`
+#### `remove_user_group`
 Removes a user group from MikroTik device.
 - Parameters:
   - `name` (required): Group name
 - Example:
   ```
-  mikrotik_remove_user_group(name="operators")
+  remove_user_group(name="operators")
   ```
 
-#### `mikrotik_get_active_users`
+#### `get_active_users`
 Gets currently active/logged-in users.
 - Parameters: None
 - Example:
   ```
-  mikrotik_get_active_users()
+  get_active_users()
   ```
 
-#### `mikrotik_disconnect_user`
+#### `disconnect_user`
 Disconnects an active user session.
 - Parameters:
   - `user_id` (required): User session ID
 - Example:
   ```
-  mikrotik_disconnect_user(user_id="*1")
+  disconnect_user(user_id="*1")
   ```
 
-#### `mikrotik_export_user_config`
+#### `export_user_config`
 Exports user configuration to a file.
 - Parameters:
   - `filename` (optional): Export filename
 - Example:
   ```
-  mikrotik_export_user_config(filename="users.rsc")
+  export_user_config(filename="users.rsc")
   ```
 
-#### `mikrotik_set_user_ssh_keys`
+#### `set_user_ssh_keys`
 Sets SSH public keys for a user.
 - Parameters:
   - `username` (required): Username
   - `key_file` (required): SSH key filename
 - Example:
   ```
-  mikrotik_set_user_ssh_keys(username="john", key_file="id_rsa.pub")
+  set_user_ssh_keys(username="john", key_file="id_rsa.pub")
   ```
 
-#### `mikrotik_list_user_ssh_keys`
+#### `list_user_ssh_keys`
 Lists SSH keys for a specific user.
 - Parameters:
   - `username` (required): Username
 - Example:
   ```
-  mikrotik_list_user_ssh_keys(username="john")
+  list_user_ssh_keys(username="john")
   ```
 
-#### `mikrotik_remove_user_ssh_key`
+#### `remove_user_ssh_key`
 Removes an SSH key.
 - Parameters:
   - `key_id` (required): SSH key ID
 - Example:
   ```
-  mikrotik_remove_user_ssh_key(key_id="*1")
+  remove_user_ssh_key(key_id="*1")
   ```
-

--- a/docs/reference/vlan/README.md
+++ b/docs/reference/vlan/README.md
@@ -1,6 +1,6 @@
 # VLAN Interface Management
 
-## `mikrotik_create_vlan_interface`
+## `create_vlan_interface`
 Creates a VLAN interface on MikroTik device.
 - Parameters:
   - `name` (required): VLAN interface name
@@ -14,10 +14,10 @@ Creates a VLAN interface on MikroTik device.
   - `arp_timeout` (optional): ARP timeout
 - Example:
   ```
-  mikrotik_create_vlan_interface(name="vlan100", vlan_id=100, interface="ether1")
+  create_vlan_interface(name="vlan100", vlan_id=100, interface="ether1")
   ```
 
-## `mikrotik_list_vlan_interfaces`
+## `list_vlan_interfaces`
 Lists VLAN interfaces on MikroTik device.
 - Parameters:
   - `name_filter` (optional): Filter by name
@@ -26,19 +26,19 @@ Lists VLAN interfaces on MikroTik device.
   - `disabled_only` (optional): Show only disabled interfaces
 - Example:
   ```
-  mikrotik_list_vlan_interfaces(vlan_id_filter=100)
+  list_vlan_interfaces(vlan_id_filter=100)
   ```
 
-## `mikrotik_get_vlan_interface`
+## `get_vlan_interface`
 Gets detailed information about a specific VLAN interface.
 - Parameters:
   - `name` (required): VLAN interface name
 - Example:
   ```
-  mikrotik_get_vlan_interface(name="vlan100")
+  get_vlan_interface(name="vlan100")
   ```
 
-## `mikrotik_update_vlan_interface`
+## `update_vlan_interface`
 Updates an existing VLAN interface.
 - Parameters:
   - `name` (required): Current VLAN interface name
@@ -53,14 +53,14 @@ Updates an existing VLAN interface.
   - `arp_timeout` (optional): ARP timeout
 - Example:
   ```
-  mikrotik_update_vlan_interface(name="vlan100", comment="Production VLAN")
+  update_vlan_interface(name="vlan100", comment="Production VLAN")
   ```
 
-## `mikrotik_remove_vlan_interface`
+## `remove_vlan_interface`
 Removes a VLAN interface from MikroTik device.
 - Parameters:
   - `name` (required): VLAN interface name
 - Example:
   ```
-  mikrotik_remove_vlan_interface(name="vlan100")
+  remove_vlan_interface(name="vlan100")
   ```

--- a/src/mcp_mikrotik/tools/backup_tools.py
+++ b/src/mcp_mikrotik/tools/backup_tools.py
@@ -12,7 +12,7 @@ def get_backup_tools() -> List[Tool]:
     return [
         # Backup and Export tools
         Tool(
-            name="mikrotik_create_backup",
+            name="create_backup",
             description="Creates a system backup on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -26,7 +26,7 @@ def get_backup_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_list_backups",
+            name="list_backups",
             description="Lists backup files on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -38,7 +38,7 @@ def get_backup_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_create_export",
+            name="create_export",
             description="Creates a configuration export on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -55,7 +55,7 @@ def get_backup_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_export_section",
+            name="export_section",
             description="Exports a specific configuration section",
             inputSchema={
                 "type": "object",
@@ -69,7 +69,7 @@ def get_backup_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_download_file",
+            name="download_file",
             description="Downloads a file from MikroTik device",
             inputSchema={
                 "type": "object",
@@ -81,7 +81,7 @@ def get_backup_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_upload_file",
+            name="upload_file",
             description="Uploads a file to MikroTik device",
             inputSchema={
                 "type": "object",
@@ -93,7 +93,7 @@ def get_backup_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_restore_backup",
+            name="restore_backup",
             description="Restores a system backup on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -105,7 +105,7 @@ def get_backup_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_import_configuration",
+            name="import_configuration",
             description="Imports a configuration script file",
             inputSchema={
                 "type": "object",
@@ -118,7 +118,7 @@ def get_backup_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_remove_file",
+            name="remove_file",
             description="Removes a file from MikroTik device",
             inputSchema={
                 "type": "object",
@@ -129,7 +129,7 @@ def get_backup_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_backup_info",
+            name="backup_info",
             description="Gets detailed information about a backup file",
             inputSchema={
                 "type": "object",
@@ -144,17 +144,17 @@ def get_backup_tools() -> List[Tool]:
 def get_backup_handlers() -> Dict[str, Callable]:
     """Return the handlers for backup and export tools."""
     return {
-        "mikrotik_create_backup": lambda args: mikrotik_create_backup(
+        "create_backup": lambda args: mikrotik_create_backup(
             args.get("name"),
             args.get("dont_encrypt", False),
             args.get("include_password", True),
             args.get("comment")
         ),
-        "mikrotik_list_backups": lambda args: mikrotik_list_backups(
+        "list_backups": lambda args: mikrotik_list_backups(
             args.get("name_filter"),
             args.get("include_exports", False)
         ),
-        "mikrotik_create_export": lambda args: mikrotik_create_export(
+        "create_export": lambda args: mikrotik_create_export(
             args.get("name"),
             args.get("file_format", "rsc"),
             args.get("export_type", "full"),
@@ -163,33 +163,33 @@ def get_backup_handlers() -> Dict[str, Callable]:
             args.get("compact", False),
             args.get("comment")
         ),
-        "mikrotik_export_section": lambda args: mikrotik_export_section(
+        "export_section": lambda args: mikrotik_export_section(
             args["section"],
             args.get("name"),
             args.get("hide_sensitive", True),
             args.get("compact", False)
         ),
-        "mikrotik_download_file": lambda args: mikrotik_download_file(
+        "download_file": lambda args: mikrotik_download_file(
             args["filename"],
             args.get("file_type", "backup")
         ),
-        "mikrotik_upload_file": lambda args: mikrotik_upload_file(
+        "upload_file": lambda args: mikrotik_upload_file(
             args["filename"],
             args["content_base64"]
         ),
-        "mikrotik_restore_backup": lambda args: mikrotik_restore_backup(
+        "restore_backup": lambda args: mikrotik_restore_backup(
             args["filename"],
             args.get("password")
         ),
-        "mikrotik_import_configuration": lambda args: mikrotik_import_configuration(
+        "import_configuration": lambda args: mikrotik_import_configuration(
             args["filename"],
             args.get("run_after_reset", False),
             args.get("verbose", False)
         ),
-        "mikrotik_remove_file": lambda args: mikrotik_remove_file(
+        "remove_file": lambda args: mikrotik_remove_file(
             args["filename"]
         ),
-        "mikrotik_backup_info": lambda args: mikrotik_backup_info(
+        "backup_info": lambda args: mikrotik_backup_info(
             args["filename"]
         ),
     }

--- a/src/mcp_mikrotik/tools/dhcp_tools.py
+++ b/src/mcp_mikrotik/tools/dhcp_tools.py
@@ -11,7 +11,7 @@ def get_dhcp_tools() -> List[Tool]:
     return [
         # DHCP Server tools
         Tool(
-            name="mikrotik_create_dhcp_server",
+            name="create_dhcp_server",
             description="Creates a DHCP server on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -29,7 +29,7 @@ def get_dhcp_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_list_dhcp_servers",
+            name="list_dhcp_servers",
             description="Lists DHCP servers on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -43,7 +43,7 @@ def get_dhcp_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_dhcp_server",
+            name="get_dhcp_server",
             description="Gets detailed information about a specific DHCP server",
             inputSchema={
                 "type": "object",
@@ -54,7 +54,7 @@ def get_dhcp_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_create_dhcp_network",
+            name="create_dhcp_network",
             description="Creates a DHCP network configuration",
             inputSchema={
                 "type": "object",
@@ -73,7 +73,7 @@ def get_dhcp_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_create_dhcp_pool",
+            name="create_dhcp_pool",
             description="Creates a DHCP address pool",
             inputSchema={
                 "type": "object",
@@ -87,7 +87,7 @@ def get_dhcp_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_remove_dhcp_server",
+            name="remove_dhcp_server",
             description="Removes a DHCP server from MikroTik device",
             inputSchema={
                 "type": "object",
@@ -102,7 +102,7 @@ def get_dhcp_tools() -> List[Tool]:
 def get_dhcp_handlers() -> Dict[str, Callable]:
     """Return the handlers for DHCP server tools."""
     return {
-        "mikrotik_create_dhcp_server": lambda args: mikrotik_create_dhcp_server(
+        "create_dhcp_server": lambda args: mikrotik_create_dhcp_server(
             args["name"],
             args["interface"],
             args.get("lease_time", "1d"),
@@ -112,16 +112,16 @@ def get_dhcp_handlers() -> Dict[str, Callable]:
             args.get("delay_threshold"),
             args.get("comment")
         ),
-        "mikrotik_list_dhcp_servers": lambda args: mikrotik_list_dhcp_servers(
+        "list_dhcp_servers": lambda args: mikrotik_list_dhcp_servers(
             args.get("name_filter"),
             args.get("interface_filter"),
             args.get("disabled_only", False),
             args.get("invalid_only", False)
         ),
-        "mikrotik_get_dhcp_server": lambda args: mikrotik_get_dhcp_server(
+        "get_dhcp_server": lambda args: mikrotik_get_dhcp_server(
             args["name"]
         ),
-        "mikrotik_create_dhcp_network": lambda args: mikrotik_create_dhcp_network(
+        "create_dhcp_network": lambda args: mikrotik_create_dhcp_network(
             args["network"],
             args["gateway"],
             args.get("netmask"),
@@ -132,13 +132,13 @@ def get_dhcp_handlers() -> Dict[str, Callable]:
             args.get("dhcp_option"),
             args.get("comment")
         ),
-        "mikrotik_create_dhcp_pool": lambda args: mikrotik_create_dhcp_pool(
+        "create_dhcp_pool": lambda args: mikrotik_create_dhcp_pool(
             args["name"],
             args["ranges"],
             args.get("next_pool"),
             args.get("comment")
         ),
-        "mikrotik_remove_dhcp_server": lambda args: mikrotik_remove_dhcp_server(
+        "remove_dhcp_server": lambda args: mikrotik_remove_dhcp_server(
             args["name"]
         ),
     }

--- a/src/mcp_mikrotik/tools/dns_tools.py
+++ b/src/mcp_mikrotik/tools/dns_tools.py
@@ -16,7 +16,7 @@ def get_dns_tools() -> List[Tool]:
     return [
         # DNS tools
         Tool(
-            name="mikrotik_set_dns_servers",
+            name="set_dns_servers",
             description="Sets DNS server configuration on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -35,7 +35,7 @@ def get_dns_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_dns_settings",
+            name="get_dns_settings",
             description="Gets current DNS configuration",
             inputSchema={
                 "type": "object",
@@ -44,7 +44,7 @@ def get_dns_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_add_dns_static",
+            name="add_dns_static",
             description="Adds a static DNS entry",
             inputSchema={
                 "type": "object",
@@ -68,7 +68,7 @@ def get_dns_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_list_dns_static",
+            name="list_dns_static",
             description="Lists static DNS entries",
             inputSchema={
                 "type": "object",
@@ -83,7 +83,7 @@ def get_dns_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_dns_static",
+            name="get_dns_static",
             description="Gets details of a specific static DNS entry",
             inputSchema={
                 "type": "object",
@@ -94,7 +94,7 @@ def get_dns_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_update_dns_static",
+            name="update_dns_static",
             description="Updates an existing static DNS entry",
             inputSchema={
                 "type": "object",
@@ -119,7 +119,7 @@ def get_dns_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_remove_dns_static",
+            name="remove_dns_static",
             description="Removes a static DNS entry",
             inputSchema={
                 "type": "object",
@@ -130,7 +130,7 @@ def get_dns_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_enable_dns_static",
+            name="enable_dns_static",
             description="Enables a static DNS entry",
             inputSchema={
                 "type": "object",
@@ -141,7 +141,7 @@ def get_dns_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_disable_dns_static",
+            name="disable_dns_static",
             description="Disables a static DNS entry",
             inputSchema={
                 "type": "object",
@@ -152,7 +152,7 @@ def get_dns_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_dns_cache",
+            name="get_dns_cache",
             description="Gets the current DNS cache",
             inputSchema={
                 "type": "object",
@@ -161,7 +161,7 @@ def get_dns_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_flush_dns_cache",
+            name="flush_dns_cache",
             description="Flushes the DNS cache",
             inputSchema={
                 "type": "object",
@@ -170,7 +170,7 @@ def get_dns_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_dns_cache_statistics",
+            name="get_dns_cache_statistics",
             description="Gets DNS cache statistics",
             inputSchema={
                 "type": "object",
@@ -179,7 +179,7 @@ def get_dns_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_add_dns_regexp",
+            name="add_dns_regexp",
             description="Adds a DNS regexp entry for pattern matching",
             inputSchema={
                 "type": "object",
@@ -194,7 +194,7 @@ def get_dns_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_test_dns_query",
+            name="test_dns_query",
             description="Tests a DNS query",
             inputSchema={
                 "type": "object",
@@ -207,7 +207,7 @@ def get_dns_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_export_dns_config",
+            name="export_dns_config",
             description="Exports DNS configuration to a file",
             inputSchema={
                 "type": "object",
@@ -222,7 +222,7 @@ def get_dns_tools() -> List[Tool]:
 def get_dns_handlers() -> Dict[str, Callable]:
     """Return the handlers for DNS tools."""
     return {
-        "mikrotik_set_dns_servers": lambda args: mikrotik_set_dns_servers(
+        "set_dns_servers": lambda args: mikrotik_set_dns_servers(
             args["servers"],
             args.get("allow_remote_requests", False),
             args.get("max_udp_packet_size"),
@@ -233,8 +233,8 @@ def get_dns_handlers() -> Dict[str, Callable]:
             args.get("doh_server"),
             args.get("verify_doh_cert", True)
         ),
-        "mikrotik_get_dns_settings": lambda args: mikrotik_get_dns_settings(),
-        "mikrotik_add_dns_static": lambda args: mikrotik_add_dns_static(
+        "get_dns_settings": lambda args: mikrotik_get_dns_settings(),
+        "add_dns_static": lambda args: mikrotik_add_dns_static(
             args["name"],
             args.get("address"),
             args.get("cname"),
@@ -250,17 +250,17 @@ def get_dns_handlers() -> Dict[str, Callable]:
             args.get("disabled", False),
             args.get("regexp")
         ),
-        "mikrotik_list_dns_static": lambda args: mikrotik_list_dns_static(
+        "list_dns_static": lambda args: mikrotik_list_dns_static(
             args.get("name_filter"),
             args.get("address_filter"),
             args.get("type_filter"),
             args.get("disabled_only", False),
             args.get("regexp_only", False)
         ),
-        "mikrotik_get_dns_static": lambda args: mikrotik_get_dns_static(
+        "get_dns_static": lambda args: mikrotik_get_dns_static(
             args["entry_id"]
         ),
-        "mikrotik_update_dns_static": lambda args: mikrotik_update_dns_static(
+        "update_dns_static": lambda args: mikrotik_update_dns_static(
             args["entry_id"],
             args.get("name"),
             args.get("address"),
@@ -277,31 +277,31 @@ def get_dns_handlers() -> Dict[str, Callable]:
             args.get("disabled"),
             args.get("regexp")
         ),
-        "mikrotik_remove_dns_static": lambda args: mikrotik_remove_dns_static(
+        "remove_dns_static": lambda args: mikrotik_remove_dns_static(
             args["entry_id"]
         ),
-        "mikrotik_enable_dns_static": lambda args: mikrotik_enable_dns_static(
+        "enable_dns_static": lambda args: mikrotik_enable_dns_static(
             args["entry_id"]
         ),
-        "mikrotik_disable_dns_static": lambda args: mikrotik_disable_dns_static(
+        "disable_dns_static": lambda args: mikrotik_disable_dns_static(
             args["entry_id"]
         ),
-        "mikrotik_get_dns_cache": lambda args: mikrotik_get_dns_cache(),
-        "mikrotik_flush_dns_cache": lambda args: mikrotik_flush_dns_cache(),
-        "mikrotik_get_dns_cache_statistics": lambda args: mikrotik_get_dns_cache_statistics(),
-        "mikrotik_add_dns_regexp": lambda args: mikrotik_add_dns_regexp(
+        "get_dns_cache": lambda args: mikrotik_get_dns_cache(),
+        "flush_dns_cache": lambda args: mikrotik_flush_dns_cache(),
+        "get_dns_cache_statistics": lambda args: mikrotik_get_dns_cache_statistics(),
+        "add_dns_regexp": lambda args: mikrotik_add_dns_regexp(
             args["regexp"],
             args["address"],
             args.get("ttl", "1d"),
             args.get("comment"),
             args.get("disabled", False)
         ),
-        "mikrotik_test_dns_query": lambda args: mikrotik_test_dns_query(
+        "test_dns_query": lambda args: mikrotik_test_dns_query(
             args["name"],
             args.get("server"),
             args.get("type", "A")
         ),
-        "mikrotik_export_dns_config": lambda args: mikrotik_export_dns_config(
+        "export_dns_config": lambda args: mikrotik_export_dns_config(
             args.get("filename")
         ),
     }

--- a/src/mcp_mikrotik/tools/firewall_tools.py
+++ b/src/mcp_mikrotik/tools/firewall_tools.py
@@ -19,7 +19,7 @@ def get_firewall_filter_tools() -> List[Tool]:
     return [
         # Firewall Filter tools
         Tool(
-            name="mikrotik_create_filter_rule",
+            name="create_filter_rule",
             description="Creates a firewall filter rule on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -49,7 +49,7 @@ def get_firewall_filter_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_list_filter_rules",
+            name="list_filter_rules",
             description="Lists firewall filter rules on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -68,7 +68,7 @@ def get_firewall_filter_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_filter_rule",
+            name="get_filter_rule",
             description="Gets detailed information about a specific firewall filter rule",
             inputSchema={
                 "type": "object",
@@ -79,7 +79,7 @@ def get_firewall_filter_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_update_filter_rule",
+            name="update_filter_rule",
             description="Updates an existing firewall filter rule on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -109,7 +109,7 @@ def get_firewall_filter_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_remove_filter_rule",
+            name="remove_filter_rule",
             description="Removes a firewall filter rule from MikroTik device",
             inputSchema={
                 "type": "object",
@@ -120,7 +120,7 @@ def get_firewall_filter_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_move_filter_rule",
+            name="move_filter_rule",
             description="Moves a firewall filter rule to a different position",
             inputSchema={
                 "type": "object",
@@ -132,7 +132,7 @@ def get_firewall_filter_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_enable_filter_rule",
+            name="enable_filter_rule",
             description="Enables a firewall filter rule",
             inputSchema={
                 "type": "object",
@@ -143,7 +143,7 @@ def get_firewall_filter_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_disable_filter_rule",
+            name="disable_filter_rule",
             description="Disables a firewall filter rule",
             inputSchema={
                 "type": "object",
@@ -154,7 +154,7 @@ def get_firewall_filter_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_create_basic_firewall_setup",
+            name="create_basic_firewall_setup",
             description="Creates a basic firewall setup with common security rules",
             inputSchema={
                 "type": "object",
@@ -169,7 +169,7 @@ def get_firewall_nat_tools() -> List[Tool]:
     return [
         # NAT tools
         Tool(
-            name="mikrotik_create_nat_rule",
+            name="create_nat_rule",
             description="Creates a NAT rule on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -195,7 +195,7 @@ def get_firewall_nat_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_list_nat_rules",
+            name="list_nat_rules",
             description="Lists NAT rules on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -213,7 +213,7 @@ def get_firewall_nat_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_nat_rule",
+            name="get_nat_rule",
             description="Gets detailed information about a specific NAT rule",
             inputSchema={
                 "type": "object",
@@ -224,7 +224,7 @@ def get_firewall_nat_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_update_nat_rule",
+            name="update_nat_rule",
             description="Updates an existing NAT rule on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -250,7 +250,7 @@ def get_firewall_nat_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_remove_nat_rule",
+            name="remove_nat_rule",
             description="Removes a NAT rule from MikroTik device",
             inputSchema={
                 "type": "object",
@@ -261,7 +261,7 @@ def get_firewall_nat_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_move_nat_rule",
+            name="move_nat_rule",
             description="Moves a NAT rule to a different position in the chain",
             inputSchema={
                 "type": "object",
@@ -273,7 +273,7 @@ def get_firewall_nat_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_enable_nat_rule",
+            name="enable_nat_rule",
             description="Enables a NAT rule",
             inputSchema={
                 "type": "object",
@@ -284,7 +284,7 @@ def get_firewall_nat_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_disable_nat_rule",
+            name="disable_nat_rule",
             description="Disables a NAT rule",
             inputSchema={
                 "type": "object",
@@ -299,7 +299,7 @@ def get_firewall_nat_tools() -> List[Tool]:
 def get_firewall_filter_handlers() -> Dict[str, Callable]:
     """Return the handlers for firewall filter tools."""
     return {
-        "mikrotik_create_filter_rule": lambda args: mikrotik_create_filter_rule(
+        "create_filter_rule": lambda args: mikrotik_create_filter_rule(
             args["chain"],
             args["action"],
             args.get("src_address"),
@@ -321,7 +321,7 @@ def get_firewall_filter_handlers() -> Dict[str, Callable]:
             args.get("log_prefix"),
             args.get("place_before")
         ),
-        "mikrotik_list_filter_rules": lambda args: mikrotik_list_filter_rules(
+        "list_filter_rules": lambda args: mikrotik_list_filter_rules(
             args.get("chain_filter"),
             args.get("action_filter"),
             args.get("src_address_filter"),
@@ -332,10 +332,10 @@ def get_firewall_filter_handlers() -> Dict[str, Callable]:
             args.get("invalid_only", False),
             args.get("dynamic_only", False)
         ),
-        "mikrotik_get_filter_rule": lambda args: mikrotik_get_filter_rule(
+        "get_filter_rule": lambda args: mikrotik_get_filter_rule(
             args["rule_id"]
         ),
-        "mikrotik_update_filter_rule": lambda args: mikrotik_update_filter_rule(
+        "update_filter_rule": lambda args: mikrotik_update_filter_rule(
             args["rule_id"],
             args.get("chain"),
             args.get("action"),
@@ -357,26 +357,26 @@ def get_firewall_filter_handlers() -> Dict[str, Callable]:
             args.get("log"),
             args.get("log_prefix")
         ),
-        "mikrotik_remove_filter_rule": lambda args: mikrotik_remove_filter_rule(
+        "remove_filter_rule": lambda args: mikrotik_remove_filter_rule(
             args["rule_id"]
         ),
-        "mikrotik_move_filter_rule": lambda args: mikrotik_move_filter_rule(
+        "move_filter_rule": lambda args: mikrotik_move_filter_rule(
             args["rule_id"],
             args["destination"]
         ),
-        "mikrotik_enable_filter_rule": lambda args: mikrotik_enable_filter_rule(
+        "enable_filter_rule": lambda args: mikrotik_enable_filter_rule(
             args["rule_id"]
         ),
-        "mikrotik_disable_filter_rule": lambda args: mikrotik_disable_filter_rule(
+        "disable_filter_rule": lambda args: mikrotik_disable_filter_rule(
             args["rule_id"]
         ),
-        "mikrotik_create_basic_firewall_setup": lambda args: mikrotik_create_basic_firewall_setup(),
+        "create_basic_firewall_setup": lambda args: mikrotik_create_basic_firewall_setup(),
     }
 
 def get_firewall_nat_handlers() -> Dict[str, Callable]:
     """Return the handlers for firewall NAT tools."""
     return {
-        "mikrotik_create_nat_rule": lambda args: mikrotik_create_nat_rule(
+        "create_nat_rule": lambda args: mikrotik_create_nat_rule(
             args["chain"],
             args["action"],
             args.get("src_address"),
@@ -394,7 +394,7 @@ def get_firewall_nat_handlers() -> Dict[str, Callable]:
             args.get("log_prefix"),
             args.get("place_before")
         ),
-        "mikrotik_list_nat_rules": lambda args: mikrotik_list_nat_rules(
+        "list_nat_rules": lambda args: mikrotik_list_nat_rules(
             args.get("chain_filter"),
             args.get("action_filter"),
             args.get("src_address_filter"),
@@ -404,10 +404,10 @@ def get_firewall_nat_handlers() -> Dict[str, Callable]:
             args.get("disabled_only", False),
             args.get("invalid_only", False)
         ),
-        "mikrotik_get_nat_rule": lambda args: mikrotik_get_nat_rule(
+        "get_nat_rule": lambda args: mikrotik_get_nat_rule(
             args["rule_id"]
         ),
-        "mikrotik_update_nat_rule": lambda args: mikrotik_update_nat_rule(
+        "update_nat_rule": lambda args: mikrotik_update_nat_rule(
             args["rule_id"],
             args.get("chain"),
             args.get("action"),
@@ -425,17 +425,17 @@ def get_firewall_nat_handlers() -> Dict[str, Callable]:
             args.get("log"),
             args.get("log_prefix")
         ),
-        "mikrotik_remove_nat_rule": lambda args: mikrotik_remove_nat_rule(
+        "remove_nat_rule": lambda args: mikrotik_remove_nat_rule(
             args["rule_id"]
         ),
-        "mikrotik_move_nat_rule": lambda args: mikrotik_move_nat_rule(
+        "move_nat_rule": lambda args: mikrotik_move_nat_rule(
             args["rule_id"],
             args["destination"]
         ),
-        "mikrotik_enable_nat_rule": lambda args: mikrotik_enable_nat_rule(
+        "enable_nat_rule": lambda args: mikrotik_enable_nat_rule(
             args["rule_id"]
         ),
-        "mikrotik_disable_nat_rule": lambda args: mikrotik_disable_nat_rule(
+        "disable_nat_rule": lambda args: mikrotik_disable_nat_rule(
             args["rule_id"]
         ),
     }

--- a/src/mcp_mikrotik/tools/ip_tools.py
+++ b/src/mcp_mikrotik/tools/ip_tools.py
@@ -15,7 +15,7 @@ def get_ip_address_tools() -> List[Tool]:
     return [
         # IP Address tools
         Tool(
-            name="mikrotik_add_ip_address",
+            name="add_ip_address",
             description="Adds an IP address to an interface",
             inputSchema={
                 "type": "object",
@@ -31,7 +31,7 @@ def get_ip_address_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_list_ip_addresses",
+            name="list_ip_addresses",
             description="Lists IP addresses on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -46,7 +46,7 @@ def get_ip_address_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_ip_address",
+            name="get_ip_address",
             description="Gets detailed information about a specific IP address",
             inputSchema={
                 "type": "object",
@@ -57,7 +57,7 @@ def get_ip_address_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_remove_ip_address",
+            name="remove_ip_address",
             description="Removes an IP address from MikroTik device",
             inputSchema={
                 "type": "object",
@@ -74,7 +74,7 @@ def get_ip_pool_tools() -> List[Tool]:
     return [
         # IP Pool tools
         Tool(
-            name="mikrotik_create_ip_pool",
+            name="create_ip_pool",
             description="Creates an IP pool on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -88,7 +88,7 @@ def get_ip_pool_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_list_ip_pools",
+            name="list_ip_pools",
             description="Lists IP pools on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -101,7 +101,7 @@ def get_ip_pool_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_ip_pool",
+            name="get_ip_pool",
             description="Gets detailed information about a specific IP pool",
             inputSchema={
                 "type": "object",
@@ -112,7 +112,7 @@ def get_ip_pool_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_update_ip_pool",
+            name="update_ip_pool",
             description="Updates an existing IP pool on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -127,7 +127,7 @@ def get_ip_pool_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_remove_ip_pool",
+            name="remove_ip_pool",
             description="Removes an IP pool from MikroTik device",
             inputSchema={
                 "type": "object",
@@ -138,7 +138,7 @@ def get_ip_pool_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_list_ip_pool_used",
+            name="list_ip_pool_used",
             description="Lists used addresses from IP pools",
             inputSchema={
                 "type": "object",
@@ -152,7 +152,7 @@ def get_ip_pool_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_expand_ip_pool",
+            name="expand_ip_pool",
             description="Expands an existing IP pool by adding more ranges",
             inputSchema={
                 "type": "object",
@@ -168,7 +168,7 @@ def get_ip_pool_tools() -> List[Tool]:
 def get_ip_address_handlers() -> Dict[str, Callable]:
     """Return the handlers for IP address tools."""
     return {
-        "mikrotik_add_ip_address": lambda args: mikrotik_add_ip_address(
+        "add_ip_address": lambda args: mikrotik_add_ip_address(
             args["address"],
             args["interface"],
             args.get("network"),
@@ -176,17 +176,17 @@ def get_ip_address_handlers() -> Dict[str, Callable]:
             args.get("comment"),
             args.get("disabled", False)
         ),
-        "mikrotik_list_ip_addresses": lambda args: mikrotik_list_ip_addresses(
+        "list_ip_addresses": lambda args: mikrotik_list_ip_addresses(
             args.get("interface_filter"),
             args.get("address_filter"),
             args.get("network_filter"),
             args.get("disabled_only", False),
             args.get("dynamic_only", False)
         ),
-        "mikrotik_get_ip_address": lambda args: mikrotik_get_ip_address(
+        "get_ip_address": lambda args: mikrotik_get_ip_address(
             args["address_id"]
         ),
-        "mikrotik_remove_ip_address": lambda args: mikrotik_remove_ip_address(
+        "remove_ip_address": lambda args: mikrotik_remove_ip_address(
             args["address_id"]
         ),
     }
@@ -194,37 +194,37 @@ def get_ip_address_handlers() -> Dict[str, Callable]:
 def get_ip_pool_handlers() -> Dict[str, Callable]:
     """Return the handlers for IP pool tools."""
     return {
-        "mikrotik_create_ip_pool": lambda args: mikrotik_create_ip_pool(
+        "create_ip_pool": lambda args: mikrotik_create_ip_pool(
             args["name"],
             args["ranges"],
             args.get("next_pool"),
             args.get("comment")
         ),
-        "mikrotik_list_ip_pools": lambda args: mikrotik_list_ip_pools(
+        "list_ip_pools": lambda args: mikrotik_list_ip_pools(
             args.get("name_filter"),
             args.get("ranges_filter"),
             args.get("include_used", False)
         ),
-        "mikrotik_get_ip_pool": lambda args: mikrotik_get_ip_pool(
+        "get_ip_pool": lambda args: mikrotik_get_ip_pool(
             args["name"]
         ),
-        "mikrotik_update_ip_pool": lambda args: mikrotik_update_ip_pool(
+        "update_ip_pool": lambda args: mikrotik_update_ip_pool(
             args["name"],
             args.get("new_name"),
             args.get("ranges"),
             args.get("next_pool"),
             args.get("comment")
         ),
-        "mikrotik_remove_ip_pool": lambda args: mikrotik_remove_ip_pool(
+        "remove_ip_pool": lambda args: mikrotik_remove_ip_pool(
             args["name"]
         ),
-        "mikrotik_list_ip_pool_used": lambda args: mikrotik_list_ip_pool_used(
+        "list_ip_pool_used": lambda args: mikrotik_list_ip_pool_used(
             args.get("pool_name"),
             args.get("address_filter"),
             args.get("mac_filter"),
             args.get("info_filter")
         ),
-        "mikrotik_expand_ip_pool": lambda args: mikrotik_expand_ip_pool(
+        "expand_ip_pool": lambda args: mikrotik_expand_ip_pool(
             args["name"],
             args["additional_ranges"]
         ),

--- a/src/mcp_mikrotik/tools/log_tools.py
+++ b/src/mcp_mikrotik/tools/log_tools.py
@@ -12,7 +12,7 @@ def get_log_tools() -> List[Tool]:
     return [
         # Log tools
         Tool(
-            name="mikrotik_get_logs",
+            name="get_logs",
             description="Gets logs from MikroTik device with filtering options",
             inputSchema={
                 "type": "object",
@@ -30,7 +30,7 @@ def get_log_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_logs_by_severity",
+            name="get_logs_by_severity",
             description="Gets logs filtered by severity level",
             inputSchema={
                 "type": "object",
@@ -43,7 +43,7 @@ def get_log_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_logs_by_topic",
+            name="get_logs_by_topic",
             description="Gets logs for a specific topic/facility",
             inputSchema={
                 "type": "object",
@@ -56,7 +56,7 @@ def get_log_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_search_logs",
+            name="search_logs",
             description="Searches logs for a specific term",
             inputSchema={
                 "type": "object",
@@ -70,7 +70,7 @@ def get_log_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_system_events",
+            name="get_system_events",
             description="Gets system-related log events",
             inputSchema={
                 "type": "object",
@@ -83,7 +83,7 @@ def get_log_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_security_logs",
+            name="get_security_logs",
             description="Gets security-related log entries",
             inputSchema={
                 "type": "object",
@@ -95,7 +95,7 @@ def get_log_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_clear_logs",
+            name="clear_logs",
             description="Clears all logs from MikroTik device",
             inputSchema={
                 "type": "object",
@@ -104,7 +104,7 @@ def get_log_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_log_statistics",
+            name="get_log_statistics",
             description="Gets statistics about log entries",
             inputSchema={
                 "type": "object",
@@ -113,7 +113,7 @@ def get_log_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_export_logs",
+            name="export_logs",
             description="Exports logs to a file on the MikroTik device",
             inputSchema={
                 "type": "object",
@@ -127,7 +127,7 @@ def get_log_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_monitor_logs",
+            name="monitor_logs",
             description="Monitors logs in real-time for a specified duration",
             inputSchema={
                 "type": "object",
@@ -144,7 +144,7 @@ def get_log_tools() -> List[Tool]:
 def get_log_handlers() -> Dict[str, Callable]:
     """Return the handlers for log tools."""
     return {
-        "mikrotik_get_logs": lambda args: mikrotik_get_logs(
+        "get_logs": lambda args: mikrotik_get_logs(
             args.get("topics"),
             args.get("action"),
             args.get("time_filter"),
@@ -154,40 +154,40 @@ def get_log_handlers() -> Dict[str, Callable]:
             args.get("follow", False),
             args.get("print_as", "value")
         ),
-        "mikrotik_get_logs_by_severity": lambda args: mikrotik_get_logs_by_severity(
+        "get_logs_by_severity": lambda args: mikrotik_get_logs_by_severity(
             args["severity"],
             args.get("time_filter"),
             args.get("limit")
         ),
-        "mikrotik_get_logs_by_topic": lambda args: mikrotik_get_logs_by_topic(
+        "get_logs_by_topic": lambda args: mikrotik_get_logs_by_topic(
             args["topic"],
             args.get("time_filter"),
             args.get("limit")
         ),
-        "mikrotik_search_logs": lambda args: mikrotik_search_logs(
+        "search_logs": lambda args: mikrotik_search_logs(
             args["search_term"],
             args.get("time_filter"),
             args.get("case_sensitive", False),
             args.get("limit")
         ),
-        "mikrotik_get_system_events": lambda args: mikrotik_get_system_events(
+        "get_system_events": lambda args: mikrotik_get_system_events(
             args.get("event_type"),
             args.get("time_filter"),
             args.get("limit")
         ),
-        "mikrotik_get_security_logs": lambda args: mikrotik_get_security_logs(
+        "get_security_logs": lambda args: mikrotik_get_security_logs(
             args.get("time_filter"),
             args.get("limit")
         ),
-        "mikrotik_clear_logs": lambda args: mikrotik_clear_logs(),
-        "mikrotik_get_log_statistics": lambda args: mikrotik_get_log_statistics(),
-        "mikrotik_export_logs": lambda args: mikrotik_export_logs(
+        "clear_logs": lambda args: mikrotik_clear_logs(),
+        "get_log_statistics": lambda args: mikrotik_get_log_statistics(),
+        "export_logs": lambda args: mikrotik_export_logs(
             args.get("filename"),
             args.get("topics"),
             args.get("time_filter"),
             args.get("format", "plain")
         ),
-        "mikrotik_monitor_logs": lambda args: mikrotik_monitor_logs(
+        "monitor_logs": lambda args: mikrotik_monitor_logs(
             args.get("topics"),
             args.get("action"),
             args.get("duration", 10)

--- a/src/mcp_mikrotik/tools/route_tools.py
+++ b/src/mcp_mikrotik/tools/route_tools.py
@@ -13,7 +13,7 @@ def get_route_tools() -> List[Tool]:
     return [
         # Route tools
         Tool(
-            name="mikrotik_add_route",
+            name="add_route",
             description="Adds a route to MikroTik routing table",
             inputSchema={
                 "type": "object",
@@ -34,7 +34,7 @@ def get_route_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_list_routes",
+            name="list_routes",
             description="Lists routes in MikroTik routing table",
             inputSchema={
                 "type": "object",
@@ -52,7 +52,7 @@ def get_route_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_route",
+            name="get_route",
             description="Gets detailed information about a specific route",
             inputSchema={
                 "type": "object",
@@ -63,7 +63,7 @@ def get_route_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_update_route",
+            name="update_route",
             description="Updates an existing route in MikroTik routing table",
             inputSchema={
                 "type": "object",
@@ -85,7 +85,7 @@ def get_route_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_remove_route",
+            name="remove_route",
             description="Removes a route from MikroTik routing table",
             inputSchema={
                 "type": "object",
@@ -96,7 +96,7 @@ def get_route_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_enable_route",
+            name="enable_route",
             description="Enables a route",
             inputSchema={
                 "type": "object",
@@ -107,7 +107,7 @@ def get_route_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_disable_route",
+            name="disable_route",
             description="Disables a route",
             inputSchema={
                 "type": "object",
@@ -118,7 +118,7 @@ def get_route_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_routing_table",
+            name="get_routing_table",
             description="Gets a specific routing table",
             inputSchema={
                 "type": "object",
@@ -131,7 +131,7 @@ def get_route_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_check_route_path",
+            name="check_route_path",
             description="Checks the route path to a destination",
             inputSchema={
                 "type": "object",
@@ -144,7 +144,7 @@ def get_route_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_route_cache",
+            name="get_route_cache",
             description="Gets the route cache",
             inputSchema={
                 "type": "object",
@@ -153,7 +153,7 @@ def get_route_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_flush_route_cache",
+            name="flush_route_cache",
             description="Flushes the route cache",
             inputSchema={
                 "type": "object",
@@ -162,7 +162,7 @@ def get_route_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_add_default_route",
+            name="add_default_route",
             description="Adds a default route (0.0.0.0/0)",
             inputSchema={
                 "type": "object",
@@ -176,7 +176,7 @@ def get_route_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_add_blackhole_route",
+            name="add_blackhole_route",
             description="Adds a blackhole route",
             inputSchema={
                 "type": "object",
@@ -189,7 +189,7 @@ def get_route_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_route_statistics",
+            name="get_route_statistics",
             description="Gets routing table statistics",
             inputSchema={
                 "type": "object",
@@ -202,7 +202,7 @@ def get_route_tools() -> List[Tool]:
 def get_route_handlers() -> Dict[str, Callable]:
     """Return the handlers for route tools."""
     return {
-        "mikrotik_add_route": lambda args: mikrotik_add_route(
+        "add_route": lambda args: mikrotik_add_route(
             args["dst_address"],
             args["gateway"],
             args.get("distance"),
@@ -215,7 +215,7 @@ def get_route_handlers() -> Dict[str, Callable]:
             args.get("pref_src"),
             args.get("check_gateway")
         ),
-        "mikrotik_list_routes": lambda args: mikrotik_list_routes(
+        "list_routes": lambda args: mikrotik_list_routes(
             args.get("dst_filter"),
             args.get("gateway_filter"),
             args.get("routing_mark_filter"),
@@ -225,10 +225,10 @@ def get_route_handlers() -> Dict[str, Callable]:
             args.get("dynamic_only", False),
             args.get("static_only", False)
         ),
-        "mikrotik_get_route": lambda args: mikrotik_get_route(
+        "get_route": lambda args: mikrotik_get_route(
             args["route_id"]
         ),
-        "mikrotik_update_route": lambda args: mikrotik_update_route(
+        "update_route": lambda args: mikrotik_update_route(
             args["route_id"],
             args.get("dst_address"),
             args.get("gateway"),
@@ -242,37 +242,37 @@ def get_route_handlers() -> Dict[str, Callable]:
             args.get("pref_src"),
             args.get("check_gateway")
         ),
-        "mikrotik_remove_route": lambda args: mikrotik_remove_route(
+        "remove_route": lambda args: mikrotik_remove_route(
             args["route_id"]
         ),
-        "mikrotik_enable_route": lambda args: mikrotik_enable_route(
+        "enable_route": lambda args: mikrotik_enable_route(
             args["route_id"]
         ),
-        "mikrotik_disable_route": lambda args: mikrotik_disable_route(
+        "disable_route": lambda args: mikrotik_disable_route(
             args["route_id"]
         ),
-        "mikrotik_get_routing_table": lambda args: mikrotik_get_routing_table(
+        "get_routing_table": lambda args: mikrotik_get_routing_table(
             args.get("table_name", "main"),
             args.get("protocol_filter"),
             args.get("active_only", True)
         ),
-        "mikrotik_check_route_path": lambda args: mikrotik_check_route_path(
+        "check_route_path": lambda args: mikrotik_check_route_path(
             args["destination"],
             args.get("source"),
             args.get("routing_mark")
         ),
-        "mikrotik_get_route_cache": lambda args: mikrotik_get_route_cache(),
-        "mikrotik_flush_route_cache": lambda args: mikrotik_flush_route_cache(),
-        "mikrotik_add_default_route": lambda args: mikrotik_add_default_route(
+        "get_route_cache": lambda args: mikrotik_get_route_cache(),
+        "flush_route_cache": lambda args: mikrotik_flush_route_cache(),
+        "add_default_route": lambda args: mikrotik_add_default_route(
             args["gateway"],
             args.get("distance", 1),
             args.get("comment"),
             args.get("check_gateway", "ping")
         ),
-        "mikrotik_add_blackhole_route": lambda args: mikrotik_add_blackhole_route(
+        "add_blackhole_route": lambda args: mikrotik_add_blackhole_route(
             args["dst_address"],
             args.get("distance", 1),
             args.get("comment")
         ),
-        "mikrotik_get_route_statistics": lambda args: mikrotik_get_route_statistics(),
+        "get_route_statistics": lambda args: mikrotik_get_route_statistics(),
     }

--- a/src/mcp_mikrotik/tools/user_tools.py
+++ b/src/mcp_mikrotik/tools/user_tools.py
@@ -14,7 +14,7 @@ def get_user_tools() -> List[Tool]:
     return [
         # User Management tools
         Tool(
-            name="mikrotik_add_user",
+            name="add_user",
             description="Adds a new user to MikroTik device",
             inputSchema={
                 "type": "object",
@@ -30,7 +30,7 @@ def get_user_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_list_users",
+            name="list_users",
             description="Lists users on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -44,7 +44,7 @@ def get_user_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_user",
+            name="get_user",
             description="Gets detailed information about a specific user",
             inputSchema={
                 "type": "object",
@@ -55,7 +55,7 @@ def get_user_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_update_user",
+            name="update_user",
             description="Updates an existing user on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -72,7 +72,7 @@ def get_user_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_remove_user",
+            name="remove_user",
             description="Removes a user from MikroTik device",
             inputSchema={
                 "type": "object",
@@ -83,7 +83,7 @@ def get_user_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_disable_user",
+            name="disable_user",
             description="Disables a user account",
             inputSchema={
                 "type": "object",
@@ -94,7 +94,7 @@ def get_user_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_enable_user",
+            name="enable_user",
             description="Enables a user account",
             inputSchema={
                 "type": "object",
@@ -105,7 +105,7 @@ def get_user_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_add_user_group",
+            name="add_user_group",
             description="Adds a new user group to MikroTik device",
             inputSchema={
                 "type": "object",
@@ -119,7 +119,7 @@ def get_user_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_list_user_groups",
+            name="list_user_groups",
             description="Lists user groups on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -131,7 +131,7 @@ def get_user_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_user_group",
+            name="get_user_group",
             description="Gets detailed information about a specific user group",
             inputSchema={
                 "type": "object",
@@ -142,7 +142,7 @@ def get_user_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_update_user_group",
+            name="update_user_group",
             description="Updates an existing user group on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -157,7 +157,7 @@ def get_user_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_remove_user_group",
+            name="remove_user_group",
             description="Removes a user group from MikroTik device",
             inputSchema={
                 "type": "object",
@@ -168,7 +168,7 @@ def get_user_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_active_users",
+            name="get_active_users",
             description="Gets currently active/logged-in users",
             inputSchema={
                 "type": "object",
@@ -177,7 +177,7 @@ def get_user_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_disconnect_user",
+            name="disconnect_user",
             description="Disconnects an active user session",
             inputSchema={
                 "type": "object",
@@ -188,7 +188,7 @@ def get_user_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_export_user_config",
+            name="export_user_config",
             description="Exports user configuration to a file",
             inputSchema={
                 "type": "object",
@@ -199,7 +199,7 @@ def get_user_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_set_user_ssh_keys",
+            name="set_user_ssh_keys",
             description="Sets SSH public keys for a user",
             inputSchema={
                 "type": "object",
@@ -211,7 +211,7 @@ def get_user_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_list_user_ssh_keys",
+            name="list_user_ssh_keys",
             description="Lists SSH keys for a specific user",
             inputSchema={
                 "type": "object",
@@ -222,7 +222,7 @@ def get_user_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_remove_user_ssh_key",
+            name="remove_user_ssh_key",
             description="Removes an SSH key",
             inputSchema={
                 "type": "object",
@@ -237,7 +237,7 @@ def get_user_tools() -> List[Tool]:
 def get_user_handlers() -> Dict[str, Callable]:
     """Return the handlers for user management tools."""
     return {
-        "mikrotik_add_user": lambda args: mikrotik_add_user(
+        "add_user": lambda args: mikrotik_add_user(
             args["name"],
             args["password"],
             args.get("group", "read"),
@@ -245,16 +245,16 @@ def get_user_handlers() -> Dict[str, Callable]:
             args.get("comment"),
             args.get("disabled", False)
         ),
-        "mikrotik_list_users": lambda args: mikrotik_list_users(
+        "list_users": lambda args: mikrotik_list_users(
             args.get("name_filter"),
             args.get("group_filter"),
             args.get("disabled_only", False),
             args.get("active_only", False)
         ),
-        "mikrotik_get_user": lambda args: mikrotik_get_user(
+        "get_user": lambda args: mikrotik_get_user(
             args["name"]
         ),
-        "mikrotik_update_user": lambda args: mikrotik_update_user(
+        "update_user": lambda args: mikrotik_update_user(
             args["name"],
             args.get("new_name"),
             args.get("password"),
@@ -263,53 +263,53 @@ def get_user_handlers() -> Dict[str, Callable]:
             args.get("comment"),
             args.get("disabled")
         ),
-        "mikrotik_remove_user": lambda args: mikrotik_remove_user(
+        "remove_user": lambda args: mikrotik_remove_user(
             args["name"]
         ),
-        "mikrotik_disable_user": lambda args: mikrotik_disable_user(
+        "disable_user": lambda args: mikrotik_disable_user(
             args["name"]
         ),
-        "mikrotik_enable_user": lambda args: mikrotik_enable_user(
+        "enable_user": lambda args: mikrotik_enable_user(
             args["name"]
         ),
-        "mikrotik_add_user_group": lambda args: mikrotik_add_user_group(
+        "add_user_group": lambda args: mikrotik_add_user_group(
             args["name"],
             args["policy"],
             args.get("skin"),
             args.get("comment")
         ),
-        "mikrotik_list_user_groups": lambda args: mikrotik_list_user_groups(
+        "list_user_groups": lambda args: mikrotik_list_user_groups(
             args.get("name_filter"),
             args.get("policy_filter")
         ),
-        "mikrotik_get_user_group": lambda args: mikrotik_get_user_group(
+        "get_user_group": lambda args: mikrotik_get_user_group(
             args["name"]
         ),
-        "mikrotik_update_user_group": lambda args: mikrotik_update_user_group(
+        "update_user_group": lambda args: mikrotik_update_user_group(
             args["name"],
             args.get("new_name"),
             args.get("policy"),
             args.get("skin"),
             args.get("comment")
         ),
-        "mikrotik_remove_user_group": lambda args: mikrotik_remove_user_group(
+        "remove_user_group": lambda args: mikrotik_remove_user_group(
             args["name"]
         ),
-        "mikrotik_get_active_users": lambda args: mikrotik_get_active_users(),
-        "mikrotik_disconnect_user": lambda args: mikrotik_disconnect_user(
+        "get_active_users": lambda args: mikrotik_get_active_users(),
+        "disconnect_user": lambda args: mikrotik_disconnect_user(
             args["user_id"]
         ),
-        "mikrotik_export_user_config": lambda args: mikrotik_export_user_config(
+        "export_user_config": lambda args: mikrotik_export_user_config(
             args.get("filename")
         ),
-        "mikrotik_set_user_ssh_keys": lambda args: mikrotik_set_user_ssh_keys(
+        "set_user_ssh_keys": lambda args: mikrotik_set_user_ssh_keys(
             args["username"],
             args["key_file"]
         ),
-        "mikrotik_list_user_ssh_keys": lambda args: mikrotik_list_user_ssh_keys(
+        "list_user_ssh_keys": lambda args: mikrotik_list_user_ssh_keys(
             args["username"]
         ),
-        "mikrotik_remove_user_ssh_key": lambda args: mikrotik_remove_user_ssh_key(
+        "remove_user_ssh_key": lambda args: mikrotik_remove_user_ssh_key(
             args["key_id"]
         ),
     }

--- a/src/mcp_mikrotik/tools/vlan_tools.py
+++ b/src/mcp_mikrotik/tools/vlan_tools.py
@@ -11,7 +11,7 @@ def get_vlan_tools() -> List[Tool]:
     return [
         # VLAN interface tools
         Tool(
-            name="mikrotik_create_vlan_interface",
+            name="create_vlan_interface",
             description="Creates a VLAN interface on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -30,7 +30,7 @@ def get_vlan_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_list_vlan_interfaces",
+            name="list_vlan_interfaces",
             description="Lists VLAN interfaces on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -44,7 +44,7 @@ def get_vlan_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_vlan_interface",
+            name="get_vlan_interface",
             description="Gets detailed information about a specific VLAN interface",
             inputSchema={
                 "type": "object",
@@ -55,7 +55,7 @@ def get_vlan_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_update_vlan_interface",
+            name="update_vlan_interface",
             description="Updates an existing VLAN interface on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -75,7 +75,7 @@ def get_vlan_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_remove_vlan_interface",
+            name="remove_vlan_interface",
             description="Removes a VLAN interface from MikroTik device",
             inputSchema={
                 "type": "object",
@@ -90,7 +90,7 @@ def get_vlan_tools() -> List[Tool]:
 def get_vlan_handlers() -> Dict[str, Callable]:
     """Return the handlers for VLAN interface tools."""
     return {
-        "mikrotik_create_vlan_interface": lambda args: mikrotik_create_vlan_interface(
+        "create_vlan_interface": lambda args: mikrotik_create_vlan_interface(
             args["name"],
             args["vlan_id"],
             args["interface"],
@@ -101,16 +101,16 @@ def get_vlan_handlers() -> Dict[str, Callable]:
             args.get("arp", "enabled"),
             args.get("arp_timeout")
         ),
-        "mikrotik_list_vlan_interfaces": lambda args: mikrotik_list_vlan_interfaces(
+        "list_vlan_interfaces": lambda args: mikrotik_list_vlan_interfaces(
             args.get("name_filter"),
             args.get("vlan_id_filter"),
             args.get("interface_filter"),
             args.get("disabled_only", False)
         ),
-        "mikrotik_get_vlan_interface": lambda args: mikrotik_get_vlan_interface(
+        "get_vlan_interface": lambda args: mikrotik_get_vlan_interface(
             args["name"]
         ),
-        "mikrotik_update_vlan_interface": lambda args: mikrotik_update_vlan_interface(
+        "update_vlan_interface": lambda args: mikrotik_update_vlan_interface(
             args["name"],
             args.get("new_name"),
             args.get("vlan_id"),
@@ -122,7 +122,7 @@ def get_vlan_handlers() -> Dict[str, Callable]:
             args.get("arp"),
             args.get("arp_timeout")
         ),
-        "mikrotik_remove_vlan_interface": lambda args: mikrotik_remove_vlan_interface(
+        "remove_vlan_interface": lambda args: mikrotik_remove_vlan_interface(
             args["name"]
         ),
     }

--- a/src/mcp_mikrotik/tools/wireless_tools.py
+++ b/src/mcp_mikrotik/tools/wireless_tools.py
@@ -18,7 +18,7 @@ def get_wireless_tools() -> List[Tool]:
     return [
         # Wireless Interface Management
         Tool(
-            name="mikrotik_create_wireless_interface",
+            name="create_wireless_interface",
             description="Creates a wireless interface on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -48,7 +48,7 @@ def get_wireless_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_list_wireless_interfaces",
+            name="list_wireless_interfaces",
             description="Lists wireless interfaces on MikroTik device",
             inputSchema={
                 "type": "object",
@@ -61,7 +61,7 @@ def get_wireless_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_wireless_interface",
+            name="get_wireless_interface",
             description="Gets detailed information about a specific wireless interface",
             inputSchema={
                 "type": "object",
@@ -72,7 +72,7 @@ def get_wireless_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_update_wireless_interface",
+            name="update_wireless_interface",
             description="Updates an existing wireless interface",
             inputSchema={
                 "type": "object",
@@ -87,7 +87,7 @@ def get_wireless_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_remove_wireless_interface",
+            name="remove_wireless_interface",
             description="Removes a wireless interface from MikroTik device",
             inputSchema={
                 "type": "object",
@@ -98,7 +98,7 @@ def get_wireless_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_enable_wireless_interface",
+            name="enable_wireless_interface",
             description="Enables a wireless interface",
             inputSchema={
                 "type": "object",
@@ -109,7 +109,7 @@ def get_wireless_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_disable_wireless_interface",
+            name="disable_wireless_interface",
             description="Disables a wireless interface",
             inputSchema={
                 "type": "object",
@@ -122,7 +122,7 @@ def get_wireless_tools() -> List[Tool]:
 
         # Wireless Security Profile Management (Legacy)
         Tool(
-            name="mikrotik_create_wireless_security_profile",
+            name="create_wireless_security_profile",
             description="Creates a wireless security profile (legacy systems only)",
             inputSchema={
                 "type": "object",
@@ -133,7 +133,7 @@ def get_wireless_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_list_wireless_security_profiles",
+            name="list_wireless_security_profiles",
             description="Lists wireless security profiles (legacy systems only)",
             inputSchema={
                 "type": "object",
@@ -142,7 +142,7 @@ def get_wireless_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_wireless_security_profile",
+            name="get_wireless_security_profile",
             description="Gets wireless security profile details (legacy systems only)",
             inputSchema={
                 "type": "object",
@@ -153,7 +153,7 @@ def get_wireless_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_remove_wireless_security_profile",
+            name="remove_wireless_security_profile",
             description="Removes a wireless security profile (legacy systems only)",
             inputSchema={
                 "type": "object",
@@ -164,7 +164,7 @@ def get_wireless_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_set_wireless_security_profile",
+            name="set_wireless_security_profile",
             description="Sets security profile for interface (legacy systems only)",
             inputSchema={
                 "type": "object",
@@ -178,7 +178,7 @@ def get_wireless_tools() -> List[Tool]:
 
         # Wireless Network Operations
         Tool(
-            name="mikrotik_scan_wireless_networks",
+            name="scan_wireless_networks",
             description="Scans for wireless networks using specified interface",
             inputSchema={
                 "type": "object",
@@ -190,7 +190,7 @@ def get_wireless_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_get_wireless_registration_table",
+            name="get_wireless_registration_table",
             description="Gets the wireless registration table (connected clients)",
             inputSchema={
                 "type": "object",
@@ -203,7 +203,7 @@ def get_wireless_tools() -> List[Tool]:
 
         # Wireless Access List Management (Legacy)
         Tool(
-            name="mikrotik_create_wireless_access_list",
+            name="create_wireless_access_list",
             description="Creates a wireless access list entry (legacy systems only)",
             inputSchema={
                 "type": "object",
@@ -212,7 +212,7 @@ def get_wireless_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_list_wireless_access_list",
+            name="list_wireless_access_list",
             description="Lists wireless access list entries (legacy systems only)",
             inputSchema={
                 "type": "object",
@@ -221,7 +221,7 @@ def get_wireless_tools() -> List[Tool]:
             },
         ),
         Tool(
-            name="mikrotik_remove_wireless_access_list_entry",
+            name="remove_wireless_access_list_entry",
             description="Removes a wireless access list entry (legacy systems only)",
             inputSchema={
                 "type": "object",
@@ -233,7 +233,7 @@ def get_wireless_tools() -> List[Tool]:
         ),
         # Wireless Support Check
         Tool(
-            name="mikrotik_check_wireless_support",
+            name="check_wireless_support",
             description="Checks if the device supports wireless functionality",
             inputSchema={
                 "type": "object",
@@ -248,7 +248,7 @@ def get_wireless_handlers() -> Dict[str, Callable]:
     """Return the handlers for wireless management tools."""
     return {
         # Wireless Interface Management - Updated to match new function signatures
-        "mikrotik_create_wireless_interface": lambda args: mikrotik_create_wireless_interface(
+        "create_wireless_interface": lambda args: mikrotik_create_wireless_interface(
             name=args["name"],
             ssid=args.get("ssid"),
             disabled=args.get("disabled", False),
@@ -256,67 +256,67 @@ def get_wireless_handlers() -> Dict[str, Callable]:
             # Pass all other args as kwargs for legacy compatibility
             **{k: v for k, v in args.items() if k not in ["name", "ssid", "disabled", "comment"]}
         ),
-        "mikrotik_list_wireless_interfaces": lambda args: mikrotik_list_wireless_interfaces(
+        "list_wireless_interfaces": lambda args: mikrotik_list_wireless_interfaces(
             args.get("name_filter"),
             args.get("disabled_only", False),
             args.get("running_only", False)
         ),
-        "mikrotik_get_wireless_interface": lambda args: mikrotik_get_wireless_interface(
+        "get_wireless_interface": lambda args: mikrotik_get_wireless_interface(
             args["name"]
         ),
-        "mikrotik_update_wireless_interface": lambda args: mikrotik_update_wireless_interface(
+        "update_wireless_interface": lambda args: mikrotik_update_wireless_interface(
             name=args["name"],
             **{k: v for k, v in args.items() if k != "name"}
         ),
-        "mikrotik_remove_wireless_interface": lambda args: mikrotik_remove_wireless_interface(
+        "remove_wireless_interface": lambda args: mikrotik_remove_wireless_interface(
             args["name"]
         ),
-        "mikrotik_enable_wireless_interface": lambda args: mikrotik_enable_wireless_interface(
+        "enable_wireless_interface": lambda args: mikrotik_enable_wireless_interface(
             args["name"]
         ),
-        "mikrotik_disable_wireless_interface": lambda args: mikrotik_disable_wireless_interface(
+        "disable_wireless_interface": lambda args: mikrotik_disable_wireless_interface(
             args["name"]
         ),
 
         # Wireless Security Profile Management - Simplified for new system
-        "mikrotik_create_wireless_security_profile": lambda args: mikrotik_create_wireless_security_profile(
+        "create_wireless_security_profile": lambda args: mikrotik_create_wireless_security_profile(
             name=args["name"],
             **{k: v for k, v in args.items() if k != "name"}
         ),
-        "mikrotik_list_wireless_security_profiles": lambda args: mikrotik_list_wireless_security_profiles(
+        "list_wireless_security_profiles": lambda args: mikrotik_list_wireless_security_profiles(
             **args
         ),
-        "mikrotik_get_wireless_security_profile": lambda args: mikrotik_get_wireless_security_profile(
+        "get_wireless_security_profile": lambda args: mikrotik_get_wireless_security_profile(
             args["name"]
         ),
-        "mikrotik_remove_wireless_security_profile": lambda args: mikrotik_remove_wireless_security_profile(
+        "remove_wireless_security_profile": lambda args: mikrotik_remove_wireless_security_profile(
             args["name"]
         ),
-        "mikrotik_set_wireless_security_profile": lambda args: mikrotik_set_wireless_security_profile(
+        "set_wireless_security_profile": lambda args: mikrotik_set_wireless_security_profile(
             args["interface_name"],
             args["security_profile"]
         ),
 
         # Wireless Network Operations
-        "mikrotik_scan_wireless_networks": lambda args: mikrotik_scan_wireless_networks(
+        "scan_wireless_networks": lambda args: mikrotik_scan_wireless_networks(
             args["interface"],
             args.get("duration", 5)
         ),
-        "mikrotik_get_wireless_registration_table": lambda args: mikrotik_get_wireless_registration_table(
+        "get_wireless_registration_table": lambda args: mikrotik_get_wireless_registration_table(
             args.get("interface")
         ),
 
         # Wireless Access List Management - Simplified for new system
-        "mikrotik_create_wireless_access_list": lambda args: mikrotik_create_wireless_access_list(
+        "create_wireless_access_list": lambda args: mikrotik_create_wireless_access_list(
             **args
         ),
-        "mikrotik_list_wireless_access_list": lambda args: mikrotik_list_wireless_access_list(
+        "list_wireless_access_list": lambda args: mikrotik_list_wireless_access_list(
             **args
         ),
-        "mikrotik_remove_wireless_access_list_entry": lambda args: mikrotik_remove_wireless_access_list_entry(
+        "remove_wireless_access_list_entry": lambda args: mikrotik_remove_wireless_access_list_entry(
             args["entry_id"]
         ),
 
         # Wireless Support Check
-        "mikrotik_check_wireless_support": lambda args: mikrotik_check_wireless_support(),
+        "check_wireless_support": lambda args: mikrotik_check_wireless_support(),
     }


### PR DESCRIPTION
## Summary

- Strips the `mikrotik_` prefix from all MCP tool name strings (`Tool(name=...)` and handler dict keys) across 10 tool files
- Updates all documentation (15 files) to reflect the new tool names
- Python function names in `scope/` are unchanged

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)