### PR TITLE
feat(wireguard): add client configuration generator tool

### DIFF
--- a/docs/reference/wireguard/README.md
+++ b/docs/reference/wireguard/README.md
@@ -195,3 +195,92 @@ Disables a WireGuard peer without removing it.
   ```
   mikrotik_disable_wireguard_peer(peer_id="*1")
   ```
+
+---
+
+## Client Configuration
+
+### `mikrotik_generate_wireguard_client_config`
+Generates a WireGuard client configuration file (`wg0.conf` format). This tool only formats configuration text — it does not communicate with the router. Use `mikrotik_get_wireguard_interface` to obtain the server public key, and `mikrotik_add_wireguard_peer` to register the client's public key on the server side.
+- Parameters:
+  - `client_private_key` (required): Client's Base64-encoded WireGuard private key
+  - `client_address` (required): IP address with prefix assigned to the client inside the VPN tunnel (e.g. `"10.0.0.2/24"`)
+  - `server_public_key` (required): Server's Base64-encoded WireGuard public key (visible in `get_wireguard_interface` output)
+  - `server_endpoint` (required): Public IP or hostname of the MikroTik router (e.g. `"203.0.113.1"`)
+  - `server_port` (optional): UDP port the server listens on (default: `51820`)
+  - `allowed_ips` (optional): Comma-separated destination CIDRs routed through the tunnel. Use `"0.0.0.0/0, ::/0"` for full-tunnel or a specific subnet like `"10.0.0.0/24"` for split-tunnel (default: `"0.0.0.0/0"`)
+  - `dns` (optional): DNS server address(es) for the client while connected (e.g. `"1.1.1.1"`)
+  - `persistent_keepalive` (optional): Seconds between keepalive packets. Recommended when the client is behind NAT (default: `25`, use `0` to disable)
+- Example:
+  ```
+  mikrotik_generate_wireguard_client_config(
+      client_private_key="base64privatekey==",
+      client_address="10.0.0.2/24",
+      server_public_key="base64pubkey==",
+      server_endpoint="203.0.113.1",
+      server_port=51820,
+      allowed_ips="10.0.0.0/24",
+      dns="10.0.0.1"
+  )
+  ```
+
+---
+
+## Setting Up a WireGuard Server (Step-by-Step)
+
+To configure a complete WireGuard VPN server, use the individual single-responsibility tools in sequence:
+
+1. **Create the WireGuard interface** — `mikrotik_create_wireguard_interface`
+   ```
+   mikrotik_create_wireguard_interface(name="wg0", listen_port=51820)
+   ```
+
+2. **Assign an IP address to the interface** — `mikrotik_add_ip_address`
+   ```
+   mikrotik_add_ip_address(address="10.0.0.1/24", interface="wg0")
+   ```
+
+3. **Allow incoming WireGuard UDP traffic** — `mikrotik_create_filter_rule`
+   ```
+   mikrotik_create_filter_rule(
+       chain="input",
+       action="accept",
+       protocol="udp",
+       dst_port="51820",
+       comment="WireGuard wg0 input"
+   )
+   ```
+
+4. *(Optional)* **Enable internet access for VPN clients via NAT** — `mikrotik_create_nat_rule`
+   ```
+   mikrotik_create_nat_rule(
+       chain="srcnat",
+       action="masquerade",
+       out_interface="ether1",
+       comment="WireGuard wg0 masquerade"
+   )
+   ```
+
+5. **Retrieve the server's public key** for client configuration — `mikrotik_get_wireguard_interface`
+   ```
+   mikrotik_get_wireguard_interface(name="wg0")
+   ```
+
+6. **Register each client** on the server — `mikrotik_add_wireguard_peer`
+   ```
+   mikrotik_add_wireguard_peer(
+       interface="wg0",
+       public_key="client-base64pubkey==",
+       allowed_address="10.0.0.2/32"
+   )
+   ```
+
+7. **Generate the client config file** — `mikrotik_generate_wireguard_client_config`
+   ```
+   mikrotik_generate_wireguard_client_config(
+       client_private_key="client-base64privkey==",
+       client_address="10.0.0.2/24",
+       server_public_key="server-base64pubkey==",
+       server_endpoint="203.0.113.1"
+   )
+   ```

