### PR TITLE
chore(build): simplify minor version bump message pattern in GitVersi…

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,7 @@
 mode: ContinuousDelivery
 tag-prefix: '[vV]'
 major-version-bump-message: '\+semver:\s?(breaking|major)'
-minor-version-bump-message: '\+semver:\s?(feature|minor)|^feat(\(.+\))?:|^fix(\(.+\))?:|^refactor(\(.+\))?:|^perf(\(.+\))?:|^style(\(.+\))?:|^docs(\(.+\))?:|^test(\(.+\))?:|^chore(\(.+\))?:'
+minor-version-bump-message: '\+semver:\s?(feature|minor)|^feat(\(.+\))?:|^fix(\(.+\))?:|Merge pull request.*feat'  # Modified
 patch-version-bump-message: '\+semver:\s?(fix|patch)'
 no-bump-message: '\+semver:\s?(none|skip)'
 branches:


### PR DESCRIPTION
…on config

Remove unused conventional commit types (refactor, perf, style, docs, test, chore) from minor-version-bump-message pattern and add support for detecting feature PRs through merge commits. This streamlines version bumping to focus on feat and fix commits while maintaining PR-based feature detection.