--- a/src/mcp_mikrotik/scope/wireguard.py
+++ b/src/mcp_mikrotik/scope/wireguard.py
@@ -480,3 +480,84 @@ async def mikrotik_disable_wireguard_peer(ctx: Context, peer_id: str) -> str:
         return f"Failed to disable WireGuard peer: {result}"
 
     return f"WireGuard peer '{peer_id}' disabled successfully."
+
+
+@mcp.tool(name="generate_wireguard_client_config", annotations=READ)
+async def mikrotik_generate_wireguard_client_config(
+    ctx: Context,
+    client_private_key: str,
+    client_address: str,
+    server_public_key: str,
+    server_endpoint: str,
+    server_port: int = 51820,
+    allowed_ips: str = "0.0.0.0/0",
+    dns: Optional[str] = None,
+    persistent_keepalive: int = 25,
+) -> str:
+    """
+    Generates a WireGuard client configuration file (wg0.conf format).
+
+    This tool only formats configuration text – it does not communicate with
+    the router.  Use list_wireguard_interfaces / get_wireguard_interface to
+    obtain the server public key, and use add_wireguard_peer to register the
+    client's public key on the server side.
+
+    Args:
+        client_private_key: Client's Base64-encoded WireGuard private key.
+        client_address: IP address (with prefix) assigned to the client inside
+                        the VPN tunnel (e.g. "10.0.0.2/24").
+        server_public_key: Server's Base64-encoded WireGuard public key
+                           (visible in get_wireguard_interface output).
+        server_endpoint: Public IP or hostname of the MikroTik router
+                         (e.g. "203.0.113.1").
+        server_port: UDP port the server listens on (default: 51820).
+        allowed_ips: Comma-separated list of destination CIDRs routed through
+                     the tunnel.  Use "0.0.0.0/0, ::/0" for full-tunnel (all
+                     traffic) or a specific subnet like "10.0.0.0/24" for
+                     split-tunnel (default: "0.0.0.0/0").
+        dns: Optional DNS server address(es) for the client to use while
+             connected (e.g. "1.1.1.1" or "10.0.0.1").
+        persistent_keepalive: Seconds between keepalive packets sent to the
+                              server.  Recommended when the client is behind
+                              NAT (default: 25, use 0 to disable).
+
+    Returns:
+        Ready-to-use WireGuard client configuration file content.
+    """
+    await ctx.info("Generating WireGuard client configuration")
+
+    lines = [
+        "[Interface]",
+        f"PrivateKey = {client_private_key}",
+        f"Address = {client_address}",
+    ]
+
+    if dns:
+        lines.append(f"DNS = {dns}")
+
+    lines += [
+        "",
+        "[Peer]",
+        f"PublicKey = {server_public_key}",
+        f"Endpoint = {server_endpoint}:{server_port}",
+        f"AllowedIPs = {allowed_ips}",
+    ]
+
+    if persistent_keepalive > 0:
+        lines.append(f"PersistentKeepalive = {persistent_keepalive}")
+
+    config_text = "\n".join(lines)
+
+    return (
+        "WIREGUARD CLIENT CONFIGURATION\n"
+        "Save as /etc/wireguard/wg0.conf (Linux) or import into your WireGuard app:\n\n"
+        f"{config_text}\n\n"
+        "NEXT STEPS:\n"
+        "1. Generate the client key-pair on the client device:\n"
+        "     wg genkey | tee private.key | wg pubkey > public.key\n"
+        "2. Replace 'PrivateKey' above with the content of private.key.\n"
+        "3. Register the client's public key on the server with add_wireguard_peer,\n"
+        f"   setting allowed_address to {client_address.split('/')[0]}/32.\n"
+        "4. Bring the tunnel up:\n"
+        "     wg-quick up wg0"
+    )


### PR DESCRIPTION
Implement new WireGuard client configuration generator that creates standard wg0.conf format files. This tool provides a convenient way to generate ready-to-use client configurations without requiring router communication.

- Add mikrotik_generate_wireguard_client_config function with comprehensive parameter validation
- Include step-by-step setup instructions and next steps in generated output
- Update documentation with complete WireGuard server setup workflow and client configuration examples