### PR TITLE
feat(inventory): support multiple MikroTik devices (issue #44)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -334,3 +334,8 @@ _templates/
 .aider*
 
 mcp-config.json
+
+# Real inventories hold device credentials; only the example ships
+inventory.yml
+inventory.yaml
+!inventory.example.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,13 @@ COPY --from=builder /app/src ./src
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-RUN chown -R mcpuser:mcpuser /app
+# Mount point for a multi-device inventory, e.g.
+#   -v "$PWD/inventory.json:/config/inventory.json:ro" -e MIKROTIK_INVENTORY_FILE=/config/inventory.json
+# Keeping credentials in a mounted file keeps them out of `docker inspect`,
+# unlike passing them through the environment.
+RUN mkdir -p /config
+
+RUN chown -R mcpuser:mcpuser /app /config
 USER mcpuser
 
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # Mount point for a multi-device inventory, e.g.
-#   -v "$PWD/inventory.json:/config/inventory.json:ro" -e MIKROTIK_INVENTORY_FILE=/config/inventory.json
+#   -v "$PWD/inventory.yaml:/config/inventory.yaml:ro" -e MIKROTIK_INVENTORY_FILE=/config/inventory.yaml
 # Keeping credentials in a mounted file keeps them out of `docker inspect`,
 # unlike passing them through the environment.
 RUN mkdir -p /config

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,32 +4,37 @@ set -e
 usage() {
     echo "Usage: $0 [OPTIONS] [COMMAND]"
     echo ""
-    echo "Options:"
+    echo "Single device:"
     echo "  --host HOST           MikroTik device IP/hostname"
     echo "  --username USERNAME   SSH username"
     echo "  --password PASSWORD   SSH password"
     echo "  --port PORT           SSH port (default: 22)"
+    echo ""
+    echo "Multiple devices (inventory) — takes precedence over the options above:"
+    echo "  --inventory JSON      Inventory as a JSON array of devices"
+    echo "  --inventory-file PATH Path to a file holding that JSON"
+    echo ""
+    echo "Other:"
     echo "  --transport TYPE      Transport: stdio, sse, streamable-http (default: stdio)"
     echo "  --help                Show this help message"
     echo ""
     echo "Environment variables:"
-    echo "  MIKROTIK_HOST         MikroTik device IP/hostname"
-    echo "  MIKROTIK_USERNAME     SSH username"
-    echo "  MIKROTIK_PASSWORD     SSH password"
-    echo "  MIKROTIK_PORT         SSH port (default: 22)"
-    echo "  MIKROTIK_MCP__TRANSPORT         Transport type (default: stdio)"
+    echo "  MIKROTIK_HOST            MikroTik device IP/hostname"
+    echo "  MIKROTIK_USERNAME        SSH username"
+    echo "  MIKROTIK_PASSWORD        SSH password"
+    echo "  MIKROTIK_PORT            SSH port (default: 22)"
+    echo "  MIKROTIK_INVENTORY       Inventory as a JSON array of devices"
+    echo "  MIKROTIK_INVENTORY_FILE  Path to a file holding that JSON"
+    echo "  MIKROTIK_MCP__TRANSPORT  Transport type (default: stdio)"
     echo ""
     echo "Examples:"
     echo "  $0 --host 192.168.88.1 --username admin --password admin123"
     echo "  $0 --host 192.168.88.1 --username admin --password admin123 --transport sse"
     echo "  MIKROTIK_HOST=192.168.88.1 MIKROTIK_MCP__TRANSPORT=sse $0"
+    echo "  $0 --inventory-file /config/inventory.json --transport streamable-http"
     exit 1
 }
 
-MIKROTIK_HOST="${MIKROTIK_HOST:-192.168.88.1}"
-MIKROTIK_USERNAME="${MIKROTIK_USERNAME:-admin}"
-MIKROTIK_PASSWORD="${MIKROTIK_PASSWORD:-}"
-MIKROTIK_PORT="${MIKROTIK_PORT:-22}"
 MIKROTIK_MCP__TRANSPORT="${MIKROTIK_MCP__TRANSPORT:-stdio}"
 
 while [ $# -gt 0 ]; do
@@ -50,6 +55,14 @@ while [ $# -gt 0 ]; do
             MIKROTIK_PORT="$2"
             shift 2
             ;;
+        --inventory)
+            MIKROTIK_INVENTORY="$2"
+            shift 2
+            ;;
+        --inventory-file)
+            MIKROTIK_INVENTORY_FILE="$2"
+            shift 2
+            ;;
         --transport)
             MIKROTIK_MCP__TRANSPORT="$2"
             shift 2
@@ -63,11 +76,36 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-export MIKROTIK_HOST
-export MIKROTIK_USERNAME
-export MIKROTIK_PASSWORD
-export MIKROTIK_PORT
 export MIKROTIK_MCP__TRANSPORT
+
+# An inventory describes the whole fleet, so it takes precedence over the
+# single-device settings. Don't fall back to the 192.168.88.1 default in that
+# case: inventing a host nobody asked for reads as if it still applied. Values
+# the user passed with `docker run -e` are already in the environment and stay
+# there; they are simply ignored by the config layer.
+if [ -n "${MIKROTIK_INVENTORY:-}" ] || [ -n "${MIKROTIK_INVENTORY_FILE:-}" ]; then
+    if [ -n "${MIKROTIK_INVENTORY_FILE:-}" ] && [ ! -r "$MIKROTIK_INVENTORY_FILE" ]; then
+        echo "Error: inventory file '$MIKROTIK_INVENTORY_FILE' is not readable inside the container." >&2
+        echo "" >&2
+        echo "Mount it, for example:" >&2
+        echo "  -v \"\$PWD/inventory.json:/config/inventory.json:ro\"" >&2
+        echo "" >&2
+        echo "The container runs as uid 1000 (mcpuser), so the file on the host must be" >&2
+        echo "readable by that uid — 'chmod 644 inventory.json' is usually enough." >&2
+        exit 1
+    fi
+    [ -n "${MIKROTIK_INVENTORY:-}" ] && export MIKROTIK_INVENTORY
+    [ -n "${MIKROTIK_INVENTORY_FILE:-}" ] && export MIKROTIK_INVENTORY_FILE
+else
+    MIKROTIK_HOST="${MIKROTIK_HOST:-192.168.88.1}"
+    MIKROTIK_USERNAME="${MIKROTIK_USERNAME:-admin}"
+    MIKROTIK_PASSWORD="${MIKROTIK_PASSWORD:-}"
+    MIKROTIK_PORT="${MIKROTIK_PORT:-22}"
+    export MIKROTIK_HOST
+    export MIKROTIK_USERNAME
+    export MIKROTIK_PASSWORD
+    export MIKROTIK_PORT
+fi
 
 if [ $# -eq 0 ]; then
     exec mcp-server-mikrotik

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,8 +11,8 @@ usage() {
     echo "  --port PORT           SSH port (default: 22)"
     echo ""
     echo "Multiple devices (inventory) — takes precedence over the options above:"
-    echo "  --inventory JSON      Inventory as a JSON array of devices"
-    echo "  --inventory-file PATH Path to a file holding that JSON"
+    echo "  --inventory YAML      Inventory as a YAML (or JSON) list of devices"
+    echo "  --inventory-file PATH Path to a YAML file holding the inventory"
     echo ""
     echo "Other:"
     echo "  --transport TYPE      Transport: stdio, sse, streamable-http (default: stdio)"
@@ -23,15 +23,15 @@ usage() {
     echo "  MIKROTIK_USERNAME        SSH username"
     echo "  MIKROTIK_PASSWORD        SSH password"
     echo "  MIKROTIK_PORT            SSH port (default: 22)"
-    echo "  MIKROTIK_INVENTORY       Inventory as a JSON array of devices"
-    echo "  MIKROTIK_INVENTORY_FILE  Path to a file holding that JSON"
+    echo "  MIKROTIK_INVENTORY       Inventory as a YAML (or JSON) list of devices"
+    echo "  MIKROTIK_INVENTORY_FILE  Path to a YAML file holding the inventory"
     echo "  MIKROTIK_MCP__TRANSPORT  Transport type (default: stdio)"
     echo ""
     echo "Examples:"
     echo "  $0 --host 192.168.88.1 --username admin --password admin123"
     echo "  $0 --host 192.168.88.1 --username admin --password admin123 --transport sse"
     echo "  MIKROTIK_HOST=192.168.88.1 MIKROTIK_MCP__TRANSPORT=sse $0"
-    echo "  $0 --inventory-file /config/inventory.json --transport streamable-http"
+    echo "  $0 --inventory-file /config/inventory.yaml --transport streamable-http"
     exit 1
 }
 
@@ -84,14 +84,25 @@ export MIKROTIK_MCP__TRANSPORT
 # the user passed with `docker run -e` are already in the environment and stay
 # there; they are simply ignored by the config layer.
 if [ -n "${MIKROTIK_INVENTORY:-}" ] || [ -n "${MIKROTIK_INVENTORY_FILE:-}" ]; then
-    if [ -n "${MIKROTIK_INVENTORY_FILE:-}" ] && [ ! -r "$MIKROTIK_INVENTORY_FILE" ]; then
-        echo "Error: inventory file '$MIKROTIK_INVENTORY_FILE' is not readable inside the container." >&2
-        echo "" >&2
-        echo "Mount it, for example:" >&2
-        echo "  -v \"\$PWD/inventory.json:/config/inventory.json:ro\"" >&2
-        echo "" >&2
-        echo "The container runs as uid 1000 (mcpuser), so the file on the host must be" >&2
-        echo "readable by that uid — 'chmod 644 inventory.json' is usually enough." >&2
+    # -f as well as -r: when the host file named in a bind mount does not
+    # exist, Docker silently creates a DIRECTORY at both ends — which is
+    # readable, and would sail past a bare -r check.
+    if [ -n "${MIKROTIK_INVENTORY_FILE:-}" ] && { [ ! -f "$MIKROTIK_INVENTORY_FILE" ] || [ ! -r "$MIKROTIK_INVENTORY_FILE" ]; }; then
+        if [ -d "$MIKROTIK_INVENTORY_FILE" ]; then
+            echo "Error: '$MIKROTIK_INVENTORY_FILE' is a directory, not a file." >&2
+            echo "" >&2
+            echo "This usually means the host file named in the -v mount did not exist," >&2
+            echo "so Docker created a directory in its place. Create the YAML file on" >&2
+            echo "the host first, then recreate the container." >&2
+        else
+            echo "Error: inventory file '$MIKROTIK_INVENTORY_FILE' is not readable inside the container." >&2
+            echo "" >&2
+            echo "Mount it, for example:" >&2
+            echo "  -v \"\$PWD/inventory.yaml:/config/inventory.yaml:ro\"" >&2
+            echo "" >&2
+            echo "The container runs as uid 1000 (mcpuser), so the file on the host must be" >&2
+            echo "readable by that uid — 'chmod 644 inventory.yaml' is usually enough." >&2
+        fi
         exit 1
     fi
     [ -n "${MIKROTIK_INVENTORY:-}" ] && export MIKROTIK_INVENTORY

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Complete documentation for MikroTik MCP.
 
 Complete tool documentation organized by category:
 
+- **[Fleet](reference/fleet/README.md)** - Multi-Device Fleet Management
 - **[VLAN](reference/vlan/README.md)** - VLAN Interface Management
 - **[IP Address](reference/ip-address/README.md)** - IP Address Management
 - **[DHCP](reference/dhcp/README.md)** - DHCP Server Management

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -187,7 +187,8 @@ single-device variables. The inventory is a YAML file on your host, and it
 as the mount point. A mounted file is also the safer channel: unlike an
 environment variable, its contents do not show up in `docker inspect`.
 
-`inventory.yaml`:
+`inventory.yaml` (a ready-to-copy template ships at the repository root as
+[`inventory.example.yml`](../../inventory.example.yml)):
 
 ```yaml
 - title: TitleA

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -142,8 +142,8 @@ In the examples below, substitute `ghcr.io/jeff-nasseri/mikrotik-mcp:latest` for
    | `MIKROTIK_USERNAME` | SSH username | `admin` |
    | `MIKROTIK_PASSWORD` | SSH password | _(empty)_ |
    | `MIKROTIK_PORT` | SSH port | `22` |
-   | `MIKROTIK_INVENTORY` | Multiple devices, as a JSON array. Takes precedence over the four variables above. See [Inventory](../reference/inventory/README.md). | _(empty)_ |
-   | `MIKROTIK_INVENTORY_FILE` | Path **inside the container** to a file holding that JSON | _(empty)_ |
+   | `MIKROTIK_INVENTORY` | Multiple devices, written inline in YAML (or its JSON subset). Takes precedence over `MIKROTIK_INVENTORY_FILE` and the four variables above. See [Inventory](../reference/inventory/README.md). | _(empty)_ |
+   | `MIKROTIK_INVENTORY_FILE` | Path **inside the container** to a YAML file holding the inventory — mount it as a volume | _(empty)_ |
    | `MIKROTIK_MCP__TRANSPORT` | Transport type: `stdio`, `sse`, `streamable-http` | `stdio` |
    | `MIKROTIK_MCP__HOST` | HTTP server listen address | `0.0.0.0` |
    | `MIKROTIK_MCP__PORT` | HTTP server listen port | `8000` |
@@ -182,17 +182,39 @@ docker compose up -d
 #### Managing several devices
 
 To manage a fleet, give the container an **inventory** instead of the four
-single-device variables. Mounting it as a file is preferred: unlike an
+single-device variables. The inventory is a YAML file on your host, and it
+**must be mounted into the container as a volume** — the image ships `/config`
+as the mount point. A mounted file is also the safer channel: unlike an
 environment variable, its contents do not show up in `docker inspect`.
 
-`inventory.json`:
+`inventory.yaml`:
 
-```json
-[
-  { "title": "TitleA", "host": "192.168.88.1", "port": 22, "username": "admin", "password": "change-me", "region": "NL", "tags": ["branch"] },
-  { "title": "TitleB", "host": "192.168.89.1", "port": 22, "username": "admin", "key_filename": "/config/keys/id_ed25519" }
-]
+```yaml
+- title: TitleA
+  host: 192.168.88.1
+  port: 22
+  username: admin
+  password: change-me
+  region: NL
+  tags: [branch]
+
+- title: TitleB
+  host: 192.168.89.1
+  port: 22
+  username: admin
+  key_filename: /config/keys/id_ed25519
 ```
+
+With `docker run`:
+
+```bash
+docker run --rm -i \
+  -v "$PWD/inventory.yaml:/config/inventory.yaml:ro" \
+  -e MIKROTIK_INVENTORY_FILE=/config/inventory.yaml \
+  ghcr.io/jeff-nasseri/mikrotik-mcp:latest
+```
+
+With Docker Compose:
 
 ```yaml
 services:
@@ -203,22 +225,27 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ./inventory.json:/config/inventory.json:ro
+      - ./inventory.yaml:/config/inventory.yaml:ro
     environment:
-      MIKROTIK_INVENTORY_FILE: "/config/inventory.json"
+      MIKROTIK_INVENTORY_FILE: "/config/inventory.yaml"
       MIKROTIK_MCP__TRANSPORT: "streamable-http"
       MIKROTIK_MCP__HOST: "0.0.0.0"
       MIKROTIK_MCP__PORT: "8000"
 ```
 
-The image ships a `/config` directory for this. Or pass the JSON inline with
-`MIKROTIK_INVENTORY` (or `--inventory` / `--inventory-file` as entrypoint
-arguments) if a mount is inconvenient.
+If a mount is inconvenient, the inventory can go inline in
+`MIKROTIK_INVENTORY` using YAML flow syntax (no escaped quotes; JSON also
+works, since it is a YAML subset), or via the `--inventory` /
+`--inventory-file` entrypoint arguments. Inline always wins over the file.
 
-> The container runs as **uid 1000** (`mcpuser`), so the mounted file must be
-> readable by that uid — `chmod 644 inventory.json` is usually enough. If it
-> isn't readable the entrypoint stops with an explicit message rather than
-> starting a server with no devices.
+> Two traps the entrypoint catches with an explicit error rather than starting
+> a server with no devices:
+>
+> - The container runs as **uid 1000** (`mcpuser`), so the mounted file must
+>   be readable by that uid — `chmod 644 inventory.yaml` is usually enough.
+> - If `inventory.yaml` does not exist on the host when the container starts,
+>   Docker silently creates a **directory** in its place. Create the file
+>   before starting the container.
 
 When an inventory is set it takes precedence and `MIKROTIK_HOST` /
 `MIKROTIK_USERNAME` / `MIKROTIK_PASSWORD` / `MIKROTIK_PORT` are ignored, so you

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -142,6 +142,8 @@ In the examples below, substitute `ghcr.io/jeff-nasseri/mikrotik-mcp:latest` for
    | `MIKROTIK_USERNAME` | SSH username | `admin` |
    | `MIKROTIK_PASSWORD` | SSH password | _(empty)_ |
    | `MIKROTIK_PORT` | SSH port | `22` |
+   | `MIKROTIK_INVENTORY` | Multiple devices, as a JSON array. Takes precedence over the four variables above. See [Inventory](../reference/inventory/README.md). | _(empty)_ |
+   | `MIKROTIK_INVENTORY_FILE` | Path **inside the container** to a file holding that JSON | _(empty)_ |
    | `MIKROTIK_MCP__TRANSPORT` | Transport type: `stdio`, `sse`, `streamable-http` | `stdio` |
    | `MIKROTIK_MCP__HOST` | HTTP server listen address | `0.0.0.0` |
    | `MIKROTIK_MCP__PORT` | HTTP server listen port | `8000` |
@@ -176,6 +178,54 @@ services:
 ```bash
 docker compose up -d
 ```
+
+#### Managing several devices
+
+To manage a fleet, give the container an **inventory** instead of the four
+single-device variables. Mounting it as a file is preferred: unlike an
+environment variable, its contents do not show up in `docker inspect`.
+
+`inventory.json`:
+
+```json
+[
+  { "title": "TitleA", "host": "192.168.88.1", "port": 22, "username": "admin", "password": "change-me", "region": "NL", "tags": ["branch"] },
+  { "title": "TitleB", "host": "192.168.89.1", "port": 22, "username": "admin", "key_filename": "/config/keys/id_ed25519" }
+]
+```
+
+```yaml
+services:
+  mikrotik-mcp:
+    image: ghcr.io/jeff-nasseri/mikrotik-mcp:latest
+    container_name: mikrotik-mcp
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./inventory.json:/config/inventory.json:ro
+    environment:
+      MIKROTIK_INVENTORY_FILE: "/config/inventory.json"
+      MIKROTIK_MCP__TRANSPORT: "streamable-http"
+      MIKROTIK_MCP__HOST: "0.0.0.0"
+      MIKROTIK_MCP__PORT: "8000"
+```
+
+The image ships a `/config` directory for this. Or pass the JSON inline with
+`MIKROTIK_INVENTORY` (or `--inventory` / `--inventory-file` as entrypoint
+arguments) if a mount is inconvenient.
+
+> The container runs as **uid 1000** (`mcpuser`), so the mounted file must be
+> readable by that uid — `chmod 644 inventory.json` is usually enough. If it
+> isn't readable the entrypoint stops with an explicit message rather than
+> starting a server with no devices.
+
+When an inventory is set it takes precedence and `MIKROTIK_HOST` /
+`MIKROTIK_USERNAME` / `MIKROTIK_PASSWORD` / `MIKROTIK_PORT` are ignored, so you
+can drop them. The entrypoint also stops applying its `192.168.88.1` default in
+that case, rather than injecting a host nobody asked for. Tools then take a
+`device` argument naming the title to target; see
+[Inventory](../reference/inventory/README.md).
 
 The server is then reachable at `http://localhost:8000/mcp` (streamable HTTP)
 or `http://localhost:8000/sse` (if you set `MIKROTIK_MCP__TRANSPORT: sse`), and

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -4,6 +4,8 @@ Complete reference documentation for all MikroTik MCP tools.
 
 ## Available Tool Categories
 
+- **[Inventory](inventory/README.md)** - Managing multiple MikroTik devices
+
 - **[Interfaces](interfaces/README.md)** - All Interface Management (ethernet, bridge, PPPoE, SFP, LTE …)
 - **[PoE](poe/README.md)** - Power over Ethernet monitoring
 - **[VLAN](vlan/README.md)** - VLAN Interface Management

--- a/docs/reference/fleet/README.md
+++ b/docs/reference/fleet/README.md
@@ -1,0 +1,166 @@
+# Fleet Management
+
+Multi-device fleet management lets you manage a collection of MikroTik routers from a single MCP session.
+You define an inventory of devices, each with a name, connection details, and an optional list of tags.
+Tools can then target a single device by name, a group of devices by tag, or every device at once —
+executing RouterOS commands in parallel and returning per-device results.
+
+## Configuration
+
+Define your fleet by setting the `MIKROTIK_DEVICES` environment variable to a JSON array:
+
+```bash
+MIKROTIK_DEVICES='[
+  {"name": "mt-nl-1", "host": "1.1.1.1", "username": "admin", "password": "secret", "tags": ["nl", "eu", "core"]},
+  {"name": "mt-usa-1", "host": "2.2.2.1", "username": "admin", "password": "secret", "tags": ["usa", "core"]},
+  {"name": "mt-uae-1", "host": "3.3.3.1", "username": "admin", "password": "secret", "tags": ["uae"]},
+  {"name": "mt-edge-1", "host": "10.0.0.1", "port": 2222, "key_filename": "/keys/id_rsa", "tags": ["edge"]}
+]'
+```
+
+### DeviceConfig fields
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `name` | string | yes | — | Unique identifier for the device |
+| `host` | string | yes | — | IP address or hostname |
+| `username` | string | no | `admin` | SSH username |
+| `password` | string | no | `""` | SSH password |
+| `port` | integer | no | `22` | SSH port |
+| `key_filename` | string | no | `null` | Path to private key file |
+| `tags` | array[string] | no | `[]` | Labels for grouping (region, role, etc.) |
+
+> **Backward compatibility:** The single-device config (`MIKROTIK_HOST`, `MIKROTIK_USERNAME`, etc.) continues to work unchanged. Set `MIKROTIK_DEVICES` only if you want fleet capabilities; it defaults to an empty list.
+
+---
+
+## Tools
+
+### `list_devices`
+
+Lists all devices currently loaded in the fleet inventory. Read-only — never connects to any device.
+
+**Parameters:** none
+
+**Returns:** JSON array of device summaries (name, host, port, username, tags).
+
+**Example:**
+```
+list_devices()
+```
+```json
+[
+  {"name": "mt-nl-1", "host": "1.1.1.1", "port": 22, "username": "admin", "tags": ["nl", "eu", "core"]},
+  {"name": "mt-usa-1", "host": "2.2.2.1", "port": 22, "username": "admin", "tags": ["usa", "core"]},
+  {"name": "mt-uae-1", "host": "3.3.3.1", "port": 22, "username": "admin", "tags": ["uae"]}
+]
+```
+
+---
+
+### `run_command_on_device`
+
+Executes a single RouterOS command on one specific device, identified by name.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `device_name` | string | yes | The `name` of the target device as defined in `MIKROTIK_DEVICES` |
+| `command` | string | yes | RouterOS CLI command (e.g. `/ip address print`) |
+
+**Returns:** The command output prefixed with the device name, or an error message if the device is not found or the connection fails.
+
+**Example:**
+```
+run_command_on_device(device_name="mt-nl-1", command="/system resource print")
+```
+```
+mt-nl-1:
+                   uptime: 5d12h33m24s
+                  version: 7.14.3 (stable)
+             free-memory: 128.0MiB
+```
+
+---
+
+### `run_command_on_tag`
+
+Executes a RouterOS command in parallel on every device that carries the given tag.
+Results are returned as a JSON object keyed by device name so you can immediately see
+which devices succeeded and which failed.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `tag` | string | yes | Tag to match (e.g. `"eu"`, `"core"`, `"edge"`) |
+| `command` | string | yes | RouterOS CLI command |
+
+**Returns:** JSON object mapping each matching device name to its command output or an error string.
+
+**Example:**
+```
+run_command_on_tag(tag="core", command="/system resource print")
+```
+```json
+{
+  "mt-nl-1": "uptime: 5d12h...",
+  "mt-usa-1": "uptime: 2d08h..."
+}
+```
+
+If a device is unreachable:
+```json
+{
+  "mt-nl-1": "uptime: 5d12h...",
+  "mt-usa-1": "Error: Failed to connect to 2.2.2.1"
+}
+```
+
+---
+
+### `run_command_on_all_devices`
+
+Executes a RouterOS command in parallel on **all** devices in the inventory.
+An optional `tag_filter` restricts execution to devices carrying that tag
+(equivalent to `run_command_on_tag` but callable without knowing the tag up front).
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `command` | string | yes | RouterOS CLI command |
+| `tag_filter` | string | no | When provided, only devices with this tag are targeted |
+
+**Returns:** JSON object mapping every targeted device name to its command output or error.
+
+**Example — all devices:**
+```
+run_command_on_all_devices(command="/ip address print")
+```
+```json
+{
+  "mt-nl-1": "...",
+  "mt-usa-1": "...",
+  "mt-uae-1": "..."
+}
+```
+
+**Example — filtered by tag:**
+```
+run_command_on_all_devices(command="/ip address print", tag_filter="eu")
+```
+```json
+{
+  "mt-nl-1": "..."
+}
+```
+
+---
+
+## Notes
+
+- Fleet tools always open a **fresh SSH connection** per device. They do not share the Safe Mode session that may be active on the default single device.
+- Commands are dispatched concurrently with `asyncio.gather`, so latency scales with the slowest device, not the total number.
+- Passwords are never included in the `list_devices` output.

--- a/docs/reference/inventory/README.md
+++ b/docs/reference/inventory/README.md
@@ -1,0 +1,136 @@
+# Inventory (multiple devices)
+
+MikroTik MCP can manage a fleet of devices from one server. Devices are
+declared in an **inventory**; each entry has a unique `title`, which is the
+identifier tools use to target that device.
+
+With no inventory configured the server behaves exactly as before: a single
+device built from `MIKROTIK_HOST` / `MIKROTIK_USERNAME` / … , and the `device`
+argument can be omitted everywhere.
+
+## Configuring the inventory
+
+Supply a JSON array either inline or from a file:
+
+| Variable | Purpose |
+|---|---|
+| `MIKROTIK_INVENTORY` | the inventory as a JSON array |
+| `MIKROTIK_INVENTORY_FILE` | path to a file containing that JSON |
+
+In an MCP client config these belong in the server's **`env`** block — that is
+the channel a client forwards to the spawned process:
+
+```json
+{
+  "mcpServers": {
+    "mikrotik-mcp-server": {
+      "command": "python",
+      "args": ["-m", "mcp_mikrotik.server"],
+      "env": {
+        "MIKROTIK_INVENTORY": "[{\"title\":\"TitleA\",\"tags\":[\"tag1\",\"tag2\"],\"region\":\"NL\",\"host\":\"127.0.0.1\",\"port\":22,\"username\":\"admin\",\"password\":\"admin\"},{\"title\":\"TitleB\",\"tags\":[\"tag1\",\"tag3\"],\"region\":\"DE\",\"host\":\"192.168.88.1\",\"port\":22,\"username\":\"admin\",\"password\":\"admin\"}]"
+      }
+    }
+  }
+}
+```
+
+A file keeps the config readable and the secrets out of the client config:
+
+```json
+{ "env": { "MIKROTIK_INVENTORY_FILE": "/etc/mikrotik/inventory.json" } }
+```
+
+```json
+[
+  {
+    "title": "TitleA",
+    "tags": ["tag1", "tag2"],
+    "region": "NL",
+    "host": "127.0.0.1",
+    "port": 22,
+    "username": "admin",
+    "password": "admin"
+  },
+  {
+    "title": "TitleB",
+    "tags": ["tag1", "tag3"],
+    "region": "DE",
+    "host": "192.168.88.1",
+    "port": 22,
+    "username": "admin",
+    "key_filename": "/keys/id_ed25519"
+  }
+]
+```
+
+### Device fields
+
+| Field | Required | Notes |
+|---|---|---|
+| `title` | yes | Unique identifier the LLM passes as `device`. Matching is case-insensitive. |
+| `host` | yes | IP or hostname |
+| `port` | no | SSH port, default `22` |
+| `username` | no | default `admin` |
+| `password` | no | omit when using `key_filename` |
+| `key_filename` | no | path to an SSH private key (preferred over a password) |
+| `tags` | no | free-form labels, e.g. `["branch", "eu"]` |
+| `region` | no | free-form label, e.g. `"NL"` |
+
+## Selecting a device
+
+Every device-scoped tool accepts an optional `device` argument:
+
+- **One device configured** — omit `device`; that device is used.
+- **More than one** — pass the `title`. Omitting it returns an error that lists
+  the available devices, as does an unknown title, so the caller can correct
+  itself immediately.
+
+```
+list_devices()                                  # discover the fleet
+list_interfaces(device="TitleA")                # target one device
+create_vlan_interface(device="TitleB", name="vlan100", vlan_id=100, interface="ether1")
+```
+
+## `list_devices`
+
+Lists the devices this server manages — title, host, port, username, tags and
+region. **Credentials are never returned.**
+
+```
+list_devices()
+```
+
+## Safe mode is per device
+
+Safe mode holds a persistent session, and each device has its own. Enabling it
+on one device does not affect any other:
+
+```
+enable_safe_mode(device="TitleA")
+create_filter_rule(device="TitleA", chain="forward", action="drop", ...)
+commit_safe_mode(device="TitleA")     # or rollback_safe_mode(device="TitleA")
+```
+
+## Two-device test environment
+
+`routeros-docker/docker-compose.yml` starts two RouterOS instances for testing:
+
+| Container | SSH | Suggested title |
+|---|---|---|
+| `routeros-a` | `127.0.0.1:2222` | RouterA |
+| `routeros-b` | `127.0.0.1:2223` | RouterB |
+
+```bash
+docker-compose -f routeros-docker/docker-compose.yml up -d
+python tests/smoke_multi_device.py
+```
+
+> Both routers boot inside QEMU and need roughly two minutes before SSH answers.
+
+## Security
+
+Credentials live in the inventory, so the whole inventory is a secret. Prefer
+`key_filename` over `password`, keep the JSON in a file with restricted
+permissions rather than inline in a client config, and remember that values
+passed as environment variables are visible via `docker inspect` — see
+[SECURITY.md](../../../SECURITY.md).

--- a/docs/reference/inventory/README.md
+++ b/docs/reference/inventory/README.md
@@ -100,6 +100,21 @@ region. **Credentials are never returned.**
 list_devices()
 ```
 
+## Connections are per command
+
+Every command opens its own SSH connection to the target device and closes it
+when the command finishes. Connections are never pooled or shared.
+
+This matters when more than one client session talks to the same server
+process: a shared connection would mean shared fate, so one session
+disconnecting, timing out or failing to authenticate would break a command
+another session was running against the same device. With a connection per
+command the sessions cannot disturb each other.
+
+The trade-off is one SSH handshake per command. On a LAN that is a few tens of
+milliseconds; if the device is far away or heavily loaded, expect commands to
+cost noticeably more than the RouterOS work alone.
+
 ## Safe mode is per device
 
 Safe mode holds a persistent session, and each device has its own. Enabling it

--- a/docs/reference/inventory/README.md
+++ b/docs/reference/inventory/README.md
@@ -26,6 +26,9 @@ the first tool call.
 
 ### The YAML file (recommended)
 
+A ready-to-copy template ships at the repository root:
+[`inventory.example.yml`](../../../inventory.example.yml).
+
 `inventory.yaml`:
 
 ```yaml

--- a/docs/reference/inventory/README.md
+++ b/docs/reference/inventory/README.md
@@ -100,6 +100,30 @@ region. **Credentials are never returned.**
 list_devices()
 ```
 
+## Docker
+
+The image accepts the same two variables, and ships a `/config` directory to
+mount the inventory into:
+
+```bash
+docker run --rm -i \
+  -v "$PWD/inventory.json:/config/inventory.json:ro" \
+  -e MIKROTIK_INVENTORY_FILE=/config/inventory.json \
+  ghcr.io/jeff-nasseri/mikrotik-mcp:latest
+```
+
+The entrypoint also takes `--inventory '<json>'` and `--inventory-file <path>`.
+
+A mounted file is preferable to `MIKROTIK_INVENTORY`: environment values are
+visible in `docker inspect`, file contents are not. The container runs as **uid
+1000** (`mcpuser`), so the file must be readable by that uid; if it isn't, the
+entrypoint stops with an explicit message instead of starting with no devices.
+
+When an inventory is configured it wins, so `MIKROTIK_HOST` / `MIKROTIK_USERNAME`
+/ `MIKROTIK_PASSWORD` / `MIKROTIK_PORT` are ignored and can be dropped.
+
+See [Installation](../../getting-started/installation.md) for a Compose example.
+
 ## Connections are per command
 
 Every command opens its own SSH connection to the target device and closes it

--- a/docs/reference/inventory/README.md
+++ b/docs/reference/inventory/README.md
@@ -10,15 +10,45 @@ argument can be omitted everywhere.
 
 ## Configuring the inventory
 
-Supply a JSON array either inline or from a file:
+The inventory is written in **YAML**. Two sources are supported:
 
 | Variable | Purpose |
 |---|---|
-| `MIKROTIK_INVENTORY` | the inventory as a JSON array |
-| `MIKROTIK_INVENTORY_FILE` | path to a file containing that JSON |
+| `MIKROTIK_INVENTORY_FILE` | path to a YAML file holding the inventory (recommended) |
+| `MIKROTIK_INVENTORY` | the inventory written inline |
 
-In an MCP client config these belong in the server's **`env`** block — that is
-the channel a client forwards to the spawned process:
+When both are set, **the inline `MIKROTIK_INVENTORY` wins** and the file is
+ignored. When neither is set, the flat single-device settings apply.
+
+A broken inventory (missing file, bad YAML, invalid entry) stops the server at
+startup with one clear message, so mistakes surface immediately rather than at
+the first tool call.
+
+### The YAML file (recommended)
+
+`inventory.yaml`:
+
+```yaml
+- title: TitleA
+  host: 127.0.0.1
+  port: 22
+  username: admin
+  password: admin
+  tags: [tag1, tag2]
+  region: NL
+
+- title: TitleB
+  host: 192.168.88.1
+  port: 22
+  username: admin
+  key_filename: /keys/id_ed25519
+  tags: [tag1, tag3]
+  region: DE
+```
+
+Point the server at it from the MCP client config — these belong in the
+server's **`env`** block, which is the channel a client forwards to the
+spawned process:
 
 ```json
 {
@@ -27,41 +57,38 @@ the channel a client forwards to the spawned process:
       "command": "python",
       "args": ["-m", "mcp_mikrotik.server"],
       "env": {
-        "MIKROTIK_INVENTORY": "[{\"title\":\"TitleA\",\"tags\":[\"tag1\",\"tag2\"],\"region\":\"NL\",\"host\":\"127.0.0.1\",\"port\":22,\"username\":\"admin\",\"password\":\"admin\"},{\"title\":\"TitleB\",\"tags\":[\"tag1\",\"tag3\"],\"region\":\"DE\",\"host\":\"192.168.88.1\",\"port\":22,\"username\":\"admin\",\"password\":\"admin\"}]"
+        "MIKROTIK_INVENTORY_FILE": "/etc/mikrotik/inventory.yaml"
       }
     }
   }
 }
 ```
 
-A file keeps the config readable and the secrets out of the client config:
+A file keeps the config readable and the secrets out of the client config.
+
+### Inline, without a file
+
+To skip the file entirely, put the inventory itself in `MIKROTIK_INVENTORY`.
+Environment values are single strings, so a nested object cannot appear under
+`env` directly — but YAML's inline (flow) syntax gives the same structure with
+no escaped quotes:
 
 ```json
-{ "env": { "MIKROTIK_INVENTORY_FILE": "/etc/mikrotik/inventory.json" } }
-```
-
-```json
-[
-  {
-    "title": "TitleA",
-    "tags": ["tag1", "tag2"],
-    "region": "NL",
-    "host": "127.0.0.1",
-    "port": 22,
-    "username": "admin",
-    "password": "admin"
-  },
-  {
-    "title": "TitleB",
-    "tags": ["tag1", "tag3"],
-    "region": "DE",
-    "host": "192.168.88.1",
-    "port": 22,
-    "username": "admin",
-    "key_filename": "/keys/id_ed25519"
+{
+  "mcpServers": {
+    "mikrotik-mcp-server": {
+      "command": "python",
+      "args": ["-m", "mcp_mikrotik.server"],
+      "env": {
+        "MIKROTIK_INVENTORY": "[{title: TitleA, host: 127.0.0.1, username: admin, password: admin, region: NL, tags: [tag1]}, {title: TitleB, host: 192.168.88.1, username: admin, region: DE}]"
+      }
+    }
   }
-]
+}
 ```
+
+JSON is a subset of YAML, so a plain JSON array (quotes escaped) is accepted
+here too — existing configs keep working unchanged.
 
 ### Device fields
 
@@ -73,8 +100,8 @@ A file keeps the config readable and the secrets out of the client config:
 | `username` | no | default `admin` |
 | `password` | no | omit when using `key_filename` |
 | `key_filename` | no | path to an SSH private key (preferred over a password) |
-| `tags` | no | free-form labels, e.g. `["branch", "eu"]` |
-| `region` | no | free-form label, e.g. `"NL"` |
+| `tags` | no | free-form labels, e.g. `[branch, eu]` |
+| `region` | no | free-form label, e.g. `NL` |
 
 ## Selecting a device
 
@@ -102,27 +129,50 @@ list_devices()
 
 ## Docker
 
-The image accepts the same two variables, and ships a `/config` directory to
-mount the inventory into:
+When running the image, the inventory YAML file **must be mounted into the
+container as a volume** — the file lives on your host, and the container can
+only see what is mounted in. The image ships `/config` as the mount point:
 
 ```bash
 docker run --rm -i \
-  -v "$PWD/inventory.json:/config/inventory.json:ro" \
-  -e MIKROTIK_INVENTORY_FILE=/config/inventory.json \
+  -v "$PWD/inventory.yaml:/config/inventory.yaml:ro" \
+  -e MIKROTIK_INVENTORY_FILE=/config/inventory.yaml \
   ghcr.io/jeff-nasseri/mikrotik-mcp:latest
 ```
 
-The entrypoint also takes `--inventory '<json>'` and `--inventory-file <path>`.
+Or with Compose:
 
-A mounted file is preferable to `MIKROTIK_INVENTORY`: environment values are
-visible in `docker inspect`, file contents are not. The container runs as **uid
-1000** (`mcpuser`), so the file must be readable by that uid; if it isn't, the
-entrypoint stops with an explicit message instead of starting with no devices.
+```yaml
+services:
+  mikrotik-mcp:
+    image: ghcr.io/jeff-nasseri/mikrotik-mcp:latest
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./inventory.yaml:/config/inventory.yaml:ro
+    environment:
+      MIKROTIK_INVENTORY_FILE: "/config/inventory.yaml"
+      MIKROTIK_MCP__TRANSPORT: "streamable-http"
+```
+
+The entrypoint also takes `--inventory '<yaml>'` and `--inventory-file <path>`.
+
+A mounted file is preferable to inline `MIKROTIK_INVENTORY`: environment values
+are visible in `docker inspect`, file contents are not. Two traps the
+entrypoint catches with an explicit error instead of starting a broken server:
+
+- The container runs as **uid 1000** (`mcpuser`), so the mounted file must be
+  readable by that uid — `chmod 644 inventory.yaml` is usually enough.
+- If the host file does not exist when the container starts, Docker silently
+  creates a **directory** at both ends of the mount. Create the YAML file
+  before `docker run` / `docker compose up`.
 
 When an inventory is configured it wins, so `MIKROTIK_HOST` / `MIKROTIK_USERNAME`
 / `MIKROTIK_PASSWORD` / `MIKROTIK_PORT` are ignored and can be dropped.
 
-See [Installation](../../getting-started/installation.md) for a Compose example.
+See [Installation](../../getting-started/installation.md) for the full Docker
+setup.
 
 ## Connections are per command
 
@@ -169,7 +219,11 @@ python tests/smoke_multi_device.py
 ## Security
 
 Credentials live in the inventory, so the whole inventory is a secret. Prefer
-`key_filename` over `password`, keep the JSON in a file with restricted
+`key_filename` over `password`, keep the YAML in a file with restricted
 permissions rather than inline in a client config, and remember that values
 passed as environment variables are visible via `docker inspect` — see
 [SECURITY.md](../../../SECURITY.md).
+
+Validation errors never echo the inventory's contents back: a malformed entry
+is reported by position and field name only, so a typo cannot leak a password
+into a log line or a tool result.

--- a/inventory.example.yml
+++ b/inventory.example.yml
@@ -1,0 +1,35 @@
+# MikroTik MCP inventory — example
+#
+# Copy this file, edit it for your fleet, and point the server at it:
+#
+#   MIKROTIK_INVENTORY_FILE=/path/to/inventory.yml
+#
+# Docker (the image ships /config as the mount point):
+#
+#   docker run --rm -i \
+#     -v "$PWD/inventory.yml:/config/inventory.yml:ro" \
+#     -e MIKROTIK_INVENTORY_FILE=/config/inventory.yml \
+#     ghcr.io/jeff-nasseri/mikrotik-mcp:latest
+#
+# Each entry is one device. `title` is the identifier the LLM passes as the
+# `device` argument of every tool; it must be unique (matching is
+# case-insensitive). `host` is the only other required field.
+#
+# This file holds credentials — treat the whole file as a secret:
+# restrict its permissions (chmod 600), keep it out of version control,
+# and prefer `key_filename` over `password` where you can.
+
+- title: TitleA                 # required, unique — used as the `device` argument
+  host: 192.168.88.1            # required — IP or hostname
+  port: 22                      # optional, default 22
+  username: admin               # optional, default admin
+  password: change-me           # optional — omit when using key_filename
+  tags: [branch, eu]            # optional, free-form labels
+  region: NL                    # optional, free-form label
+
+- title: TitleB
+  host: 192.168.89.1
+  username: admin
+  key_filename: /config/keys/id_ed25519   # SSH private key, preferred over a password
+  tags: [datacenter]
+  region: DE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "paramiko>=3.5.1",
     "pydantic>=2.11.4",
     "pydantic-settings>=2.9.1",
+    "PyYAML>=6.0",
     "starlette>=0.27.0",
 ]
 

--- a/routeros-docker/docker-compose.yml
+++ b/routeros-docker/docker-compose.yml
@@ -1,15 +1,22 @@
+# Two RouterOS instances so multi-device (inventory) support can be exercised
+# end to end:
+#
+#   routeros-a  ->  SSH on host port 2222   (inventory title: RouterA)
+#   routeros-b  ->  SSH on host port 2223   (inventory title: RouterB)
+#
+# Both boot inside QEMU and take ~2 minutes to become healthy.
 services:
-  routeros:
+  routeros-a:
     image: ${ROUTEROS_IMAGE:-evilfreelancer/docker-routeros:latest}
-    container_name: ${CONTAINER_NAME:-routeros}
-    hostname: ${HOSTNAME:-routeros}
+    container_name: ${CONTAINER_NAME_A:-routeros-a}
+    hostname: ${HOSTNAME_A:-routeros-a}
     privileged: true
     restart: ${RESTART_POLICY:-unless-stopped}
     platform: ${PLATFORM:-linux/amd64}
 
     # Healthcheck: with eth1 present, QEMU enables hostfwd so 127.0.0.1:8728 is valid
     healthcheck:
-      test: ["CMD-SHELL", "nc -z 127.0.0.1 ${API_PORT:-8728} || exit 1"]
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 8728 || exit 1"]
       interval: 15s
       timeout: 5s
       retries: 40        # ~10 minutes max
@@ -21,28 +28,76 @@ services:
       ROUTEROS_LICENSE: ${ROUTEROS_LICENSE:-true}
 
     ports:
-      - "${WINBOX_PORT:-8291}:8291"
-      - "${API_PORT:-8728}:8728"
-      - "${API_SSL_PORT:-8729}:8729"
-      - "${FTP_PORT:-21}:21"
-      - "${SSH_PORT:-2222}:22"
-      - "${TELNET_PORT:-23}:23"
-      - "${HTTP_PORT:-80}:80"
-      - "${HTTPS_PORT:-443}:443"
-      - "${HTTP_PROXY_PORT:-8080}:8080"
-      - "${OPENVPN_PORT:-1194}:1194"
+      - "${WINBOX_PORT_A:-8291}:8291"
+      - "${API_PORT_A:-8728}:8728"
+      - "${API_SSL_PORT_A:-8729}:8729"
+      - "${FTP_PORT_A:-21}:21"
+      - "${SSH_PORT_A:-2222}:22"
+      - "${TELNET_PORT_A:-23}:23"
+      - "${HTTP_PORT_A:-80}:80"
+      - "${HTTPS_PORT_A:-443}:443"
+      - "${HTTP_PROXY_PORT_A:-8080}:8080"
+      - "${OPENVPN_PORT_A:-1194}:1194"
 
     networks:
       # Primary network: eth0 — Docker port mappings use this IP
       routeros-net:
-        ipv4_address: ${ROUTEROS_IP:-172.20.0.2}
+        ipv4_address: ${ROUTEROS_IP_A:-172.20.0.2}
       # Secondary network: eth1 — entrypoint uses this for the bridge so eth0
       # keeps its IP and QEMU enables user-mode hostfwd for the health check
       routeros-wan-net:
-        ipv4_address: ${ROUTEROS_WAN_IP:-172.21.0.2}
+        ipv4_address: ${ROUTEROS_WAN_IP_A:-172.21.0.2}
 
     volumes:
-      - ${VOLUME_NAME:-routeros-data}:/routeros
+      - ${VOLUME_NAME_A:-routeros-data-a}:/routeros
+
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+
+    devices:
+      - /dev/net/tun
+
+  routeros-b:
+    image: ${ROUTEROS_IMAGE:-evilfreelancer/docker-routeros:latest}
+    container_name: ${CONTAINER_NAME_B:-routeros-b}
+    hostname: ${HOSTNAME_B:-routeros-b}
+    privileged: true
+    restart: ${RESTART_POLICY:-unless-stopped}
+    platform: ${PLATFORM:-linux/amd64}
+
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 8728 || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 40
+      start_period: 120s
+
+    environment:
+      ROUTEROS_USER: ${ROUTEROS_USER:-admin}
+      ROUTEROS_PASS: ${ROUTEROS_PASS:-admin}
+      ROUTEROS_LICENSE: ${ROUTEROS_LICENSE:-true}
+
+    ports:
+      - "${WINBOX_PORT_B:-8292}:8291"
+      - "${API_PORT_B:-8738}:8728"
+      - "${API_SSL_PORT_B:-8739}:8729"
+      - "${FTP_PORT_B:-2121}:21"
+      - "${SSH_PORT_B:-2223}:22"
+      - "${TELNET_PORT_B:-2323}:23"
+      - "${HTTP_PORT_B:-8081}:80"
+      - "${HTTPS_PORT_B:-4443}:443"
+      - "${HTTP_PROXY_PORT_B:-8098}:8080"
+      - "${OPENVPN_PORT_B:-1195}:1194"
+
+    networks:
+      routeros-net:
+        ipv4_address: ${ROUTEROS_IP_B:-172.20.0.3}
+      routeros-wan-net:
+        ipv4_address: ${ROUTEROS_WAN_IP_B:-172.21.0.3}
+
+    volumes:
+      - ${VOLUME_NAME_B:-routeros-data-b}:/routeros
 
     cap_add:
       - NET_ADMIN
@@ -66,5 +121,7 @@ networks:
           gateway: ${WAN_NETWORK_GATEWAY:-172.21.0.1}
 
 volumes:
-  routeros-data:
+  routeros-data-a:
+    driver: local
+  routeros-data-b:
     driver: local

--- a/src/mcp_mikrotik/app.py
+++ b/src/mcp_mikrotik/app.py
@@ -22,4 +22,5 @@ async def health_check(request: Request) -> Response:
 from mcp_mikrotik.scope import (  # noqa: F401, E402
     backup, dhcp, dns, firewall_filter, firewall_nat,
     ip_address, ip_pool, logs, queue, safe_mode, routes, users, vlan, wireless, wireguard,
+    fleet,
 )

--- a/src/mcp_mikrotik/app.py
+++ b/src/mcp_mikrotik/app.py
@@ -3,7 +3,17 @@ from mcp.types import ToolAnnotations
 from starlette.requests import Request
 from starlette.responses import Response
 
-mcp = MCPServer("mcp-mikrotik")
+# Sent once, in the initialize response, instead of being repeated in all 173
+# tool descriptions — the same guidance costs ~60 tokens here rather than ~4k.
+INSTRUCTIONS = (
+    "This server manages one or more MikroTik devices. Every tool accepts an "
+    "optional `device` argument: the title of the target device, as listed by "
+    "`list_devices`. Omit it when a single device is configured; when several "
+    "are, it is required. Titles match case-insensitively, and an omitted or "
+    "unknown device returns an error naming the valid titles."
+)
+
+mcp = MCPServer("mcp-mikrotik", instructions=INSTRUCTIONS)
 
 # ── Behaviour presets ──────────────────────────────────────────────────────
 # These capture the *risk profile* of a tool (MCP spec §Tool Annotations).

--- a/src/mcp_mikrotik/app.py
+++ b/src/mcp_mikrotik/app.py
@@ -47,5 +47,5 @@ async def health_check(request: Request) -> Response:
 # Import scope modules to trigger @mcp.tool() registration
 from mcp_mikrotik.scope import (  # noqa: F401, E402
     backup, dhcp, dns, firewall_filter, firewall_nat,
-    interfaces, ip_address, ipv6_address, ip_pool, logs, poe, queue, safe_mode, routes, users, vlan, wireless, wireguard,
+    interfaces, inventory, ip_address, ipv6_address, ip_pool, logs, poe, queue, safe_mode, routes, users, vlan, wireless, wireguard,
 )

--- a/src/mcp_mikrotik/config.py
+++ b/src/mcp_mikrotik/config.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional
+from typing import List, Literal, Optional
 
 from pydantic import BaseModel
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -10,6 +10,18 @@ class McpServerSettings(BaseModel):
     port: int = 8000
 
 
+class DeviceConfig(BaseModel):
+    """Represents a single MikroTik device in the fleet inventory."""
+
+    name: str
+    host: str
+    username: str = "admin"
+    password: str = ""
+    port: int = 22
+    key_filename: Optional[str] = None
+    tags: List[str] = []
+
+
 class MikrotikConfig(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="MIKROTIK_",
@@ -19,12 +31,18 @@ class MikrotikConfig(BaseSettings):
         cli_kebab_case=True,
     )
 
+    # Single-device config (backward-compatible default)
     host: str = "127.0.0.1"
     username: str = "admin"
     password: str = ""
     port: int = 22
     key_filename: Optional[str] = None
     mcp: McpServerSettings = McpServerSettings()
+
+    # Multi-device fleet inventory.
+    # Set via MIKROTIK_DEVICES as a JSON array, e.g.:
+    #   MIKROTIK_DEVICES='[{"name":"mt-nl-1","host":"1.1.1.1","tags":["nl","eu"]}]'
+    devices: List[DeviceConfig] = []
 
 
 mikrotik_config = MikrotikConfig()

--- a/src/mcp_mikrotik/config.py
+++ b/src/mcp_mikrotik/config.py
@@ -1,6 +1,7 @@
-from typing import Literal, Optional
+import json
+from typing import List, Literal, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -19,6 +20,30 @@ class McpServerSettings(BaseModel):
     allowed_origins: str = ""
 
 
+class DeviceConfig(BaseModel):
+    """A single MikroTik device in the inventory.
+
+    ``title`` is the identifier the LLM uses to target this device; it must be
+    unique across the inventory.
+    """
+
+    title: str
+    host: str
+    port: int = 22
+    username: str = "admin"
+    password: str = ""
+    key_filename: Optional[str] = None
+    tags: List[str] = []
+    region: Optional[str] = None
+
+    @field_validator("title")
+    @classmethod
+    def _title_not_blank(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("device 'title' must be a non-empty string")
+        return v.strip()
+
+
 class MikrotikConfig(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="MIKROTIK_",
@@ -28,12 +53,44 @@ class MikrotikConfig(BaseSettings):
         cli_kebab_case=True,
     )
 
+    # ── Single-device settings (unchanged; still the default) ───────────────
     host: str = "127.0.0.1"
     username: str = "admin"
     password: str = ""
     port: int = 22
     key_filename: Optional[str] = None
     mcp: McpServerSettings = McpServerSettings()
+
+    # ── Multi-device inventory ─────────────────────────────────────────────
+    # Supplied as a JSON array, either inline or from a file:
+    #
+    #   MIKROTIK_INVENTORY='[{"title":"TitleA","host":"10.0.0.1","tags":["eu"],
+    #                         "region":"NL","username":"admin","password":"..."}]'
+    #   MIKROTIK_INVENTORY_FILE=/etc/mikrotik/inventory.json
+    #
+    # In an MCP client config these belong in the server's "env" block — that is
+    # the channel a client actually forwards to the spawned process.
+    #
+    # When left empty, a single-device inventory is synthesised from the flat
+    # settings above, so existing single-device setups keep working unchanged.
+    inventory: List[DeviceConfig] = []
+    inventory_file: Optional[str] = None
+
+    @field_validator("inventory", mode="before")
+    @classmethod
+    def _parse_inventory(cls, v):
+        """Accept a JSON string (env var) as well as a real list."""
+        if isinstance(v, str):
+            v = v.strip()
+            if not v:
+                return []
+            try:
+                v = json.loads(v)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"MIKROTIK_INVENTORY is not valid JSON: {exc}") from exc
+        if isinstance(v, dict):
+            v = [v]
+        return v
 
 
 mikrotik_config = MikrotikConfig()

--- a/src/mcp_mikrotik/config.py
+++ b/src/mcp_mikrotik/config.py
@@ -1,8 +1,8 @@
-import json
-from typing import List, Literal, Optional
+from typing import Annotated, List, Literal, Optional
 
-from pydantic import BaseModel, field_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+import yaml
+from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 
 class McpServerSettings(BaseModel):
@@ -26,6 +26,10 @@ class DeviceConfig(BaseModel):
     ``title`` is the identifier the LLM uses to target this device; it must be
     unique across the inventory.
     """
+
+    # The inventory carries credentials, so validation errors must never echo
+    # the offending input back — they end up in tool results and logs.
+    model_config = ConfigDict(hide_input_in_errors=True)
 
     title: str
     host: str
@@ -51,6 +55,9 @@ class MikrotikConfig(BaseSettings):
         nested_model_default_partial_update=True,
         cli_prog_name="mcp-server-mikrotik",
         cli_kebab_case=True,
+        # The inventory value carries credentials; validation errors must not
+        # echo the offending input into logs or tool results.
+        hide_input_in_errors=True,
     )
 
     # ── Single-device settings (unchanged; still the default) ───────────────
@@ -62,32 +69,42 @@ class MikrotikConfig(BaseSettings):
     mcp: McpServerSettings = McpServerSettings()
 
     # ── Multi-device inventory ─────────────────────────────────────────────
-    # Supplied as a JSON array, either inline or from a file:
+    # A list of devices, written in YAML. JSON is a subset of YAML, so a JSON
+    # array works everywhere YAML does. Two sources, inline winning over file:
     #
-    #   MIKROTIK_INVENTORY='[{"title":"TitleA","host":"10.0.0.1","tags":["eu"],
-    #                         "region":"NL","username":"admin","password":"..."}]'
-    #   MIKROTIK_INVENTORY_FILE=/etc/mikrotik/inventory.json
+    #   MIKROTIK_INVENTORY='[{title: TitleA, host: 10.0.0.1, region: NL}]'
+    #   MIKROTIK_INVENTORY_FILE=/config/inventory.yaml
     #
-    # In an MCP client config these belong in the server's "env" block — that is
-    # the channel a client actually forwards to the spawned process.
+    # YAML flow syntax keeps the inline form free of escaped quotes inside an
+    # MCP client's JSON config. These belong in the server's "env" block — that
+    # is the channel a client actually forwards to the spawned process.
     #
     # When left empty, a single-device inventory is synthesised from the flat
     # settings above, so existing single-device setups keep working unchanged.
-    inventory: List[DeviceConfig] = []
+    #
+    # NoDecode stops pydantic-settings from JSON-decoding the env value itself,
+    # so the raw string reaches the validator and YAML can be accepted.
+    inventory: Annotated[List[DeviceConfig], NoDecode] = []
     inventory_file: Optional[str] = None
 
     @field_validator("inventory", mode="before")
     @classmethod
     def _parse_inventory(cls, v):
-        """Accept a JSON string (env var) as well as a real list."""
+        """Accept a YAML/JSON string (env var) as well as a real list."""
         if isinstance(v, str):
             v = v.strip()
             if not v:
                 return []
             try:
-                v = json.loads(v)
-            except json.JSONDecodeError as exc:
-                raise ValueError(f"MIKROTIK_INVENTORY is not valid JSON: {exc}") from exc
+                v = yaml.safe_load(v)
+            except yaml.YAMLError as exc:
+                # Report the position only — the value holds credentials and
+                # must not be echoed back into logs or tool results.
+                mark = getattr(exc, "problem_mark", None)
+                where = f" (line {mark.line + 1}, column {mark.column + 1})" if mark else ""
+                raise ValueError(
+                    f"MIKROTIK_INVENTORY is not valid YAML/JSON{where}"
+                ) from exc
         if isinstance(v, dict):
             v = [v]
         return v

--- a/src/mcp_mikrotik/config.py
+++ b/src/mcp_mikrotik/config.py
@@ -1,3 +1,4 @@
+import json
 from typing import Annotated, List, Literal, Optional
 
 import yaml
@@ -95,16 +96,25 @@ class MikrotikConfig(BaseSettings):
             v = v.strip()
             if not v:
                 return []
+            # JSON first: PyYAML's scanner rejects tab whitespace, which is
+            # legal in JSON, so yaml.safe_load alone would break previously
+            # working tab-indented JSON inventories.
             try:
-                v = yaml.safe_load(v)
-            except yaml.YAMLError as exc:
-                # Report the position only — the value holds credentials and
-                # must not be echoed back into logs or tool results.
-                mark = getattr(exc, "problem_mark", None)
-                where = f" (line {mark.line + 1}, column {mark.column + 1})" if mark else ""
-                raise ValueError(
-                    f"MIKROTIK_INVENTORY is not valid YAML/JSON{where}"
-                ) from exc
+                v = json.loads(v)
+            except json.JSONDecodeError:
+                try:
+                    v = yaml.safe_load(v)
+                except yaml.YAMLError as exc:
+                    # Report the position only — the value holds credentials
+                    # and must not be echoed into logs or tool results.
+                    mark = getattr(exc, "problem_mark", None)
+                    where = (
+                        f" (line {mark.line + 1}, column {mark.column + 1})"
+                        if mark else ""
+                    )
+                    raise ValueError(
+                        f"MIKROTIK_INVENTORY is not valid YAML/JSON{where}"
+                    ) from exc
         if isinstance(v, dict):
             v = [v]
         return v

--- a/src/mcp_mikrotik/connector.py
+++ b/src/mcp_mikrotik/connector.py
@@ -1,10 +1,14 @@
 import asyncio
 import logging
+from typing import TYPE_CHECKING
 
 from mcp.server.fastmcp import Context
 
 from . import config
 from .mikrotik_ssh_client import MikroTikSSHClient
+
+if TYPE_CHECKING:
+    from .config import DeviceConfig
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +40,33 @@ def _execute_sync(command: str) -> str:
         ssh_client.disconnect()
 
 
+def _execute_sync_on_device(device: "DeviceConfig", command: str) -> str:
+    """Execute *command* on a specific device (blocking, for use with asyncio.to_thread)."""
+    logger.info(f"Executing on {device.name} ({device.host}): {command}")
+
+    ssh_client = MikroTikSSHClient(
+        host=device.host,
+        username=device.username,
+        password=device.password,
+        key_filename=device.key_filename,
+        port=device.port,
+    )
+
+    try:
+        if not ssh_client.connect():
+            return f"Error: Failed to connect to {device.host}"
+
+        result = ssh_client.execute_command(command)
+        logger.info(f"[{device.name}] result: {repr(result)}")
+        return result
+    except Exception as e:
+        error_msg = f"Error: {str(e)}"
+        logger.error(f"[{device.name}] {error_msg}")
+        return error_msg
+    finally:
+        ssh_client.disconnect()
+
+
 async def execute_mikrotik_command(command: str, ctx: Context) -> str:
     """Execute a MikroTik command via SSH and return the output.
 
@@ -56,6 +87,20 @@ async def execute_mikrotik_command(command: str, ctx: Context) -> str:
         result = await asyncio.to_thread(_execute_sync, command)
 
     logger.info(f"Command result: {repr(result)}")
+    if result.startswith("Error"):
+        await ctx.error(result)
+    return result
+
+
+async def execute_command_on_device(device: "DeviceConfig", command: str, ctx: Context) -> str:
+    """Execute *command* on a specific fleet device and return the output.
+
+    Unlike ``execute_mikrotik_command`` this function bypasses the global
+    single-device config and the Safe Mode manager — it always uses a fresh
+    SSH connection to the given *device*.
+    """
+    await ctx.info(f"Executing on {device.name} ({device.host}): {command}")
+    result = await asyncio.to_thread(_execute_sync_on_device, device, command)
     if result.startswith("Error"):
         await ctx.error(result)
     return result

--- a/src/mcp_mikrotik/connector.py
+++ b/src/mcp_mikrotik/connector.py
@@ -10,13 +10,18 @@ logger = logging.getLogger(__name__)
 
 
 def _execute_sync(command: str, device: Optional[str] = None) -> str:
-    """Execute a MikroTik command over the target device's SSH client (blocking)."""
+    """Execute a MikroTik command over a fresh SSH connection (blocking).
+
+    Each call opens its own connection and closes it again, so concurrent
+    sessions never share a client.
+    """
     inventory = get_inventory()
     target = inventory.resolve(device)
     logger.info(f"Executing MikroTik command on '{target.title}': {command}")
 
-    client = inventory.get_client(device)
-    result = client.execute_command(command)
+    with inventory.session(target.title) as client:
+        result = client.execute_command(command)
+
     logger.info(f"Command result: {repr(result)}")
     return result
 
@@ -26,7 +31,9 @@ def download_file_sync(filename: str, device: Optional[str] = None) -> bytes:
     inventory = get_inventory()
     target = inventory.resolve(device)
     logger.info(f"Downloading file from '{target.title}': {filename}")
-    return inventory.get_client(device).download_file(filename)
+
+    with inventory.session(target.title) as client:
+        return client.download_file(filename)
 
 
 def upload_file_sync(filename: str, data: bytes, device: Optional[str] = None) -> None:
@@ -34,7 +41,9 @@ def upload_file_sync(filename: str, data: bytes, device: Optional[str] = None) -
     inventory = get_inventory()
     target = inventory.resolve(device)
     logger.info(f"Uploading file to '{target.title}': {filename} ({len(data)} bytes)")
-    inventory.get_client(device).upload_file(filename, data)
+
+    with inventory.session(target.title) as client:
+        client.upload_file(filename, data)
 
 
 async def execute_mikrotik_command(

--- a/src/mcp_mikrotik/connector.py
+++ b/src/mcp_mikrotik/connector.py
@@ -1,99 +1,80 @@
 import asyncio
 import logging
+from typing import Optional
 
 from mcp.server.mcpserver import Context
 
-from . import config
-from .mikrotik_ssh_client import MikroTikSSHClient
+from .inventory import DeviceNotFoundError, get_inventory
 
 logger = logging.getLogger(__name__)
 
 
-def _execute_sync(command: str) -> str:
-    """Execute a MikroTik command via SSH and return the output (blocking)."""
-    logger.info(f"Executing MikroTik command: {command}")
+def _execute_sync(command: str, device: Optional[str] = None) -> str:
+    """Execute a MikroTik command over the target device's SSH client (blocking)."""
+    inventory = get_inventory()
+    target = inventory.resolve(device)
+    logger.info(f"Executing MikroTik command on '{target.title}': {command}")
 
-    ssh_client = MikroTikSSHClient(
-        host=config.mikrotik_config.host,
-        username=config.mikrotik_config.username,
-        password=config.mikrotik_config.password,
-        key_filename=config.mikrotik_config.key_filename,
-        port=config.mikrotik_config.port
-    )
-
-    try:
-        if not ssh_client.connect():
-            return "Error: Failed to connect to MikroTik device"
-
-        result = ssh_client.execute_command(command)
-        logger.info(f"Command result: {repr(result)}")
-        return result
-    except Exception as e:
-        error_msg = f"Error executing command: {str(e)}"
-        logger.error(error_msg)
-        return error_msg
-    finally:
-        ssh_client.disconnect()
+    client = inventory.get_client(device)
+    result = client.execute_command(command)
+    logger.info(f"Command result: {repr(result)}")
+    return result
 
 
-def download_file_sync(filename: str) -> bytes:
-    """Download a file from the MikroTik device over SFTP and return its bytes (blocking)."""
-    logger.info(f"Downloading MikroTik file: {filename}")
-
-    ssh_client = MikroTikSSHClient(
-        host=config.mikrotik_config.host,
-        username=config.mikrotik_config.username,
-        password=config.mikrotik_config.password,
-        key_filename=config.mikrotik_config.key_filename,
-        port=config.mikrotik_config.port
-    )
-
-    try:
-        if not ssh_client.connect():
-            raise ConnectionError("Failed to connect to MikroTik device")
-        return ssh_client.download_file(filename)
-    finally:
-        ssh_client.disconnect()
+def download_file_sync(filename: str, device: Optional[str] = None) -> bytes:
+    """Download a file from the target device over SFTP and return its bytes."""
+    inventory = get_inventory()
+    target = inventory.resolve(device)
+    logger.info(f"Downloading file from '{target.title}': {filename}")
+    return inventory.get_client(device).download_file(filename)
 
 
-def upload_file_sync(filename: str, data: bytes) -> None:
-    """Upload bytes to a file on the MikroTik device over SFTP (blocking)."""
-    logger.info(f"Uploading MikroTik file: {filename} ({len(data)} bytes)")
-
-    ssh_client = MikroTikSSHClient(
-        host=config.mikrotik_config.host,
-        username=config.mikrotik_config.username,
-        password=config.mikrotik_config.password,
-        key_filename=config.mikrotik_config.key_filename,
-        port=config.mikrotik_config.port
-    )
-
-    try:
-        if not ssh_client.connect():
-            raise ConnectionError("Failed to connect to MikroTik device")
-        ssh_client.upload_file(filename, data)
-    finally:
-        ssh_client.disconnect()
+def upload_file_sync(filename: str, data: bytes, device: Optional[str] = None) -> None:
+    """Upload bytes to a file on the target device over SFTP."""
+    inventory = get_inventory()
+    target = inventory.resolve(device)
+    logger.info(f"Uploading file to '{target.title}': {filename} ({len(data)} bytes)")
+    inventory.get_client(device).upload_file(filename, data)
 
 
-async def execute_mikrotik_command(command: str, ctx: Context) -> str:
-    """Execute a MikroTik command via SSH and return the output.
+async def execute_mikrotik_command(
+    command: str, ctx: Context, device: Optional[str] = None
+) -> str:
+    """Execute a MikroTik command on the selected device and return the output.
 
-    When Safe Mode is active the command is routed through the persistent
-    interactive shell session so it runs inside the safe-mode context.
+    ``device`` is the inventory title of the target. It may be omitted when the
+    inventory holds exactly one device.
+
+    When Safe Mode is active *for that device* the command is routed through
+    that device's persistent interactive shell so it runs inside the safe-mode
+    context.
     """
     from .safe_mode import get_safe_mode_manager
 
-    safe_mgr = get_safe_mode_manager()
+    # Resolve the target first so a bad/missing device is reported clearly and
+    # never silently executed somewhere else.
+    try:
+        target = get_inventory().resolve(device)
+    except DeviceNotFoundError as exc:
+        msg = f"Error: {exc}"
+        await ctx.error(msg)
+        return msg
+
+    safe_mgr = get_safe_mode_manager(target.title)
     if safe_mgr.is_active:
-        await ctx.info(f"Executing (safe mode): {command}")
+        await ctx.info(f"Executing on '{target.title}' (safe mode): {command}")
         try:
             result = await asyncio.to_thread(safe_mgr.execute, command)
         except Exception as e:
             result = f"Error executing command in safe mode session: {str(e)}"
     else:
-        await ctx.info(f"Executing MikroTik command: {command}")
-        result = await asyncio.to_thread(_execute_sync, command)
+        await ctx.info(f"Executing on '{target.title}': {command}")
+        try:
+            result = await asyncio.to_thread(_execute_sync, command, target.title)
+        except ConnectionError as e:
+            result = f"Error: {str(e)}"
+        except Exception as e:
+            result = f"Error executing command: {str(e)}"
 
     logger.info(f"Command result: {repr(result)}")
     if result.startswith("Error"):

--- a/src/mcp_mikrotik/inventory.py
+++ b/src/mcp_mikrotik/inventory.py
@@ -1,0 +1,63 @@
+import threading
+from typing import Dict, List, Optional
+
+from .config import DeviceConfig, mikrotik_config
+
+
+class DeviceInventory:
+    """Registry of MikroTik devices loaded from configuration.
+
+    Devices are keyed by their ``name`` field so lookups are O(1).
+    Tag-based queries scan the full list but the fleet is expected to be small
+    (tens of devices), so no secondary index is needed.
+    """
+
+    def __init__(self, devices: List[DeviceConfig]) -> None:
+        self._devices: Dict[str, DeviceConfig] = {d.name: d for d in devices}
+
+    # ------------------------------------------------------------------
+    # Queries
+    # ------------------------------------------------------------------
+
+    def get_device(self, name: str) -> Optional[DeviceConfig]:
+        """Return the device with the given name, or ``None``."""
+        return self._devices.get(name)
+
+    def get_devices_by_tag(self, tag: str) -> List[DeviceConfig]:
+        """Return all devices that carry *tag*."""
+        return [d for d in self._devices.values() if tag in d.tags]
+
+    def get_all_devices(self) -> List[DeviceConfig]:
+        """Return every device in the inventory."""
+        return list(self._devices.values())
+
+    def count(self) -> int:
+        return len(self._devices)
+
+    def list_names(self) -> List[str]:
+        return list(self._devices.keys())
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton (loaded once from mikrotik_config at import time)
+# ---------------------------------------------------------------------------
+
+_inventory: Optional[DeviceInventory] = None
+_inventory_lock = threading.Lock()
+
+
+def get_inventory() -> DeviceInventory:
+    """Return the global DeviceInventory singleton, creating it on first call."""
+    global _inventory
+    if _inventory is None:
+        with _inventory_lock:
+            if _inventory is None:
+                _inventory = DeviceInventory(mikrotik_config.devices)
+    return _inventory
+
+
+def reset_inventory() -> None:
+    """Discard the cached singleton — intended for tests only."""
+    global _inventory
+    with _inventory_lock:
+        _inventory = None

--- a/src/mcp_mikrotik/inventory.py
+++ b/src/mcp_mikrotik/inventory.py
@@ -12,6 +12,7 @@ disconnecting, timing out or failing to authenticate cannot disturb a command
 another session is running against the same device.
 """
 
+import json
 import logging
 import os
 import threading
@@ -217,17 +218,28 @@ def _load_devices() -> List[DeviceConfig]:
         path = os.path.expanduser(cfg.inventory_file)
         try:
             with open(path, "r", encoding="utf-8") as fh:
-                raw = yaml.safe_load(fh)
+                text = fh.read()
         except OSError as exc:
             raise ValueError(
                 f"Cannot read inventory file {path!r}: {exc.strerror or exc}"
             ) from exc
-        except yaml.YAMLError as exc:
-            mark = getattr(exc, "problem_mark", None)
-            where = f" (line {mark.line + 1}, column {mark.column + 1})" if mark else ""
-            raise ValueError(
-                f"Inventory file {path!r} is not valid YAML{where}"
-            ) from exc
+        # JSON first: PyYAML's scanner rejects tab whitespace, which is legal
+        # in JSON, so yaml.safe_load alone would break previously working
+        # tab-indented inventory.json files.
+        try:
+            raw = json.loads(text)
+        except json.JSONDecodeError:
+            try:
+                raw = yaml.safe_load(text)
+            except yaml.YAMLError as exc:
+                mark = getattr(exc, "problem_mark", None)
+                where = (
+                    f" (line {mark.line + 1}, column {mark.column + 1})"
+                    if mark else ""
+                )
+                raise ValueError(
+                    f"Inventory file {path!r} is not valid YAML{where}"
+                ) from exc
         return _validate_entries(raw, source=path)
 
     # Backwards-compatible single device.

--- a/src/mcp_mikrotik/inventory.py
+++ b/src/mcp_mikrotik/inventory.py
@@ -1,0 +1,221 @@
+"""Device inventory for multi-device (fleet) support — issue #44.
+
+The :class:`Inventory` owns the list of MikroTik devices and the
+``MikroTikSSHClient`` used to reach each one.  Tools pass a device ``title``
+down to the connector, which asks the inventory to resolve it to the matching
+client and runs the command over that client's SSH channel.
+
+Clients are created lazily (on first use for a device) rather than eagerly at
+start-up, so an unreachable device cannot block server start-up or wedge the
+whole inventory.
+"""
+
+import json
+import logging
+import os
+import threading
+from typing import Dict, List, Optional
+
+from . import config
+from .config import DeviceConfig
+from .mikrotik_ssh_client import MikroTikSSHClient
+
+logger = logging.getLogger(__name__)
+
+
+class DeviceNotFoundError(LookupError):
+    """Raised when a requested device title cannot be resolved."""
+
+
+class Inventory:
+    """Holds device definitions and their SSH clients, keyed by title."""
+
+    def __init__(self, devices: List[DeviceConfig]) -> None:
+        self._devices: Dict[str, DeviceConfig] = {}
+        self._clients: Dict[str, MikroTikSSHClient] = {}
+        self._lock = threading.Lock()
+
+        for device in devices:
+            key = device.title.casefold()
+            if key in self._devices:
+                raise ValueError(
+                    f"Duplicate device title {device.title!r} in inventory — "
+                    "titles must be unique."
+                )
+            self._devices[key] = device
+
+    # ── Introspection ──────────────────────────────────────────────────────
+
+    def __len__(self) -> int:
+        return len(self._devices)
+
+    @property
+    def titles(self) -> List[str]:
+        return [d.title for d in self._devices.values()]
+
+    def all_devices(self) -> List[DeviceConfig]:
+        return list(self._devices.values())
+
+    def describe(self) -> List[dict]:
+        """Device metadata for the LLM. Never includes credentials."""
+        return [
+            {
+                "title": d.title,
+                "host": d.host,
+                "port": d.port,
+                "username": d.username,
+                "tags": d.tags,
+                "region": d.region,
+            }
+            for d in self._devices.values()
+        ]
+
+    # ── Resolution ─────────────────────────────────────────────────────────
+
+    def resolve(self, title: Optional[str] = None) -> DeviceConfig:
+        """Resolve a device title to its definition.
+
+        With a single-device inventory the title may be omitted.  With more
+        than one device the title is required, and an unknown title raises
+        :class:`DeviceNotFoundError` listing the valid titles so the caller can
+        correct itself in one step.
+        """
+        if not self._devices:
+            raise DeviceNotFoundError(
+                "No MikroTik devices are configured. Set MIKROTIK_INVENTORY "
+                "(or the single-device MIKROTIK_HOST settings)."
+            )
+
+        if title is None or not str(title).strip():
+            if len(self._devices) == 1:
+                return next(iter(self._devices.values()))
+            raise DeviceNotFoundError(
+                "This server manages multiple MikroTik devices, so a device "
+                f"must be specified. Available devices: {', '.join(self.titles)}."
+            )
+
+        device = self._devices.get(str(title).strip().casefold())
+        if device is None:
+            raise DeviceNotFoundError(
+                f"Unknown device {title!r}. "
+                f"Available devices: {', '.join(self.titles)}."
+            )
+        return device
+
+    # ── SSH clients ────────────────────────────────────────────────────────
+
+    def get_client(self, title: Optional[str] = None) -> MikroTikSSHClient:
+        """Return a connected SSH client for the resolved device.
+
+        The client for each device is created once and reused.  A client whose
+        connection has dropped is rebuilt transparently on the next call.
+        """
+        device = self.resolve(title)
+        key = device.title.casefold()
+
+        with self._lock:
+            client = self._clients.get(key)
+            if client is not None and self._is_alive(client):
+                return client
+
+            if client is not None:
+                # Stale/broken session — drop it before rebuilding.
+                try:
+                    client.disconnect()
+                except Exception:
+                    pass
+                self._clients.pop(key, None)
+
+            client = MikroTikSSHClient(
+                host=device.host,
+                username=device.username,
+                password=device.password,
+                key_filename=device.key_filename,
+                port=device.port,
+            )
+            if not client.connect():
+                raise ConnectionError(
+                    f"Failed to connect to MikroTik device '{device.title}' "
+                    f"({device.host}:{device.port})"
+                )
+            self._clients[key] = client
+            logger.info(f"Opened SSH client for device '{device.title}'")
+            return client
+
+    @staticmethod
+    def _is_alive(client: MikroTikSSHClient) -> bool:
+        """True when the client's transport is still usable."""
+        try:
+            transport = client.client.get_transport() if client.client else None
+            return bool(transport and transport.is_active())
+        except Exception:
+            return False
+
+    def close(self) -> None:
+        """Disconnect every open client."""
+        with self._lock:
+            for title, client in self._clients.items():
+                try:
+                    client.disconnect()
+                except Exception:
+                    logger.debug(f"Error closing client for '{title}'", exc_info=True)
+            self._clients.clear()
+
+
+# ---------------------------------------------------------------------------
+# Module-level inventory
+# ---------------------------------------------------------------------------
+
+_inventory: Optional[Inventory] = None
+_inventory_lock = threading.Lock()
+
+
+def _load_devices() -> List[DeviceConfig]:
+    """Build the device list from configuration.
+
+    Precedence: ``inventory`` (inline JSON) > ``inventory_file`` > the flat
+    single-device settings.  The last case keeps every existing single-device
+    deployment working with no configuration change.
+    """
+    cfg = config.mikrotik_config
+
+    if cfg.inventory:
+        return list(cfg.inventory)
+
+    if cfg.inventory_file:
+        path = os.path.expanduser(cfg.inventory_file)
+        with open(path, "r", encoding="utf-8") as fh:
+            raw = json.load(fh)
+        if isinstance(raw, dict):
+            raw = raw.get("inventory", [raw])
+        return [DeviceConfig(**item) for item in raw]
+
+    # Backwards-compatible single device.
+    return [
+        DeviceConfig(
+            title=cfg.host,
+            host=cfg.host,
+            port=cfg.port,
+            username=cfg.username,
+            password=cfg.password,
+            key_filename=cfg.key_filename,
+        )
+    ]
+
+
+def get_inventory() -> Inventory:
+    global _inventory
+    if _inventory is None:
+        with _inventory_lock:
+            if _inventory is None:
+                _inventory = Inventory(_load_devices())
+    return _inventory
+
+
+def reset_inventory() -> None:
+    """Drop the cached inventory (used by tests and after config reloads)."""
+    global _inventory
+    with _inventory_lock:
+        if _inventory is not None:
+            _inventory.close()
+        _inventory = None

--- a/src/mcp_mikrotik/inventory.py
+++ b/src/mcp_mikrotik/inventory.py
@@ -12,12 +12,14 @@ disconnecting, timing out or failing to authenticate cannot disturb a command
 another session is running against the same device.
 """
 
-import json
 import logging
 import os
 import threading
 from contextlib import contextmanager
 from typing import Dict, Iterator, List, Optional
+
+import yaml
+from pydantic import ValidationError
 
 from . import config
 from .config import DeviceConfig
@@ -162,12 +164,49 @@ _inventory: Optional[Inventory] = None
 _inventory_lock = threading.Lock()
 
 
+def _validate_entries(raw, source: str) -> List[DeviceConfig]:
+    """Turn parsed YAML/JSON into DeviceConfigs with credential-safe errors.
+
+    A malformed entry must fail with the entry's position and the offending
+    field names only — the inventory holds passwords, and anything raised here
+    can end up verbatim in a tool result or a log line.
+    """
+    if isinstance(raw, dict):
+        raw = raw.get("inventory", [raw])
+    if not isinstance(raw, list):
+        raise ValueError(
+            f"{source}: the inventory must be a list of devices "
+            f"(got {type(raw).__name__})"
+        )
+
+    devices: List[DeviceConfig] = []
+    for index, item in enumerate(raw, start=1):
+        if not isinstance(item, dict):
+            raise ValueError(
+                f"{source}: device #{index} must be a mapping "
+                f"(got {type(item).__name__})"
+            )
+        try:
+            devices.append(DeviceConfig(**item))
+        except ValidationError as exc:
+            problems = "; ".join(
+                f"{'.'.join(str(p) for p in err['loc']) or 'entry'}: {err['msg']}"
+                for err in exc.errors()
+            )
+            label = item.get("title") or f"#{index}"
+            raise ValueError(
+                f"{source}: device {label!r} is invalid — {problems}"
+            ) from None
+    return devices
+
+
 def _load_devices() -> List[DeviceConfig]:
     """Build the device list from configuration.
 
-    Precedence: ``inventory`` (inline JSON) > ``inventory_file`` > the flat
-    single-device settings.  The last case keeps every existing single-device
-    deployment working with no configuration change.
+    Precedence: inline ``MIKROTIK_INVENTORY`` (YAML, or its JSON subset) >
+    ``MIKROTIK_INVENTORY_FILE`` (a YAML file) > the flat single-device
+    settings.  The last case keeps every existing single-device deployment
+    working with no configuration change.
     """
     cfg = config.mikrotik_config
 
@@ -176,11 +215,20 @@ def _load_devices() -> List[DeviceConfig]:
 
     if cfg.inventory_file:
         path = os.path.expanduser(cfg.inventory_file)
-        with open(path, "r", encoding="utf-8") as fh:
-            raw = json.load(fh)
-        if isinstance(raw, dict):
-            raw = raw.get("inventory", [raw])
-        return [DeviceConfig(**item) for item in raw]
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                raw = yaml.safe_load(fh)
+        except OSError as exc:
+            raise ValueError(
+                f"Cannot read inventory file {path!r}: {exc.strerror or exc}"
+            ) from exc
+        except yaml.YAMLError as exc:
+            mark = getattr(exc, "problem_mark", None)
+            where = f" (line {mark.line + 1}, column {mark.column + 1})" if mark else ""
+            raise ValueError(
+                f"Inventory file {path!r} is not valid YAML{where}"
+            ) from exc
+        return _validate_entries(raw, source=path)
 
     # Backwards-compatible single device.
     return [

--- a/src/mcp_mikrotik/inventory.py
+++ b/src/mcp_mikrotik/inventory.py
@@ -1,20 +1,23 @@
 """Device inventory for multi-device (fleet) support — issue #44.
 
-The :class:`Inventory` owns the list of MikroTik devices and the
-``MikroTikSSHClient`` used to reach each one.  Tools pass a device ``title``
-down to the connector, which asks the inventory to resolve it to the matching
-client and runs the command over that client's SSH channel.
+The :class:`Inventory` owns the list of MikroTik devices and knows how to reach
+each one.  Tools pass a device ``title`` down to the connector, which asks the
+inventory to open a connection to the matching device and runs the command over
+it.
 
-Clients are created lazily (on first use for a device) rather than eagerly at
-start-up, so an unreachable device cannot block server start-up or wedge the
-whole inventory.
+Connections are **never pooled or shared**.  Every call gets a brand-new
+``MikroTikSSHClient`` that is closed as soon as the command finishes, so
+concurrent MCP sessions are fully isolated from one another: one session
+disconnecting, timing out or failing to authenticate cannot disturb a command
+another session is running against the same device.
 """
 
 import json
 import logging
 import os
 import threading
-from typing import Dict, List, Optional
+from contextlib import contextmanager
+from typing import Dict, Iterator, List, Optional
 
 from . import config
 from .config import DeviceConfig
@@ -28,12 +31,14 @@ class DeviceNotFoundError(LookupError):
 
 
 class Inventory:
-    """Holds device definitions and their SSH clients, keyed by title."""
+    """Holds the device definitions, keyed by title.
+
+    The inventory is immutable after construction and holds no connection
+    state, so a single instance is safe to share across sessions and threads.
+    """
 
     def __init__(self, devices: List[DeviceConfig]) -> None:
         self._devices: Dict[str, DeviceConfig] = {}
-        self._clients: Dict[str, MikroTikSSHClient] = {}
-        self._lock = threading.Lock()
 
         for device in devices:
             key = device.title.casefold()
@@ -104,62 +109,49 @@ class Inventory:
 
     # ── SSH clients ────────────────────────────────────────────────────────
 
-    def get_client(self, title: Optional[str] = None) -> MikroTikSSHClient:
-        """Return a connected SSH client for the resolved device.
+    def connect(self, title: Optional[str] = None) -> MikroTikSSHClient:
+        """Open and return a **new** SSH connection to the resolved device.
 
-        The client for each device is created once and reused.  A client whose
-        connection has dropped is rebuilt transparently on the next call.
+        Connections are deliberately not pooled.  Sharing one client between
+        concurrent MCP sessions would make them share a fate — a disconnect,
+        timeout or dropped transport in one session would break a command
+        another session was running — so every caller gets its own.
+
+        The caller owns the returned client and must close it.  Prefer
+        :meth:`session`, which closes it automatically.
         """
         device = self.resolve(title)
-        key = device.title.casefold()
 
-        with self._lock:
-            client = self._clients.get(key)
-            if client is not None and self._is_alive(client):
-                return client
-
-            if client is not None:
-                # Stale/broken session — drop it before rebuilding.
-                try:
-                    client.disconnect()
-                except Exception:
-                    pass
-                self._clients.pop(key, None)
-
-            client = MikroTikSSHClient(
-                host=device.host,
-                username=device.username,
-                password=device.password,
-                key_filename=device.key_filename,
-                port=device.port,
+        client = MikroTikSSHClient(
+            host=device.host,
+            username=device.username,
+            password=device.password,
+            key_filename=device.key_filename,
+            port=device.port,
+        )
+        if not client.connect():
+            raise ConnectionError(
+                f"Failed to connect to MikroTik device '{device.title}' "
+                f"({device.host}:{device.port})"
             )
-            if not client.connect():
-                raise ConnectionError(
-                    f"Failed to connect to MikroTik device '{device.title}' "
-                    f"({device.host}:{device.port})"
-                )
-            self._clients[key] = client
-            logger.info(f"Opened SSH client for device '{device.title}'")
-            return client
+        logger.debug(f"Opened SSH connection to '{device.title}'")
+        return client
 
-    @staticmethod
-    def _is_alive(client: MikroTikSSHClient) -> bool:
-        """True when the client's transport is still usable."""
+    @contextmanager
+    def session(self, title: Optional[str] = None) -> Iterator[MikroTikSSHClient]:
+        """Yield a fresh SSH connection to the device, closed on exit.
+
+        The connection is closed even if the command raises, so a failing
+        command cannot leak a session on the router.
+        """
+        client = self.connect(title)
         try:
-            transport = client.client.get_transport() if client.client else None
-            return bool(transport and transport.is_active())
-        except Exception:
-            return False
-
-    def close(self) -> None:
-        """Disconnect every open client."""
-        with self._lock:
-            for title, client in self._clients.items():
-                try:
-                    client.disconnect()
-                except Exception:
-                    logger.debug(f"Error closing client for '{title}'", exc_info=True)
-            self._clients.clear()
+            yield client
+        finally:
+            try:
+                client.disconnect()
+            except Exception:
+                logger.debug("Error closing SSH connection", exc_info=True)
 
 
 # ---------------------------------------------------------------------------
@@ -216,6 +208,4 @@ def reset_inventory() -> None:
     """Drop the cached inventory (used by tests and after config reloads)."""
     global _inventory
     with _inventory_lock:
-        if _inventory is not None:
-            _inventory.close()
         _inventory = None

--- a/src/mcp_mikrotik/mikrotik_ssh_client.py
+++ b/src/mcp_mikrotik/mikrotik_ssh_client.py
@@ -61,6 +61,15 @@ class MikroTikSSHClient:
             return True
         except Exception as e:
             logger.error(f"Failed to connect to MikroTik: {e}")
+            # A rejected login still leaves paramiko's transport running: it
+            # keeps a thread and a socket, and paramiko holds a strong
+            # reference to it, so it is never collected.  Close it here rather
+            # than abandoning a half-open connection.
+            try:
+                self.client.close()
+            except Exception:
+                pass
+            self.client = None
             return False
 
     def execute_command(self, command: str) -> str:

--- a/src/mcp_mikrotik/safe_mode.py
+++ b/src/mcp_mikrotik/safe_mode.py
@@ -21,8 +21,30 @@ _ANSI_RE = re.compile(
     r'|[()][0-9A-Za-z]'
     r'|\[?\?[0-9]+[hl]'
     r'|\[\d*[ABCDEFGHJKLMST]'
+    r'|\[c'
+    r'|Z'
     r')'
 )
+
+# The RouterOS console treats the session as a real terminal: it measures the
+# screen by moving the cursor to the extremes and asking where it ended up, and
+# probes the terminal type. If nothing answers, the console stays
+# half-initialised — slow to render, and RouterOS closes the channel outright
+# when Ctrl-X asks it to redraw for safe mode. Answer as a healthy 220x50 VT.
+_TERMINAL_QUERIES = (
+    ('\x1b[6n', '\x1b[50;220R'),   # DSR: report cursor position
+    ('\x1bZ', '\x1b[?6c'),         # DECID: identify terminal
+    ('\x1b[c', '\x1b[?6c'),        # DA: device attributes
+)
+
+# End-of-command sentinel for the safe-mode shell (see execute()).  The echoed
+# command line contains it inside quotes; the output occurrence stands alone.
+_EOC = "__MCP_SAFE_MODE_EOC__"
+_EOC_LINE_RE = re.compile(rf'^{_EOC}\s*$', re.MULTILINE)
+
+# A redraw can leave a prompt fragment without its trailing "> " on its own
+# line; treat those as prompt noise too when cleaning command output.
+_PROMPT_NOISE_RE = re.compile(r'^\[.+?@.+?\] (?:<SAFE> ?)?>? ?$')
 
 
 def _strip_ansi(text: str) -> str:
@@ -90,8 +112,9 @@ class SafeModeManager:
             self._ssh = ssh
             self._channel = channel
 
-            # Wait for the initial shell prompt
-            initial = self._read_until_prompt(timeout=20)
+            # Wait for the initial shell prompt, answering RouterOS's
+            # first-login dialogs on the way.
+            initial = self._login_until_prompt(timeout=45)
             if not _PROMPT_RE.search(initial):
                 self._cleanup()
                 return (
@@ -101,9 +124,16 @@ class SafeModeManager:
 
             # Ctrl+X activates safe mode
             channel.send('\x18')
-            response = self._read_until_prompt(timeout=10)
+            response = self._read_until_prompt(timeout=30)
 
-            if '<SAFE>' not in response:
+            # RouterOS 7.21+ confirms with "Taking Safe Mode session...
+            # Success!" and only redraws the <SAFE> prompt afterwards — on a
+            # slow (QEMU serial) console that redraw can outlast any sane read
+            # window, so the confirmation message must count as activation too.
+            activated = '<SAFE>' in response or (
+                'Safe Mode session' in response and 'Success' in response
+            )
+            if not activated:
                 self._cleanup()
                 return (
                     f"Error: Safe mode did not activate. "
@@ -118,13 +148,20 @@ class SafeModeManager:
             )
 
     def execute(self, command: str) -> str:
-        """Execute a command through the safe-mode persistent shell session."""
+        """Execute a command through the safe-mode persistent shell session.
+
+        The command is chained with ``:put`` of a sentinel, and the read runs
+        until that sentinel arrives on a line of its own.  Matching the
+        rendered prompt instead is a race: the console redraws prompt + echo
+        the moment the command is sent, so a prompt-shaped fragment can end a
+        chunk long before the command's real output has arrived.
+        """
         if not self._active or not self._channel:
             raise RuntimeError("Safe mode session is not active.")
 
         with self._lock:
-            self._channel.send(command + '\n')
-            raw = self._read_until_prompt()
+            self._channel.send(f'{command}; :put "{_EOC}"\n')
+            raw = self._read_until_marker()
             return self._extract_output(raw, command)
 
     def commit(self) -> str:
@@ -149,6 +186,10 @@ class SafeModeManager:
                 return "Safe mode is not active. Nothing to roll back."
 
             self._cleanup()
+            # RouterOS applies the revert asynchronously after the session
+            # drops; give it a moment so a follow-up read doesn't catch the
+            # pre-revert state.
+            time.sleep(2.0)
             return (
                 "Safe mode session closed. MikroTik has reverted all "
                 "uncommitted changes automatically."
@@ -169,6 +210,67 @@ class SafeModeManager:
     # Internal helpers
     # ------------------------------------------------------------------
 
+    def _answer_terminal_queries(self, chunk: str) -> None:
+        """Reply to VT terminal probes found in freshly received output."""
+        for query, reply in _TERMINAL_QUERIES:
+            for _ in range(chunk.count(query)):
+                self._channel.send(reply)
+
+    def _login_until_prompt(self, timeout: float = 45.0) -> str:
+        """Read the login stream until the shell prompt, answering dialogs.
+
+        An interactive RouterOS login is not just a prompt: on a fresh device
+        it first asks "Do you want to see the software license? [Y/n]:", and as
+        long as the admin password is empty RouterOS 7.21+ interposes a
+        "Change your password" / "new password>" step on *every* login.  Both
+        block forever if unanswered, so decline the license and Ctrl-C the
+        password step (changing credentials behind the operator's back is not
+        this tool's call to make).  The QEMU serial console used by the test
+        containers also needs ~20s just to render the login banner, hence the
+        generous default timeout.
+        """
+        buf = ""
+        answered_license = False
+        skipped_password = False
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                if self._channel.recv_ready():
+                    chunk = self._channel.recv(4096).decode('utf-8', errors='replace')
+                    self._answer_terminal_queries(chunk)
+                    buf += chunk
+                    cleaned = _strip_ansi(buf)
+                    if _PROMPT_RE.search(cleaned):
+                        return cleaned
+                    if not answered_license and "[Y/n]" in cleaned:
+                        self._channel.send('n')
+                        answered_license = True
+                    if not skipped_password and "new password>" in cleaned:
+                        self._channel.send('\x03')
+                        skipped_password = True
+            except Exception:
+                break
+            time.sleep(0.05)
+        return _strip_ansi(buf)
+
+    def _read_until_marker(self, timeout: float = 30.0) -> str:
+        """Read until the end-of-command sentinel appears on its own line."""
+        buf = ""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                if self._channel.recv_ready():
+                    chunk = self._channel.recv(4096).decode('utf-8', errors='replace')
+                    self._answer_terminal_queries(chunk)
+                    buf += chunk
+                    cleaned = _strip_ansi(buf).replace('\r\n', '\n').replace('\r', '\n')
+                    if _EOC_LINE_RE.search(cleaned):
+                        return cleaned
+            except Exception:
+                break
+            time.sleep(0.05)
+        return _strip_ansi(buf)
+
     def _read_until_prompt(self, timeout: float = 15.0) -> str:
         """Read from the channel until a RouterOS prompt is detected."""
         buf = ""
@@ -177,6 +279,7 @@ class SafeModeManager:
             try:
                 if self._channel.recv_ready():
                     chunk = self._channel.recv(4096).decode('utf-8', errors='replace')
+                    self._answer_terminal_queries(chunk)
                     buf += chunk
                     cleaned = _strip_ansi(buf)
                     if _PROMPT_RE.search(cleaned):
@@ -187,23 +290,26 @@ class SafeModeManager:
         return _strip_ansi(buf)
 
     def _extract_output(self, raw: str, command: str) -> str:
-        """Strip the echoed command and trailing prompt from shell output."""
-        # Normalise line endings
-        text = raw.replace('\r\n', '\n').replace('\r', '\n')
-        lines = text.split('\n')
+        """Return the lines between the command's echo and the sentinel."""
+        text = _strip_ansi(raw).replace('\r\n', '\n').replace('\r', '\n')
 
         result_lines: list[str] = []
         past_echo = False
-        for line in lines:
+        for line in text.split('\n'):
             stripped = line.strip()
-            if not past_echo:
-                # The interactive shell echoes the command we sent
-                if command.strip() in stripped:
-                    past_echo = True
-                continue
-            # Stop at the next prompt
-            if _PROMPT_RE.match(stripped):
+            if stripped == _EOC:
+                # The ':put' output — everything after it is the next prompt.
                 break
+            if _EOC in stripped or (not past_echo and command.strip() in stripped):
+                # An echo of the sent line.  The console can replay it more
+                # than once (typing echo, then a history reprint), and every
+                # replay carries the chained ':put' suffix — skip them all.
+                past_echo = True
+                continue
+            if not past_echo:
+                continue
+            if _PROMPT_RE.match(stripped) or _PROMPT_NOISE_RE.match(stripped):
+                continue
             result_lines.append(line)
 
         return '\n'.join(result_lines).strip()

--- a/src/mcp_mikrotik/safe_mode.py
+++ b/src/mcp_mikrotik/safe_mode.py
@@ -62,9 +62,9 @@ class SafeModeManager:
             if self._active:
                 return "Safe mode is already active."
 
-            # Safe mode needs its OWN persistent shell, separate from the
-            # inventory's pooled client, so it is built from the resolved
-            # device's connection details rather than the global config.
+            # Safe mode needs a persistent shell that outlives a single
+            # command, so it holds its own connection rather than borrowing one
+            # from the inventory, and builds it from the resolved device.
             from .inventory import DeviceNotFoundError, get_inventory
 
             try:

--- a/src/mcp_mikrotik/safe_mode.py
+++ b/src/mcp_mikrotik/safe_mode.py
@@ -2,9 +2,8 @@ import logging
 import re
 import threading
 import time
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
-from . import config
 from .mikrotik_ssh_client import MikroTikSSHClient
 
 logger = logging.getLogger(__name__)
@@ -343,17 +342,24 @@ _manager_lock = threading.Lock()
 
 
 def _manager_key(device: Optional[str]) -> str:
-    """Resolve the device to a stable key, falling back to the raw value."""
-    try:
-        from .inventory import get_inventory
+    """Resolve the device to a stable key.
 
-        return get_inventory().resolve(device).title.casefold()
-    except Exception:
-        return (device or "").casefold()
+    Resolution failures must propagate: swallowing them here would fabricate a
+    fresh inactive manager under a phantom key, so a typo'd or omitted device
+    would be told "safe mode is not active — nothing to commit" while the real
+    device still holds uncommitted changes that revert when its session drops.
+    """
+    from .inventory import get_inventory
+
+    return get_inventory().resolve(device).title.casefold()
 
 
 def get_safe_mode_manager(device: Optional[str] = None) -> SafeModeManager:
-    """Return the safe-mode manager for ``device`` (the only device if omitted)."""
+    """Return the safe-mode manager for ``device`` (the only device if omitted).
+
+    Raises :class:`~mcp_mikrotik.inventory.DeviceNotFoundError` when the device
+    cannot be resolved, exactly like every other device-scoped operation.
+    """
     key = _manager_key(device)
     manager = _managers.get(key)
     if manager is None:
@@ -364,7 +370,3 @@ def get_safe_mode_manager(device: Optional[str] = None) -> SafeModeManager:
                 _managers[key] = manager
     return manager
 
-
-def get_active_safe_mode_devices() -> List[str]:
-    """Titles of devices that currently have an active safe-mode session."""
-    return [m.device or key for key, m in _managers.items() if m.is_active]

--- a/src/mcp_mikrotik/safe_mode.py
+++ b/src/mcp_mikrotik/safe_mode.py
@@ -123,7 +123,7 @@ class SafeModeManager:
 
             # Ctrl+X activates safe mode
             channel.send('\x18')
-            response = self._read_until_prompt(timeout=30)
+            response = self._read_until_safe_mode_ack(timeout=30)
 
             # RouterOS 7.21+ confirms with "Taking Safe Mode session...
             # Success!" and only redraws the <SAFE> prompt afterwards — on a
@@ -209,11 +209,19 @@ class SafeModeManager:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _answer_terminal_queries(self, chunk: str) -> None:
-        """Reply to VT terminal probes found in freshly received output."""
+    def _answer_terminal_queries(self, buf: str, answered: Dict[str, int]) -> None:
+        """Reply to VT terminal probes, remembering what was already answered.
+
+        Counting against the accumulated buffer rather than the last chunk
+        means a probe split across two network reads is still answered once
+        its tail arrives — a missed probe can stall the console (the DA query
+        after each prompt is sent exactly once and gates the final "> ").
+        """
         for query, reply in _TERMINAL_QUERIES:
-            for _ in range(chunk.count(query)):
+            seen = buf.count(query)
+            for _ in range(seen - answered.get(query, 0)):
                 self._channel.send(reply)
+            answered[query] = seen
 
     def _login_until_prompt(self, timeout: float = 45.0) -> str:
         """Read the login stream until the shell prompt, answering dialogs.
@@ -229,6 +237,7 @@ class SafeModeManager:
         generous default timeout.
         """
         buf = ""
+        answered: Dict[str, int] = {}
         answered_license = False
         skipped_password = False
         deadline = time.monotonic() + timeout
@@ -236,8 +245,8 @@ class SafeModeManager:
             try:
                 if self._channel.recv_ready():
                     chunk = self._channel.recv(4096).decode('utf-8', errors='replace')
-                    self._answer_terminal_queries(chunk)
                     buf += chunk
+                    self._answer_terminal_queries(buf, answered)
                     cleaned = _strip_ansi(buf)
                     if _PROMPT_RE.search(cleaned):
                         return cleaned
@@ -252,16 +261,45 @@ class SafeModeManager:
             time.sleep(0.05)
         return _strip_ansi(buf)
 
-    def _read_until_marker(self, timeout: float = 30.0) -> str:
-        """Read until the end-of-command sentinel appears on its own line."""
+    def _read_until_safe_mode_ack(self, timeout: float = 30.0) -> str:
+        """Read until safe-mode activation is acknowledged.
+
+        Waiting for the prompt alone would stall: RouterOS 7.21 prints
+        "Taking Safe Mode session... Success!" within a second, but its
+        colored <SAFE> prompt redraw does not reliably match the prompt
+        pattern — so without the early exit every enable would sit out the
+        whole timeout before the fallback check rescued it.
+        """
         buf = ""
+        answered: Dict[str, int] = {}
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             try:
                 if self._channel.recv_ready():
                     chunk = self._channel.recv(4096).decode('utf-8', errors='replace')
-                    self._answer_terminal_queries(chunk)
                     buf += chunk
+                    self._answer_terminal_queries(buf, answered)
+                    cleaned = _strip_ansi(buf)
+                    if '<SAFE>' in cleaned or (
+                        'Safe Mode session' in cleaned and 'Success' in cleaned
+                    ):
+                        return cleaned
+            except Exception:
+                break
+            time.sleep(0.05)
+        return _strip_ansi(buf)
+
+    def _read_until_marker(self, timeout: float = 30.0) -> str:
+        """Read until the end-of-command sentinel appears on its own line."""
+        buf = ""
+        answered: Dict[str, int] = {}
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                if self._channel.recv_ready():
+                    chunk = self._channel.recv(4096).decode('utf-8', errors='replace')
+                    buf += chunk
+                    self._answer_terminal_queries(buf, answered)
                     cleaned = _strip_ansi(buf).replace('\r\n', '\n').replace('\r', '\n')
                     if _EOC_LINE_RE.search(cleaned):
                         return cleaned
@@ -273,13 +311,14 @@ class SafeModeManager:
     def _read_until_prompt(self, timeout: float = 15.0) -> str:
         """Read from the channel until a RouterOS prompt is detected."""
         buf = ""
+        answered: Dict[str, int] = {}
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             try:
                 if self._channel.recv_ready():
                     chunk = self._channel.recv(4096).decode('utf-8', errors='replace')
-                    self._answer_terminal_queries(chunk)
                     buf += chunk
+                    self._answer_terminal_queries(buf, answered)
                     cleaned = _strip_ansi(buf)
                     if _PROMPT_RE.search(cleaned):
                         return cleaned

--- a/src/mcp_mikrotik/safe_mode.py
+++ b/src/mcp_mikrotik/safe_mode.py
@@ -2,7 +2,7 @@ import logging
 import re
 import threading
 import time
-from typing import Optional
+from typing import Dict, List, Optional
 
 from . import config
 from .mikrotik_ssh_client import MikroTikSSHClient
@@ -39,7 +39,10 @@ class SafeModeManager:
     exits Safe Mode.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, device: Optional[str] = None) -> None:
+        # Inventory title of the device this session belongs to. ``None`` means
+        # "the only device", resolved through the inventory at connect time.
+        self.device = device
         self._ssh: Optional[MikroTikSSHClient] = None
         self._channel = None
         self._active = False
@@ -59,15 +62,28 @@ class SafeModeManager:
             if self._active:
                 return "Safe mode is already active."
 
+            # Safe mode needs its OWN persistent shell, separate from the
+            # inventory's pooled client, so it is built from the resolved
+            # device's connection details rather than the global config.
+            from .inventory import DeviceNotFoundError, get_inventory
+
+            try:
+                target = get_inventory().resolve(self.device)
+            except DeviceNotFoundError as exc:
+                return f"Error: {exc}"
+
             ssh = MikroTikSSHClient(
-                host=config.mikrotik_config.host,
-                username=config.mikrotik_config.username,
-                password=config.mikrotik_config.password,
-                key_filename=config.mikrotik_config.key_filename,
-                port=config.mikrotik_config.port,
+                host=target.host,
+                username=target.username,
+                password=target.password,
+                key_filename=target.key_filename,
+                port=target.port,
             )
             if not ssh.connect():
-                return "Error: Failed to connect to MikroTik device for safe mode session."
+                return (
+                    f"Error: Failed to connect to MikroTik device '{target.title}' "
+                    "for safe mode session."
+                )
 
             channel = ssh.client.invoke_shell(term='dumb', width=220, height=50)
             channel.settimeout(1.0)
@@ -209,17 +225,40 @@ class SafeModeManager:
 
 
 # ---------------------------------------------------------------------------
-# Module-level singleton
+# One manager per device
 # ---------------------------------------------------------------------------
+#
+# Safe mode holds a persistent shell, so it MUST be tracked per device: with a
+# single shared manager, enabling safe mode on one router would silently route
+# every other device's commands into that router's shell.
 
-_manager: Optional[SafeModeManager] = None
+_managers: Dict[str, SafeModeManager] = {}
 _manager_lock = threading.Lock()
 
 
-def get_safe_mode_manager() -> SafeModeManager:
-    global _manager
-    if _manager is None:
+def _manager_key(device: Optional[str]) -> str:
+    """Resolve the device to a stable key, falling back to the raw value."""
+    try:
+        from .inventory import get_inventory
+
+        return get_inventory().resolve(device).title.casefold()
+    except Exception:
+        return (device or "").casefold()
+
+
+def get_safe_mode_manager(device: Optional[str] = None) -> SafeModeManager:
+    """Return the safe-mode manager for ``device`` (the only device if omitted)."""
+    key = _manager_key(device)
+    manager = _managers.get(key)
+    if manager is None:
         with _manager_lock:
-            if _manager is None:
-                _manager = SafeModeManager()
-    return _manager
+            manager = _managers.get(key)
+            if manager is None:
+                manager = SafeModeManager(device)
+                _managers[key] = manager
+    return manager
+
+
+def get_active_safe_mode_devices() -> List[str]:
+    """Titles of devices that currently have an active safe-mode session."""
+    return [m.device or key for key, m in _managers.items() if m.is_active]

--- a/src/mcp_mikrotik/scope/backup.py
+++ b/src/mcp_mikrotik/scope/backup.py
@@ -13,9 +13,14 @@ async def mikrotik_create_backup(
     name: Optional[str] = None,
     dont_encrypt: bool = False,
     include_password: bool = True,
-    comment: Optional[str] = None
+    comment: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
-    """Creates a system backup on the MikroTik device."""
+    """Creates a system backup on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     # Generate filename if not provided
     if not name:
         name = f"backup_{int(time.time())}"
@@ -34,14 +39,14 @@ async def mikrotik_create_backup(
     if not include_password:
         cmd += " password-file=no"
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     # Check if backup was successful
     print(result)
     if "saved" in result or not result.strip():
         # Get file details
         file_cmd = f"/file print detail where name={name}.backup"
-        file_details = await execute_mikrotik_command(file_cmd, ctx)
+        file_details = await execute_mikrotik_command(file_cmd, ctx, device=device)
 
         if file_details:
             return f"Backup created successfully:\n\n{file_details}"
@@ -54,9 +59,14 @@ async def mikrotik_create_backup(
 async def mikrotik_list_backups(
     ctx: Context,
     name_filter: Optional[str] = None,
-    include_exports: bool = False
+    include_exports: bool = False,
+    device: Optional[str] = None
 ) -> str:
-    """Lists backup files on the MikroTik device."""
+    """Lists backup files on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Listing backups with filter: name={name_filter}")
 
     # Build the command
@@ -72,7 +82,7 @@ async def mikrotik_list_backups(
         else:
             cmd = f'/file print where type=backup and name~"{name_filter}"'
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "" or result.strip() == "no such item":
         return "No backup files found."
@@ -88,9 +98,14 @@ async def mikrotik_create_export(
     hide_sensitive: bool = True,
     verbose: bool = False,
     compact: bool = False,
-    comment: Optional[str] = None
+    comment: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
-    """Creates a configuration export file (rsc/json/xml) on the MikroTik device."""
+    """Creates a configuration export file (rsc/json/xml) on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     # Generate filename if not provided
     if not name:
         name = f"export_{int(time.time())}"
@@ -121,13 +136,13 @@ async def mikrotik_create_export(
     if export_type != "full":
         cmd += f" file={name}"
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     # Check if export was successful
     if not result.strip() or "failure:" not in result.lower():
         # Get file details
         file_cmd = f"/file print detail where name={full_name}"
-        file_details = await execute_mikrotik_command(file_cmd, ctx)
+        file_details = await execute_mikrotik_command(file_cmd, ctx, device=device)
 
         if file_details:
             return f"Export created successfully:\n\n{file_details}"
@@ -142,13 +157,15 @@ async def mikrotik_export_section(
     section: str,
     name: Optional[str] = None,
     hide_sensitive: bool = True,
-    compact: bool = False
+    compact: bool = False,
+    device: Optional[str] = None
 ) -> str:
     """Exports a specific RouterOS configuration section to a file.
 
     Notes:
         section: RouterOS path without leading slash e.g. "ip address", "interface vlan",
             "ip firewall filter", "ip firewall nat", "queue simple"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     # Generate filename if not provided
     if not name:
@@ -166,13 +183,13 @@ async def mikrotik_export_section(
     if compact:
         cmd += " compact"
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     # Check if export was successful
     if not result.strip() or "failure:" not in result.lower():
         # Get file details
         file_cmd = f"/file print detail where name={name}.rsc"
-        file_details = await execute_mikrotik_command(file_cmd, ctx)
+        file_details = await execute_mikrotik_command(file_cmd, ctx, device=device)
 
         if file_details:
             return f"Section export created successfully:\n\n{file_details}"
@@ -185,14 +202,19 @@ async def mikrotik_export_section(
 async def mikrotik_download_file(
     ctx: Context,
     filename: str,
-    file_type: Literal["backup", "export"] = "backup"
+    file_type: Literal["backup", "export"] = "backup",
+    device: Optional[str] = None
 ) -> str:
-    """Downloads a backup or export file from the MikroTik device as base64-encoded content."""
+    """Downloads a backup or export file from the MikroTik device as base64-encoded content.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Downloading file: filename={filename}, type={file_type}")
 
     # First, check if the file exists.
     check_cmd = f'/file print count-only where name="{filename}"'
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         return f"File '{filename}' not found."
@@ -200,7 +222,7 @@ async def mikrotik_download_file(
     # Transfer the raw bytes over SFTP, then base64-encode for safe transport.
     # This preserves binary backups (.backup) as well as text exports (.rsc).
     try:
-        content = await asyncio.to_thread(download_file_sync, filename)
+        content = await asyncio.to_thread(download_file_sync, filename, device)
     except Exception as e:
         return f"Failed to download file '{filename}': {str(e)}"
 
@@ -211,9 +233,14 @@ async def mikrotik_download_file(
 async def mikrotik_upload_file(
     ctx: Context,
     filename: str,
-    content_base64: str
+    content_base64: str,
+    device: Optional[str] = None
 ) -> str:
-    """Uploads a base64-encoded file to the MikroTik device (for restore operations)."""
+    """Uploads a base64-encoded file to the MikroTik device (for restore operations).
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Uploading file: filename={filename}")
 
     # Decode the base64 payload to raw bytes (keep binary intact — no utf-8 decode).
@@ -224,7 +251,7 @@ async def mikrotik_upload_file(
 
     # Push the bytes to the device over SFTP.
     try:
-        await asyncio.to_thread(upload_file_sync, filename, content)
+        await asyncio.to_thread(upload_file_sync, filename, content, device)
     except Exception as e:
         return f"Failed to upload file '{filename}': {str(e)}"
 
@@ -234,14 +261,19 @@ async def mikrotik_upload_file(
 async def mikrotik_restore_backup(
     ctx: Context,
     filename: str,
-    password: Optional[str] = None
+    password: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
-    """Restores a system backup on the MikroTik device; triggers a reboot."""
+    """Restores a system backup on the MikroTik device; triggers a reboot.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Restoring backup: filename={filename}")
 
     # Check if backup file exists
     check_cmd = f"/file print count-only where name={filename}"
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         return f"Backup file '{filename}' not found."
@@ -252,7 +284,7 @@ async def mikrotik_restore_backup(
     if password:
         cmd += f' password="{password}"'
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "Restoring system configuration" in result or not result.strip():
         return f"Backup '{filename}' restored successfully. System will reboot."
@@ -264,14 +296,19 @@ async def mikrotik_import_configuration(
     ctx: Context,
     filename: str,
     run_after_reset: bool = False,
-    verbose: bool = False
+    verbose: bool = False,
+    device: Optional[str] = None
 ) -> str:
-    """Imports and executes a RouterOS configuration script (.rsc file) on the device."""
+    """Imports and executes a RouterOS configuration script (.rsc file) on the device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Importing configuration: filename={filename}")
 
     # Check if file exists
     check_cmd = f"/file print count-only where name={filename}"
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         return f"Configuration file '{filename}' not found."
@@ -285,7 +322,7 @@ async def mikrotik_import_configuration(
     if verbose:
         cmd += " verbose=yes"
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result.strip() or "Script file loaded and executed successfully" in result:
         return f"Configuration '{filename}' imported successfully."
@@ -295,21 +332,26 @@ async def mikrotik_import_configuration(
 @mcp.tool(name="remove_file", annotations=annotate(DANGEROUS, "Remove File"))
 async def mikrotik_remove_file(
     ctx: Context,
-    filename: str
+    filename: str,
+    device: Optional[str] = None
 ) -> str:
-    """Removes a file from the MikroTik device filesystem."""
+    """Removes a file from the MikroTik device filesystem.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Removing file: filename={filename}")
 
     # Check if file exists
     check_cmd = f"/file print count-only where name={filename}"
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         return f"File '{filename}' not found."
 
     # Remove the file
     cmd = f"/file remove {filename}"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result.strip():
         return f"File '{filename}' removed successfully."
@@ -319,14 +361,19 @@ async def mikrotik_remove_file(
 @mcp.tool(name="backup_info", annotations=annotate(READ, "Backup File Info"))
 async def mikrotik_backup_info(
     ctx: Context,
-    filename: str
+    filename: str,
+    device: Optional[str] = None
 ) -> str:
-    """Gets detailed information about a backup file on the MikroTik device."""
+    """Gets detailed information about a backup file on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Getting backup info: filename={filename}")
 
     # Get file details
     cmd = f"/file print detail where name={filename}"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return f"Backup file '{filename}' not found."

--- a/src/mcp_mikrotik/scope/backup.py
+++ b/src/mcp_mikrotik/scope/backup.py
@@ -16,11 +16,7 @@ async def mikrotik_create_backup(
     comment: Optional[str] = None,
     device: Optional[str] = None
 ) -> str:
-    """Creates a system backup on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Creates a system backup on the MikroTik device."""
     # Generate filename if not provided
     if not name:
         name = f"backup_{int(time.time())}"
@@ -62,11 +58,7 @@ async def mikrotik_list_backups(
     include_exports: bool = False,
     device: Optional[str] = None
 ) -> str:
-    """Lists backup files on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Lists backup files on the MikroTik device."""
     await ctx.info(f"Listing backups with filter: name={name_filter}")
 
     # Build the command
@@ -101,11 +93,7 @@ async def mikrotik_create_export(
     comment: Optional[str] = None,
     device: Optional[str] = None
 ) -> str:
-    """Creates a configuration export file (rsc/json/xml) on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Creates a configuration export file (rsc/json/xml) on the MikroTik device."""
     # Generate filename if not provided
     if not name:
         name = f"export_{int(time.time())}"
@@ -165,7 +153,6 @@ async def mikrotik_export_section(
     Notes:
         section: RouterOS path without leading slash e.g. "ip address", "interface vlan",
             "ip firewall filter", "ip firewall nat", "queue simple"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     # Generate filename if not provided
     if not name:
@@ -205,11 +192,7 @@ async def mikrotik_download_file(
     file_type: Literal["backup", "export"] = "backup",
     device: Optional[str] = None
 ) -> str:
-    """Downloads a backup or export file from the MikroTik device as base64-encoded content.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Downloads a backup or export file from the MikroTik device as base64-encoded content."""
     await ctx.info(f"Downloading file: filename={filename}, type={file_type}")
 
     # First, check if the file exists.
@@ -236,11 +219,7 @@ async def mikrotik_upload_file(
     content_base64: str,
     device: Optional[str] = None
 ) -> str:
-    """Uploads a base64-encoded file to the MikroTik device (for restore operations).
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Uploads a base64-encoded file to the MikroTik device (for restore operations)."""
     await ctx.info(f"Uploading file: filename={filename}")
 
     # Decode the base64 payload to raw bytes (keep binary intact — no utf-8 decode).
@@ -264,11 +243,7 @@ async def mikrotik_restore_backup(
     password: Optional[str] = None,
     device: Optional[str] = None
 ) -> str:
-    """Restores a system backup on the MikroTik device; triggers a reboot.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Restores a system backup on the MikroTik device; triggers a reboot."""
     await ctx.info(f"Restoring backup: filename={filename}")
 
     # Check if backup file exists
@@ -299,11 +274,7 @@ async def mikrotik_import_configuration(
     verbose: bool = False,
     device: Optional[str] = None
 ) -> str:
-    """Imports and executes a RouterOS configuration script (.rsc file) on the device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Imports and executes a RouterOS configuration script (.rsc file) on the device."""
     await ctx.info(f"Importing configuration: filename={filename}")
 
     # Check if file exists
@@ -335,11 +306,7 @@ async def mikrotik_remove_file(
     filename: str,
     device: Optional[str] = None
 ) -> str:
-    """Removes a file from the MikroTik device filesystem.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Removes a file from the MikroTik device filesystem."""
     await ctx.info(f"Removing file: filename={filename}")
 
     # Check if file exists
@@ -364,11 +331,7 @@ async def mikrotik_backup_info(
     filename: str,
     device: Optional[str] = None
 ) -> str:
-    """Gets detailed information about a backup file on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets detailed information about a backup file on the MikroTik device."""
     await ctx.info(f"Getting backup info: filename={filename}")
 
     # Get file details

--- a/src/mcp_mikrotik/scope/dhcp.py
+++ b/src/mcp_mikrotik/scope/dhcp.py
@@ -16,12 +16,14 @@ async def mikrotik_create_dhcp_server(
     disabled: bool = False,
     authoritative: Literal["yes", "no", "after-2sec-delay"] = "yes",
     delay_threshold: Optional[str] = None,
-    comment: Optional[str] = None
+    comment: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
     """Creates a DHCP server bound to the specified interface on the MikroTik device.
 
     Notes:
         lease_time: duration e.g. "1d", "12h", "30m", "1h30m"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Creating DHCP server: name={name}, interface={interface}")
 
@@ -44,14 +46,14 @@ async def mikrotik_create_dhcp_server(
     if comment:
         cmd += f' comment="{comment}"'
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to create DHCP server: {result}"
 
     # Get the created server details
     details_cmd = f'/ip dhcp-server print detail where name="{name}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
     return f"DHCP server created successfully:\n\n{details}"
 
@@ -61,9 +63,14 @@ async def mikrotik_list_dhcp_servers(
     name_filter: Optional[str] = None,
     interface_filter: Optional[str] = None,
     disabled_only: bool = False,
-    invalid_only: bool = False
+    invalid_only: bool = False,
+    device: Optional[str] = None
 ) -> str:
-    """Lists DHCP servers on the MikroTik device."""
+    """Lists DHCP servers on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Listing DHCP servers with filters: name={name_filter}, interface={interface_filter}")
 
     # Build the command
@@ -83,7 +90,7 @@ async def mikrotik_list_dhcp_servers(
     if filters:
         cmd += " where " + " ".join(filters)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return "No DHCP servers found matching the criteria."
@@ -91,12 +98,16 @@ async def mikrotik_list_dhcp_servers(
     return f"DHCP SERVERS:\n\n{result}"
 
 @mcp.tool(name="get_dhcp_server", annotations=annotate(READ, "Get DHCP Server"))
-async def mikrotik_get_dhcp_server(ctx: Context, name: str) -> str:
-    """Gets detailed information about a specific DHCP server."""
+async def mikrotik_get_dhcp_server(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Gets detailed information about a specific DHCP server.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Getting DHCP server details: name={name}")
 
     cmd = f'/ip dhcp-server print detail where name="{name}"'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return f"DHCP server '{name}' not found."
@@ -114,9 +125,14 @@ async def mikrotik_create_dhcp_network(
     wins_servers: Optional[List[str]] = None,
     ntp_servers: Optional[List[str]] = None,
     dhcp_option: Optional[List[str]] = None,
-    comment: Optional[str] = None
+    comment: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
-    """Creates a DHCP network configuration (gateway, DNS, domain, etc.) on the MikroTik device."""
+    """Creates a DHCP network configuration (gateway, DNS, domain, etc.) on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Creating DHCP network: network={network}, gateway={gateway}")
 
     # Build the command
@@ -144,14 +160,14 @@ async def mikrotik_create_dhcp_network(
     if comment:
         cmd += f' comment="{comment}"'
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to create DHCP network: {result}"
 
     # Get the created network details
     details_cmd = f'/ip dhcp-server network print detail where address="{network}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
     return f"DHCP network created successfully:\n\n{details}"
 
@@ -161,13 +177,15 @@ async def mikrotik_create_dhcp_pool(
     name: str,
     ranges: str,
     next_pool: Optional[str] = None,
-    comment: Optional[str] = None
+    comment: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
     """Creates a DHCP address pool with the given IP ranges on the MikroTik device.
 
     Notes:
         ranges: hyphen-separated range(s) e.g. "192.168.1.1-192.168.1.100"
             Multiple ranges comma-separated: "10.0.0.1-10.0.0.50,10.0.0.100-10.0.0.120"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Creating DHCP pool: name={name}, ranges={ranges}")
 
@@ -181,32 +199,36 @@ async def mikrotik_create_dhcp_pool(
     if comment:
         cmd += f' comment="{comment}"'
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to create DHCP pool: {result}"
 
     # Get the created pool details
     details_cmd = f'/ip pool print detail where name="{name}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
     return f"DHCP pool created successfully:\n\n{details}"
 
 @mcp.tool(name="remove_dhcp_server", annotations=annotate(DESTRUCTIVE, "Remove DHCP Server"))
-async def mikrotik_remove_dhcp_server(ctx: Context, name: str) -> str:
-    """Removes a DHCP server from the MikroTik device."""
+async def mikrotik_remove_dhcp_server(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Removes a DHCP server from the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Removing DHCP server: name={name}")
 
     # First check if the server exists
     check_cmd = f'/ip dhcp-server print count-only where name="{name}"'
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         return f"DHCP server '{name}' not found."
 
     # Remove the server
     cmd = f'/ip dhcp-server remove [find name="{name}"]'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to remove DHCP server: {result}"

--- a/src/mcp_mikrotik/scope/dhcp.py
+++ b/src/mcp_mikrotik/scope/dhcp.py
@@ -23,7 +23,6 @@ async def mikrotik_create_dhcp_server(
 
     Notes:
         lease_time: duration e.g. "1d", "12h", "30m", "1h30m"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Creating DHCP server: name={name}, interface={interface}")
 
@@ -66,11 +65,7 @@ async def mikrotik_list_dhcp_servers(
     invalid_only: bool = False,
     device: Optional[str] = None
 ) -> str:
-    """Lists DHCP servers on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Lists DHCP servers on the MikroTik device."""
     await ctx.info(f"Listing DHCP servers with filters: name={name_filter}, interface={interface_filter}")
 
     # Build the command
@@ -99,11 +94,7 @@ async def mikrotik_list_dhcp_servers(
 
 @mcp.tool(name="get_dhcp_server", annotations=annotate(READ, "Get DHCP Server"))
 async def mikrotik_get_dhcp_server(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Gets detailed information about a specific DHCP server.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets detailed information about a specific DHCP server."""
     await ctx.info(f"Getting DHCP server details: name={name}")
 
     cmd = f'/ip dhcp-server print detail where name="{name}"'
@@ -128,11 +119,7 @@ async def mikrotik_create_dhcp_network(
     comment: Optional[str] = None,
     device: Optional[str] = None
 ) -> str:
-    """Creates a DHCP network configuration (gateway, DNS, domain, etc.) on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Creates a DHCP network configuration (gateway, DNS, domain, etc.) on the MikroTik device."""
     await ctx.info(f"Creating DHCP network: network={network}, gateway={gateway}")
 
     # Build the command
@@ -185,7 +172,6 @@ async def mikrotik_create_dhcp_pool(
     Notes:
         ranges: hyphen-separated range(s) e.g. "192.168.1.1-192.168.1.100"
             Multiple ranges comma-separated: "10.0.0.1-10.0.0.50,10.0.0.100-10.0.0.120"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Creating DHCP pool: name={name}, ranges={ranges}")
 
@@ -212,11 +198,7 @@ async def mikrotik_create_dhcp_pool(
 
 @mcp.tool(name="remove_dhcp_server", annotations=annotate(DESTRUCTIVE, "Remove DHCP Server"))
 async def mikrotik_remove_dhcp_server(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Removes a DHCP server from the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Removes a DHCP server from the MikroTik device."""
     await ctx.info(f"Removing DHCP server: name={name}")
 
     # First check if the server exists

--- a/src/mcp_mikrotik/scope/dns.py
+++ b/src/mcp_mikrotik/scope/dns.py
@@ -16,9 +16,14 @@ async def mikrotik_set_dns_servers(
     cache_max_ttl: Optional[str] = None,
     use_doh: bool = False,
     doh_server: Optional[str] = None,
-    verify_doh_cert: bool = True
+    verify_doh_cert: bool = True,
+    device: Optional[str] = None
 ) -> str:
-    """Sets DNS server configuration."""
+    """Sets DNS server configuration.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Setting DNS servers: {', '.join(servers)}")
 
     cmd = "/ip dns set servers=" + ",".join(servers)
@@ -44,22 +49,26 @@ async def mikrotik_set_dns_servers(
         cmd += f' use-doh-server="{doh_server}"'
         cmd += f' verify-doh-cert={"yes" if verify_doh_cert else "no"}'
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result.strip() or "failure:" not in result.lower():
         details_cmd = "/ip dns print"
-        details = await execute_mikrotik_command(details_cmd, ctx)
+        details = await execute_mikrotik_command(details_cmd, ctx, device=device)
         return f"DNS settings updated successfully:\n\n{details}"
     else:
         return f"Failed to update DNS settings: {result}"
 
 @mcp.tool(name="get_dns_settings", annotations=annotate(READ, "DNS Settings"))
-async def mikrotik_get_dns_settings(ctx: Context) -> str:
-    """Gets current DNS configuration."""
+async def mikrotik_get_dns_settings(ctx: Context, device: Optional[str] = None) -> str:
+    """Gets current DNS configuration.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Getting DNS settings")
 
     cmd = "/ip dns print"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result:
         return "Unable to retrieve DNS settings."
@@ -82,9 +91,14 @@ async def mikrotik_add_dns_static(
     ttl: Optional[str] = None,
     comment: Optional[str] = None,
     disabled: bool = False,
-    regexp: Optional[str] = None
+    regexp: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
-    """Adds a static DNS entry."""
+    """Adds a static DNS entry.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Adding static DNS entry: name={name}")
 
     cmd = f'/ip dns static add name="{name}"'
@@ -117,13 +131,13 @@ async def mikrotik_add_dns_static(
     if regexp:
         cmd += f' regexp="{regexp}"'
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if result.strip():
         if "*" in result or result.strip().isdigit():
             entry_id = result.strip()
             details_cmd = f"/ip dns static print detail where .id={entry_id}"
-            details = await execute_mikrotik_command(details_cmd, ctx)
+            details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
             if details.strip():
                 return f"Static DNS entry added successfully:\n\n{details}"
@@ -133,7 +147,7 @@ async def mikrotik_add_dns_static(
             return f"Failed to add static DNS entry: {result}"
     else:
         details_cmd = f'/ip dns static print detail where name="{name}"'
-        details = await execute_mikrotik_command(details_cmd, ctx)
+        details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
         if details.strip():
             return f"Static DNS entry added successfully:\n\n{details}"
@@ -147,9 +161,14 @@ async def mikrotik_list_dns_static(
     address_filter: Optional[str] = None,
     type_filter: Optional[str] = None,
     disabled_only: bool = False,
-    regexp_only: bool = False
+    regexp_only: bool = False,
+    device: Optional[str] = None
 ) -> str:
-    """Lists static DNS entries."""
+    """Lists static DNS entries.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Listing static DNS entries with filters: name={name_filter}")
 
     cmd = "/ip dns static print"
@@ -169,7 +188,7 @@ async def mikrotik_list_dns_static(
     if filters:
         cmd += " where " + " ".join(filters)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "" or result.strip() == "no such item":
         return "No static DNS entries found matching the criteria."
@@ -177,12 +196,16 @@ async def mikrotik_list_dns_static(
     return f"STATIC DNS ENTRIES:\n\n{result}"
 
 @mcp.tool(name="get_dns_static", annotations=annotate(READ, "Get DNS Static Entry"))
-async def mikrotik_get_dns_static(ctx: Context, entry_id: str) -> str:
-    """Gets details of a specific static DNS entry."""
+async def mikrotik_get_dns_static(ctx: Context, entry_id: str, device: Optional[str] = None) -> str:
+    """Gets details of a specific static DNS entry.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Getting static DNS entry details: entry_id={entry_id}")
 
     cmd = f"/ip dns static print detail where .id={entry_id}"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return f"Static DNS entry with ID '{entry_id}' not found."
@@ -206,9 +229,14 @@ async def mikrotik_update_dns_static(
     ttl: Optional[str] = None,
     comment: Optional[str] = None,
     disabled: Optional[bool] = None,
-    regexp: Optional[str] = None
+    regexp: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
-    """Updates a static DNS entry."""
+    """Updates a static DNS entry.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Updating static DNS entry: entry_id={entry_id}")
 
     cmd = f"/ip dns static set {entry_id}"
@@ -269,29 +297,33 @@ async def mikrotik_update_dns_static(
 
     cmd += " " + " ".join(updates)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to update static DNS entry: {result}"
 
     details_cmd = f"/ip dns static print detail where .id={entry_id}"
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
     return f"Static DNS entry updated successfully:\n\n{details}"
 
 @mcp.tool(name="remove_dns_static", annotations=annotate(DESTRUCTIVE, "Remove DNS Static Entry"))
-async def mikrotik_remove_dns_static(ctx: Context, entry_id: str) -> str:
-    """Removes a static DNS entry."""
+async def mikrotik_remove_dns_static(ctx: Context, entry_id: str, device: Optional[str] = None) -> str:
+    """Removes a static DNS entry.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Removing static DNS entry: entry_id={entry_id}")
 
     check_cmd = f"/ip dns static print count-only where .id={entry_id}"
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         return f"Static DNS entry with ID '{entry_id}' not found."
 
     cmd = f"/ip dns static remove {entry_id}"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to remove static DNS entry: {result}"
@@ -299,22 +331,34 @@ async def mikrotik_remove_dns_static(ctx: Context, entry_id: str) -> str:
     return f"Static DNS entry with ID '{entry_id}' removed successfully."
 
 @mcp.tool(name="enable_dns_static", annotations=annotate(WRITE_IDEMPOTENT, "Enable DNS Static Entry"))
-async def mikrotik_enable_dns_static(ctx: Context, entry_id: str) -> str:
-    """Enables a static DNS entry."""
-    return await mikrotik_update_dns_static(entry_id, disabled=False, ctx=ctx)
+async def mikrotik_enable_dns_static(ctx: Context, entry_id: str, device: Optional[str] = None) -> str:
+    """Enables a static DNS entry.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
+    return await mikrotik_update_dns_static(entry_id, disabled=False, ctx=ctx, device=device)
 
 @mcp.tool(name="disable_dns_static", annotations=annotate(WRITE_IDEMPOTENT, "Disable DNS Static Entry"))
-async def mikrotik_disable_dns_static(ctx: Context, entry_id: str) -> str:
-    """Disables a static DNS entry."""
-    return await mikrotik_update_dns_static(entry_id, disabled=True, ctx=ctx)
+async def mikrotik_disable_dns_static(ctx: Context, entry_id: str, device: Optional[str] = None) -> str:
+    """Disables a static DNS entry.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
+    return await mikrotik_update_dns_static(entry_id, disabled=True, ctx=ctx, device=device)
 
 @mcp.tool(name="get_dns_cache", annotations=annotate(READ, "DNS Cache"))
-async def mikrotik_get_dns_cache(ctx: Context) -> str:
-    """Gets the current DNS cache."""
+async def mikrotik_get_dns_cache(ctx: Context, device: Optional[str] = None) -> str:
+    """Gets the current DNS cache.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Getting DNS cache")
 
     cmd = "/ip dns cache print"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return "DNS cache is empty."
@@ -322,12 +366,16 @@ async def mikrotik_get_dns_cache(ctx: Context) -> str:
     return f"DNS CACHE:\n\n{result}"
 
 @mcp.tool(name="flush_dns_cache", annotations=annotate(DESTRUCTIVE, "Flush DNS Cache"))
-async def mikrotik_flush_dns_cache(ctx: Context) -> str:
-    """Flushes the DNS cache."""
+async def mikrotik_flush_dns_cache(ctx: Context, device: Optional[str] = None) -> str:
+    """Flushes the DNS cache.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Flushing DNS cache")
 
     cmd = "/ip dns cache flush"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result.strip():
         return "DNS cache flushed successfully."
@@ -335,12 +383,16 @@ async def mikrotik_flush_dns_cache(ctx: Context) -> str:
         return f"Flush result: {result}"
 
 @mcp.tool(name="get_dns_cache_statistics", annotations=annotate(READ, "DNS Cache Statistics"))
-async def mikrotik_get_dns_cache_statistics(ctx: Context) -> str:
-    """Gets DNS cache statistics."""
+async def mikrotik_get_dns_cache_statistics(ctx: Context, device: Optional[str] = None) -> str:
+    """Gets DNS cache statistics.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Getting DNS cache statistics")
 
     cmd = "/ip dns cache print stats"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result:
         return "Unable to retrieve DNS cache statistics."
@@ -354,9 +406,14 @@ async def mikrotik_add_dns_regexp(
     address: str,
     ttl: str = "1d",
     comment: Optional[str] = None,
-    disabled: bool = False
+    disabled: bool = False,
+    device: Optional[str] = None
 ) -> str:
-    """Adds a DNS regexp entry."""
+    """Adds a DNS regexp entry.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Adding DNS regexp entry: regexp={regexp}")
 
     return await mikrotik_add_dns_static(
@@ -366,7 +423,8 @@ async def mikrotik_add_dns_regexp(
         ttl=ttl,
         comment=comment,
         disabled=disabled,
-        ctx=ctx
+        ctx=ctx,
+        device=device
     )
 
 @mcp.tool(name="test_dns_query", annotations=annotate(READ, "Test DNS Query"))
@@ -374,9 +432,14 @@ async def mikrotik_test_dns_query(
     ctx: Context,
     name: str,
     server: Optional[str] = None,
-    type: str = "A"
+    type: str = "A",
+    device: Optional[str] = None
 ) -> str:
-    """Tests a DNS query."""
+    """Tests a DNS query.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Testing DNS query: name={name}, type={type}")
 
     cmd = f"/resolve {name}"
@@ -387,7 +450,7 @@ async def mikrotik_test_dns_query(
     if type != "A":
         cmd += f" type={type}"
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result:
         return f"Failed to resolve {name}"
@@ -395,15 +458,19 @@ async def mikrotik_test_dns_query(
     return f"DNS QUERY RESULT for {name}:\n\n{result}"
 
 @mcp.tool(name="export_dns_config", annotations=annotate(READ, "Export DNS Config"))
-async def mikrotik_export_dns_config(ctx: Context, filename: Optional[str] = None) -> str:
-    """Exports DNS configuration to a file."""
+async def mikrotik_export_dns_config(ctx: Context, filename: Optional[str] = None, device: Optional[str] = None) -> str:
+    """Exports DNS configuration to a file.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Exporting DNS configuration")
 
     if not filename:
         filename = "dns_config"
 
     cmd = f"/ip dns export file={filename}"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result.strip():
         return f"DNS configuration exported to {filename}.rsc"

--- a/src/mcp_mikrotik/scope/dns.py
+++ b/src/mcp_mikrotik/scope/dns.py
@@ -19,11 +19,7 @@ async def mikrotik_set_dns_servers(
     verify_doh_cert: bool = True,
     device: Optional[str] = None
 ) -> str:
-    """Sets DNS server configuration.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Sets DNS server configuration."""
     await ctx.info(f"Setting DNS servers: {', '.join(servers)}")
 
     cmd = "/ip dns set servers=" + ",".join(servers)
@@ -60,11 +56,7 @@ async def mikrotik_set_dns_servers(
 
 @mcp.tool(name="get_dns_settings", annotations=annotate(READ, "DNS Settings"))
 async def mikrotik_get_dns_settings(ctx: Context, device: Optional[str] = None) -> str:
-    """Gets current DNS configuration.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets current DNS configuration."""
     await ctx.info("Getting DNS settings")
 
     cmd = "/ip dns print"
@@ -94,11 +86,7 @@ async def mikrotik_add_dns_static(
     regexp: Optional[str] = None,
     device: Optional[str] = None
 ) -> str:
-    """Adds a static DNS entry.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Adds a static DNS entry."""
     await ctx.info(f"Adding static DNS entry: name={name}")
 
     cmd = f'/ip dns static add name="{name}"'
@@ -164,11 +152,7 @@ async def mikrotik_list_dns_static(
     regexp_only: bool = False,
     device: Optional[str] = None
 ) -> str:
-    """Lists static DNS entries.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Lists static DNS entries."""
     await ctx.info(f"Listing static DNS entries with filters: name={name_filter}")
 
     cmd = "/ip dns static print"
@@ -197,11 +181,7 @@ async def mikrotik_list_dns_static(
 
 @mcp.tool(name="get_dns_static", annotations=annotate(READ, "Get DNS Static Entry"))
 async def mikrotik_get_dns_static(ctx: Context, entry_id: str, device: Optional[str] = None) -> str:
-    """Gets details of a specific static DNS entry.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets details of a specific static DNS entry."""
     await ctx.info(f"Getting static DNS entry details: entry_id={entry_id}")
 
     cmd = f"/ip dns static print detail where .id={entry_id}"
@@ -232,11 +212,7 @@ async def mikrotik_update_dns_static(
     regexp: Optional[str] = None,
     device: Optional[str] = None
 ) -> str:
-    """Updates a static DNS entry.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Updates a static DNS entry."""
     await ctx.info(f"Updating static DNS entry: entry_id={entry_id}")
 
     cmd = f"/ip dns static set {entry_id}"
@@ -309,11 +285,7 @@ async def mikrotik_update_dns_static(
 
 @mcp.tool(name="remove_dns_static", annotations=annotate(DESTRUCTIVE, "Remove DNS Static Entry"))
 async def mikrotik_remove_dns_static(ctx: Context, entry_id: str, device: Optional[str] = None) -> str:
-    """Removes a static DNS entry.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Removes a static DNS entry."""
     await ctx.info(f"Removing static DNS entry: entry_id={entry_id}")
 
     check_cmd = f"/ip dns static print count-only where .id={entry_id}"
@@ -332,29 +304,17 @@ async def mikrotik_remove_dns_static(ctx: Context, entry_id: str, device: Option
 
 @mcp.tool(name="enable_dns_static", annotations=annotate(WRITE_IDEMPOTENT, "Enable DNS Static Entry"))
 async def mikrotik_enable_dns_static(ctx: Context, entry_id: str, device: Optional[str] = None) -> str:
-    """Enables a static DNS entry.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Enables a static DNS entry."""
     return await mikrotik_update_dns_static(entry_id, disabled=False, ctx=ctx, device=device)
 
 @mcp.tool(name="disable_dns_static", annotations=annotate(WRITE_IDEMPOTENT, "Disable DNS Static Entry"))
 async def mikrotik_disable_dns_static(ctx: Context, entry_id: str, device: Optional[str] = None) -> str:
-    """Disables a static DNS entry.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Disables a static DNS entry."""
     return await mikrotik_update_dns_static(entry_id, disabled=True, ctx=ctx, device=device)
 
 @mcp.tool(name="get_dns_cache", annotations=annotate(READ, "DNS Cache"))
 async def mikrotik_get_dns_cache(ctx: Context, device: Optional[str] = None) -> str:
-    """Gets the current DNS cache.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets the current DNS cache."""
     await ctx.info("Getting DNS cache")
 
     cmd = "/ip dns cache print"
@@ -367,11 +327,7 @@ async def mikrotik_get_dns_cache(ctx: Context, device: Optional[str] = None) -> 
 
 @mcp.tool(name="flush_dns_cache", annotations=annotate(DESTRUCTIVE, "Flush DNS Cache"))
 async def mikrotik_flush_dns_cache(ctx: Context, device: Optional[str] = None) -> str:
-    """Flushes the DNS cache.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Flushes the DNS cache."""
     await ctx.info("Flushing DNS cache")
 
     cmd = "/ip dns cache flush"
@@ -384,11 +340,7 @@ async def mikrotik_flush_dns_cache(ctx: Context, device: Optional[str] = None) -
 
 @mcp.tool(name="get_dns_cache_statistics", annotations=annotate(READ, "DNS Cache Statistics"))
 async def mikrotik_get_dns_cache_statistics(ctx: Context, device: Optional[str] = None) -> str:
-    """Gets DNS cache statistics.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets DNS cache statistics."""
     await ctx.info("Getting DNS cache statistics")
 
     cmd = "/ip dns cache print stats"
@@ -409,11 +361,7 @@ async def mikrotik_add_dns_regexp(
     disabled: bool = False,
     device: Optional[str] = None
 ) -> str:
-    """Adds a DNS regexp entry.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Adds a DNS regexp entry."""
     await ctx.info(f"Adding DNS regexp entry: regexp={regexp}")
 
     return await mikrotik_add_dns_static(
@@ -435,11 +383,7 @@ async def mikrotik_test_dns_query(
     type: str = "A",
     device: Optional[str] = None
 ) -> str:
-    """Tests a DNS query.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Tests a DNS query."""
     await ctx.info(f"Testing DNS query: name={name}, type={type}")
 
     cmd = f"/resolve {name}"
@@ -459,11 +403,7 @@ async def mikrotik_test_dns_query(
 
 @mcp.tool(name="export_dns_config", annotations=annotate(READ, "Export DNS Config"))
 async def mikrotik_export_dns_config(ctx: Context, filename: Optional[str] = None, device: Optional[str] = None) -> str:
-    """Exports DNS configuration to a file.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Exports DNS configuration to a file."""
     await ctx.info("Exporting DNS configuration")
 
     if not filename:

--- a/src/mcp_mikrotik/scope/firewall_filter.py
+++ b/src/mcp_mikrotik/scope/firewall_filter.py
@@ -25,7 +25,8 @@ async def mikrotik_create_filter_rule(
     disabled: bool = False,
     log: bool = False,
     log_prefix: Optional[str] = None,
-    place_before: Optional[str] = None
+    place_before: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
     """Creates a firewall filter rule in the specified chain on the MikroTik device.
 
@@ -34,6 +35,7 @@ async def mikrotik_create_filter_rule(
         limit: RouterOS rate/burst string e.g. "10,5:packet" or "10/1s:packet"
         tcp_flags: RouterOS flag expression e.g. "syn,!ack"
         place_before: rule number or ID (*N) to insert before e.g. "0" or "*3"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Creating firewall filter rule: chain={chain}, action={action}")
 
@@ -94,7 +96,7 @@ async def mikrotik_create_filter_rule(
     if place_before:
         cmd += f" place-before={place_before}"
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     # Check if creation was successful
     if result.strip():
@@ -103,7 +105,7 @@ async def mikrotik_create_filter_rule(
             # Success - get the details
             rule_id = result.strip()
             details_cmd = f"/ip firewall filter print detail where .id={rule_id}"
-            details = await execute_mikrotik_command(details_cmd, ctx)
+            details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
             if details.strip():
                 return f"Firewall filter rule created successfully:\n\n{details}"
@@ -115,12 +117,12 @@ async def mikrotik_create_filter_rule(
     else:
         # No output might mean success, let's check
         details_cmd = "/ip firewall filter print detail count-only"
-        count = await execute_mikrotik_command(details_cmd, ctx)
+        count = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
         if count.strip().isdigit() and int(count.strip()) > 0:
             # Get the last rule
             last_rule_cmd = f"/ip firewall filter print detail from={int(count.strip())-1}"
-            details = await execute_mikrotik_command(last_rule_cmd, ctx)
+            details = await execute_mikrotik_command(last_rule_cmd, ctx, device=device)
             return f"Firewall filter rule created successfully:\n\n{details}"
         else:
             return "Firewall filter rule creation completed but unable to verify."
@@ -136,9 +138,14 @@ async def mikrotik_list_filter_rules(
     interface_filter: Optional[str] = None,
     disabled_only: bool = False,
     invalid_only: bool = False,
-    dynamic_only: bool = False
+    dynamic_only: bool = False,
+    device: Optional[str] = None
 ) -> str:
-    """Lists firewall filter rules on the MikroTik device."""
+    """Lists firewall filter rules on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Listing firewall filter rules with filters: chain={chain_filter}, action={action_filter}")
 
     # Build the command
@@ -168,7 +175,7 @@ async def mikrotik_list_filter_rules(
     if filters:
         cmd += " where " + " ".join(filters)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     # Check for empty result
     if not result or result.strip() == "" or result.strip() == "no such item":
@@ -177,16 +184,17 @@ async def mikrotik_list_filter_rules(
     return f"FIREWALL FILTER RULES:\n\n{result}"
 
 @mcp.tool(name="get_filter_rule", annotations=annotate(READ, "Get Firewall Filter Rule"))
-async def mikrotik_get_filter_rule(ctx: Context, rule_id: str) -> str:
+async def mikrotik_get_filter_rule(ctx: Context, rule_id: str, device: Optional[str] = None) -> str:
     """Gets detailed information about a specific firewall filter rule.
 
     Notes:
         rule_id: use the ID from list output e.g. "*1" or "0"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Getting firewall filter rule details: rule_id={rule_id}")
 
     cmd = f"/ip firewall filter print detail where .id={rule_id}"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return f"Firewall filter rule with ID '{rule_id}' not found."
@@ -215,7 +223,8 @@ async def mikrotik_update_filter_rule(
     comment: Optional[str] = None,
     disabled: Optional[bool] = None,
     log: Optional[bool] = None,
-    log_prefix: Optional[str] = None
+    log_prefix: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
     """Updates an existing firewall filter rule on the MikroTik device.
 
@@ -225,6 +234,7 @@ async def mikrotik_update_filter_rule(
         limit: RouterOS rate string e.g. "10,5:packet"
         tcp_flags: RouterOS flag expression e.g. "syn,!ack"
         Pass "" to clear an optional field (e.g. src_address="").
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Updating firewall filter rule: rule_id={rule_id}")
 
@@ -316,7 +326,7 @@ async def mikrotik_update_filter_rule(
 
     cmd += " " + " ".join(updates)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     # Check if update was successful
     if "failure:" in result.lower() or "error" in result.lower():
@@ -324,29 +334,30 @@ async def mikrotik_update_filter_rule(
 
     # Get the updated rule details
     details_cmd = f"/ip firewall filter print detail where .id={rule_id}"
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
     return f"Firewall filter rule updated successfully:\n\n{details}"
 
 @mcp.tool(name="remove_filter_rule", annotations=annotate(DESTRUCTIVE, "Remove Firewall Filter Rule"))
-async def mikrotik_remove_filter_rule(ctx: Context, rule_id: str) -> str:
+async def mikrotik_remove_filter_rule(ctx: Context, rule_id: str, device: Optional[str] = None) -> str:
     """Removes a firewall filter rule from the MikroTik device.
 
     Notes:
         rule_id: use the ID from list output e.g. "*1" or "0"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Removing firewall filter rule: rule_id={rule_id}")
 
     # First check if the rule exists
     check_cmd = f"/ip firewall filter print count-only where .id={rule_id}"
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         return f"Firewall filter rule with ID '{rule_id}' not found."
 
     # Remove the rule
     cmd = f"/ip firewall filter remove {rule_id}"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to remove firewall filter rule: {result}"
@@ -354,25 +365,26 @@ async def mikrotik_remove_filter_rule(ctx: Context, rule_id: str) -> str:
     return f"Firewall filter rule with ID '{rule_id}' removed successfully."
 
 @mcp.tool(name="move_filter_rule", annotations=annotate(WRITE_IDEMPOTENT, "Move Filter Rule"))
-async def mikrotik_move_filter_rule(ctx: Context, rule_id: str, destination: int) -> str:
+async def mikrotik_move_filter_rule(ctx: Context, rule_id: str, destination: int, device: Optional[str] = None) -> str:
     """Moves a firewall filter rule to a different position in the chain.
 
     Notes:
         rule_id: use the ID from list output e.g. "*1" or "0"
         destination: 0-based target position index
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Moving firewall filter rule: rule_id={rule_id} to position {destination}")
 
     # Check if the rule exists
     check_cmd = f"/ip firewall filter print count-only where .id={rule_id}"
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         return f"Firewall filter rule with ID '{rule_id}' not found."
 
     # Move the rule
     cmd = f"/ip firewall filter move {rule_id} destination={destination}"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to move firewall filter rule: {result}"
@@ -380,45 +392,57 @@ async def mikrotik_move_filter_rule(ctx: Context, rule_id: str, destination: int
     return f"Firewall filter rule with ID '{rule_id}' moved to position {destination}."
 
 @mcp.tool(name="enable_filter_rule", annotations=annotate(WRITE_IDEMPOTENT, "Enable Filter Rule"))
-async def mikrotik_enable_filter_rule(ctx: Context, rule_id: str) -> str:
-    """Enables a firewall filter rule."""
-    return await mikrotik_update_filter_rule(rule_id, disabled=False, ctx=ctx)
+async def mikrotik_enable_filter_rule(ctx: Context, rule_id: str, device: Optional[str] = None) -> str:
+    """Enables a firewall filter rule.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
+    return await mikrotik_update_filter_rule(rule_id, disabled=False, ctx=ctx, device=device)
 
 @mcp.tool(name="disable_filter_rule", annotations=annotate(WRITE_IDEMPOTENT, "Disable Filter Rule"))
-async def mikrotik_disable_filter_rule(ctx: Context, rule_id: str) -> str:
-    """Disables a firewall filter rule."""
-    return await mikrotik_update_filter_rule(rule_id, disabled=True, ctx=ctx)
+async def mikrotik_disable_filter_rule(ctx: Context, rule_id: str, device: Optional[str] = None) -> str:
+    """Disables a firewall filter rule.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
+    return await mikrotik_update_filter_rule(rule_id, disabled=True, ctx=ctx, device=device)
 
 @mcp.tool(name="create_basic_firewall_setup", annotations=annotate(DANGEROUS, "Create Basic Firewall Setup"))
-async def mikrotik_create_basic_firewall_setup(ctx: Context) -> str:
-    """Creates a basic firewall setup with common security rules on the MikroTik device."""
+async def mikrotik_create_basic_firewall_setup(ctx: Context, device: Optional[str] = None) -> str:
+    """Creates a basic firewall setup with common security rules on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Creating basic firewall setup")
 
     results = []
 
     # Allow established and related connections
     cmd1 = "/ip firewall filter add chain=input action=accept connection-state=established,related comment=\"Accept established,related\""
-    result1 = await execute_mikrotik_command(cmd1, ctx)
+    result1 = await execute_mikrotik_command(cmd1, ctx, device=device)
     results.append("Rule 1 (established/related): " + ("Created" if not result1 or "*" in result1 else result1))
 
     # Drop invalid connections
     cmd2 = "/ip firewall filter add chain=input action=drop connection-state=invalid comment=\"Drop invalid\""
-    result2 = await execute_mikrotik_command(cmd2, ctx)
+    result2 = await execute_mikrotik_command(cmd2, ctx, device=device)
     results.append("Rule 2 (drop invalid): " + ("Created" if not result2 or "*" in result2 else result2))
 
     # Allow ICMP
     cmd3 = "/ip firewall filter add chain=input action=accept protocol=icmp comment=\"Accept ICMP\""
-    result3 = await execute_mikrotik_command(cmd3, ctx)
+    result3 = await execute_mikrotik_command(cmd3, ctx, device=device)
     results.append("Rule 3 (ICMP): " + ("Created" if not result3 or "*" in result3 else result3))
 
     # Allow management from specific network
     cmd4 = "/ip firewall filter add chain=input action=accept src-address=192.168.88.0/24 comment=\"Accept management network\""
-    result4 = await execute_mikrotik_command(cmd4, ctx)
+    result4 = await execute_mikrotik_command(cmd4, ctx, device=device)
     results.append("Rule 4 (management network): " + ("Created" if not result4 or "*" in result4 else result4))
 
     # Drop everything else
     cmd5 = "/ip firewall filter add chain=input action=drop comment=\"Drop everything else\""
-    result5 = await execute_mikrotik_command(cmd5, ctx)
+    result5 = await execute_mikrotik_command(cmd5, ctx, device=device)
     results.append("Rule 5 (drop all): " + ("Created" if not result5 or "*" in result5 else result5))
 
     return "BASIC FIREWALL SETUP RESULTS:\n\n" + "\n".join(results)

--- a/src/mcp_mikrotik/scope/firewall_filter.py
+++ b/src/mcp_mikrotik/scope/firewall_filter.py
@@ -35,7 +35,6 @@ async def mikrotik_create_filter_rule(
         limit: RouterOS rate/burst string e.g. "10,5:packet" or "10/1s:packet"
         tcp_flags: RouterOS flag expression e.g. "syn,!ack"
         place_before: rule number or ID (*N) to insert before e.g. "0" or "*3"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Creating firewall filter rule: chain={chain}, action={action}")
 
@@ -141,11 +140,7 @@ async def mikrotik_list_filter_rules(
     dynamic_only: bool = False,
     device: Optional[str] = None
 ) -> str:
-    """Lists firewall filter rules on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Lists firewall filter rules on the MikroTik device."""
     await ctx.info(f"Listing firewall filter rules with filters: chain={chain_filter}, action={action_filter}")
 
     # Build the command
@@ -189,7 +184,6 @@ async def mikrotik_get_filter_rule(ctx: Context, rule_id: str, device: Optional[
 
     Notes:
         rule_id: use the ID from list output e.g. "*1" or "0"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Getting firewall filter rule details: rule_id={rule_id}")
 
@@ -234,7 +228,6 @@ async def mikrotik_update_filter_rule(
         limit: RouterOS rate string e.g. "10,5:packet"
         tcp_flags: RouterOS flag expression e.g. "syn,!ack"
         Pass "" to clear an optional field (e.g. src_address="").
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Updating firewall filter rule: rule_id={rule_id}")
 
@@ -344,7 +337,6 @@ async def mikrotik_remove_filter_rule(ctx: Context, rule_id: str, device: Option
 
     Notes:
         rule_id: use the ID from list output e.g. "*1" or "0"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Removing firewall filter rule: rule_id={rule_id}")
 
@@ -371,7 +363,6 @@ async def mikrotik_move_filter_rule(ctx: Context, rule_id: str, destination: int
     Notes:
         rule_id: use the ID from list output e.g. "*1" or "0"
         destination: 0-based target position index
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Moving firewall filter rule: rule_id={rule_id} to position {destination}")
 
@@ -393,29 +384,17 @@ async def mikrotik_move_filter_rule(ctx: Context, rule_id: str, destination: int
 
 @mcp.tool(name="enable_filter_rule", annotations=annotate(WRITE_IDEMPOTENT, "Enable Filter Rule"))
 async def mikrotik_enable_filter_rule(ctx: Context, rule_id: str, device: Optional[str] = None) -> str:
-    """Enables a firewall filter rule.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Enables a firewall filter rule."""
     return await mikrotik_update_filter_rule(rule_id, disabled=False, ctx=ctx, device=device)
 
 @mcp.tool(name="disable_filter_rule", annotations=annotate(WRITE_IDEMPOTENT, "Disable Filter Rule"))
 async def mikrotik_disable_filter_rule(ctx: Context, rule_id: str, device: Optional[str] = None) -> str:
-    """Disables a firewall filter rule.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Disables a firewall filter rule."""
     return await mikrotik_update_filter_rule(rule_id, disabled=True, ctx=ctx, device=device)
 
 @mcp.tool(name="create_basic_firewall_setup", annotations=annotate(DANGEROUS, "Create Basic Firewall Setup"))
 async def mikrotik_create_basic_firewall_setup(ctx: Context, device: Optional[str] = None) -> str:
-    """Creates a basic firewall setup with common security rules on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Creates a basic firewall setup with common security rules on the MikroTik device."""
     await ctx.info("Creating basic firewall setup")
 
     results = []

--- a/src/mcp_mikrotik/scope/firewall_nat.py
+++ b/src/mcp_mikrotik/scope/firewall_nat.py
@@ -21,7 +21,8 @@ async def mikrotik_create_nat_rule(
     disabled: bool = False,
     log: bool = False,
     log_prefix: Optional[str] = None,
-    place_before: Optional[str] = None
+    place_before: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
     """Creates a NAT rule (srcnat or dstnat) on the MikroTik device.
 
@@ -29,6 +30,7 @@ async def mikrotik_create_nat_rule(
         to_addresses: single IP or range e.g. "10.0.0.1" or "10.0.0.1-10.0.0.10"
         to_ports: single port or range e.g. "8080" or "8080-8090"
         place_before: rule number or ID (*N) to insert before e.g. "0" or "*3"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Creating NAT rule: chain={chain}, action={action}")
 
@@ -86,7 +88,7 @@ async def mikrotik_create_nat_rule(
     if place_before:
         cmd += f" place-before={place_before}"
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     # Check if creation was successful
     if result.strip():
@@ -95,7 +97,7 @@ async def mikrotik_create_nat_rule(
             # Success - get the details
             rule_id = result.strip()
             details_cmd = f"/ip firewall nat print detail where .id={rule_id}"
-            details = await execute_mikrotik_command(details_cmd, ctx)
+            details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
             if details.strip():
                 return f"NAT rule created successfully:\n\n{details}"
@@ -107,12 +109,12 @@ async def mikrotik_create_nat_rule(
     else:
         # No output might mean success, let's check by getting the last rule
         details_cmd = "/ip firewall nat print detail count-only"
-        count = await execute_mikrotik_command(details_cmd, ctx)
+        count = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
         if count.strip().isdigit() and int(count.strip()) > 0:
             # Get the last rule
             last_rule_cmd = f"/ip firewall nat print detail from={int(count.strip())-1}"
-            details = await execute_mikrotik_command(last_rule_cmd, ctx)
+            details = await execute_mikrotik_command(last_rule_cmd, ctx, device=device)
             return f"NAT rule created successfully:\n\n{details}"
         else:
             return "NAT rule creation completed but unable to verify."
@@ -127,9 +129,14 @@ async def mikrotik_list_nat_rules(
     protocol_filter: Optional[str] = None,
     interface_filter: Optional[str] = None,
     disabled_only: bool = False,
-    invalid_only: bool = False
+    invalid_only: bool = False,
+    device: Optional[str] = None
 ) -> str:
-    """Lists NAT rules on the MikroTik device."""
+    """Lists NAT rules on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Listing NAT rules with filters: chain={chain_filter}, action={action_filter}")
 
     # Build the command
@@ -157,7 +164,7 @@ async def mikrotik_list_nat_rules(
     if filters:
         cmd += " where " + " ".join(filters)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     # Check for empty result
     if not result or result.strip() == "" or result.strip() == "no such item":
@@ -166,16 +173,17 @@ async def mikrotik_list_nat_rules(
     return f"NAT RULES:\n\n{result}"
 
 @mcp.tool(name="get_nat_rule", annotations=annotate(READ, "Get NAT Rule"))
-async def mikrotik_get_nat_rule(ctx: Context, rule_id: str) -> str:
+async def mikrotik_get_nat_rule(ctx: Context, rule_id: str, device: Optional[str] = None) -> str:
     """Gets detailed information about a specific NAT rule.
 
     Notes:
         rule_id: use the ID from list output e.g. "*1" or "0"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Getting NAT rule details: rule_id={rule_id}")
 
     cmd = f"/ip firewall nat print detail where .id={rule_id}"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return f"NAT rule with ID '{rule_id}' not found."
@@ -200,7 +208,8 @@ async def mikrotik_update_nat_rule(
     comment: Optional[str] = None,
     disabled: Optional[bool] = None,
     log: Optional[bool] = None,
-    log_prefix: Optional[str] = None
+    log_prefix: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
     """Updates an existing NAT rule on the MikroTik device.
 
@@ -209,6 +218,7 @@ async def mikrotik_update_nat_rule(
         to_addresses: single IP or range e.g. "10.0.0.1" or "10.0.0.1-10.0.0.10"
         to_ports: single port or range e.g. "8080" or "8080-8090"
         Pass "" to clear an optional field.
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Updating NAT rule: rule_id={rule_id}")
 
@@ -280,7 +290,7 @@ async def mikrotik_update_nat_rule(
 
     cmd += " " + " ".join(updates)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     # Check if update was successful
     if "failure:" in result.lower() or "error" in result.lower():
@@ -288,29 +298,30 @@ async def mikrotik_update_nat_rule(
 
     # Get the updated rule details
     details_cmd = f"/ip firewall nat print detail where .id={rule_id}"
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
     return f"NAT rule updated successfully:\n\n{details}"
 
 @mcp.tool(name="remove_nat_rule", annotations=annotate(DESTRUCTIVE, "Remove NAT Rule"))
-async def mikrotik_remove_nat_rule(ctx: Context, rule_id: str) -> str:
+async def mikrotik_remove_nat_rule(ctx: Context, rule_id: str, device: Optional[str] = None) -> str:
     """Removes a NAT rule from the MikroTik device.
 
     Notes:
         rule_id: use the ID from list output e.g. "*1" or "0"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Removing NAT rule: rule_id={rule_id}")
 
     # First check if the rule exists
     check_cmd = f"/ip firewall nat print count-only where .id={rule_id}"
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         return f"NAT rule with ID '{rule_id}' not found."
 
     # Remove the rule
     cmd = f"/ip firewall nat remove {rule_id}"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to remove NAT rule: {result}"
@@ -318,25 +329,26 @@ async def mikrotik_remove_nat_rule(ctx: Context, rule_id: str) -> str:
     return f"NAT rule with ID '{rule_id}' removed successfully."
 
 @mcp.tool(name="move_nat_rule", annotations=annotate(WRITE_IDEMPOTENT, "Move NAT Rule"))
-async def mikrotik_move_nat_rule(ctx: Context, rule_id: str, destination: int) -> str:
+async def mikrotik_move_nat_rule(ctx: Context, rule_id: str, destination: int, device: Optional[str] = None) -> str:
     """Moves a NAT rule to a different position in the chain.
 
     Notes:
         rule_id: use the ID from list output e.g. "*1" or "0"
         destination: 0-based target position index
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Moving NAT rule: rule_id={rule_id} to position {destination}")
 
     # Check if the rule exists
     check_cmd = f"/ip firewall nat print count-only where .id={rule_id}"
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         return f"NAT rule with ID '{rule_id}' not found."
 
     # Move the rule
     cmd = f"/ip firewall nat move {rule_id} destination={destination}"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to move NAT rule: {result}"
@@ -344,11 +356,19 @@ async def mikrotik_move_nat_rule(ctx: Context, rule_id: str, destination: int) -
     return f"NAT rule with ID '{rule_id}' moved to position {destination}."
 
 @mcp.tool(name="enable_nat_rule", annotations=annotate(WRITE_IDEMPOTENT, "Enable NAT Rule"))
-async def mikrotik_enable_nat_rule(ctx: Context, rule_id: str) -> str:
-    """Enables a NAT rule."""
-    return await mikrotik_update_nat_rule(rule_id, disabled=False, ctx=ctx)
+async def mikrotik_enable_nat_rule(ctx: Context, rule_id: str, device: Optional[str] = None) -> str:
+    """Enables a NAT rule.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
+    return await mikrotik_update_nat_rule(rule_id, disabled=False, ctx=ctx, device=device)
 
 @mcp.tool(name="disable_nat_rule", annotations=annotate(WRITE_IDEMPOTENT, "Disable NAT Rule"))
-async def mikrotik_disable_nat_rule(ctx: Context, rule_id: str) -> str:
-    """Disables a NAT rule."""
-    return await mikrotik_update_nat_rule(rule_id, disabled=True, ctx=ctx)
+async def mikrotik_disable_nat_rule(ctx: Context, rule_id: str, device: Optional[str] = None) -> str:
+    """Disables a NAT rule.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
+    return await mikrotik_update_nat_rule(rule_id, disabled=True, ctx=ctx, device=device)

--- a/src/mcp_mikrotik/scope/firewall_nat.py
+++ b/src/mcp_mikrotik/scope/firewall_nat.py
@@ -30,7 +30,6 @@ async def mikrotik_create_nat_rule(
         to_addresses: single IP or range e.g. "10.0.0.1" or "10.0.0.1-10.0.0.10"
         to_ports: single port or range e.g. "8080" or "8080-8090"
         place_before: rule number or ID (*N) to insert before e.g. "0" or "*3"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Creating NAT rule: chain={chain}, action={action}")
 
@@ -132,11 +131,7 @@ async def mikrotik_list_nat_rules(
     invalid_only: bool = False,
     device: Optional[str] = None
 ) -> str:
-    """Lists NAT rules on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Lists NAT rules on the MikroTik device."""
     await ctx.info(f"Listing NAT rules with filters: chain={chain_filter}, action={action_filter}")
 
     # Build the command
@@ -178,7 +173,6 @@ async def mikrotik_get_nat_rule(ctx: Context, rule_id: str, device: Optional[str
 
     Notes:
         rule_id: use the ID from list output e.g. "*1" or "0"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Getting NAT rule details: rule_id={rule_id}")
 
@@ -218,7 +212,6 @@ async def mikrotik_update_nat_rule(
         to_addresses: single IP or range e.g. "10.0.0.1" or "10.0.0.1-10.0.0.10"
         to_ports: single port or range e.g. "8080" or "8080-8090"
         Pass "" to clear an optional field.
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Updating NAT rule: rule_id={rule_id}")
 
@@ -308,7 +301,6 @@ async def mikrotik_remove_nat_rule(ctx: Context, rule_id: str, device: Optional[
 
     Notes:
         rule_id: use the ID from list output e.g. "*1" or "0"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Removing NAT rule: rule_id={rule_id}")
 
@@ -335,7 +327,6 @@ async def mikrotik_move_nat_rule(ctx: Context, rule_id: str, destination: int, d
     Notes:
         rule_id: use the ID from list output e.g. "*1" or "0"
         destination: 0-based target position index
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Moving NAT rule: rule_id={rule_id} to position {destination}")
 
@@ -357,18 +348,10 @@ async def mikrotik_move_nat_rule(ctx: Context, rule_id: str, destination: int, d
 
 @mcp.tool(name="enable_nat_rule", annotations=annotate(WRITE_IDEMPOTENT, "Enable NAT Rule"))
 async def mikrotik_enable_nat_rule(ctx: Context, rule_id: str, device: Optional[str] = None) -> str:
-    """Enables a NAT rule.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Enables a NAT rule."""
     return await mikrotik_update_nat_rule(rule_id, disabled=False, ctx=ctx, device=device)
 
 @mcp.tool(name="disable_nat_rule", annotations=annotate(WRITE_IDEMPOTENT, "Disable NAT Rule"))
 async def mikrotik_disable_nat_rule(ctx: Context, rule_id: str, device: Optional[str] = None) -> str:
-    """Disables a NAT rule.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Disables a NAT rule."""
     return await mikrotik_update_nat_rule(rule_id, disabled=True, ctx=ctx, device=device)

--- a/src/mcp_mikrotik/scope/fleet.py
+++ b/src/mcp_mikrotik/scope/fleet.py
@@ -1,0 +1,177 @@
+import asyncio
+import json
+from typing import Optional
+
+from mcp.server.fastmcp import Context
+
+from ..app import mcp, READ, WRITE
+from ..connector import execute_command_on_device
+from ..inventory import get_inventory
+
+
+@mcp.tool(name="list_devices", annotations=READ)
+async def mikrotik_list_devices(ctx: Context) -> str:
+    """
+    Lists all MikroTik devices configured in the fleet inventory.
+
+    Returns a JSON array where each element contains the device name, host,
+    port, and tags.  This tool is read-only and never connects to any device.
+
+    Returns:
+        JSON array of device summaries, or a message when the inventory is empty.
+    """
+    await ctx.info("Listing fleet inventory devices")
+
+    inventory = get_inventory()
+    devices = inventory.get_all_devices()
+
+    if not devices:
+        return (
+            "No devices are configured in the fleet inventory. "
+            "Set MIKROTIK_DEVICES as a JSON array to define your fleet, e.g.:\n"
+            'MIKROTIK_DEVICES=\'[{"name":"mt-nl-1","host":"1.1.1.1","tags":["nl","eu"]}]\''
+        )
+
+    summary = [
+        {
+            "name": d.name,
+            "host": d.host,
+            "port": d.port,
+            "username": d.username,
+            "tags": d.tags,
+        }
+        for d in devices
+    ]
+    return json.dumps(summary, indent=2)
+
+
+@mcp.tool(name="run_command_on_device", annotations=WRITE)
+async def mikrotik_run_command_on_device(
+    ctx: Context,
+    device_name: str,
+    command: str,
+) -> str:
+    """
+    Executes a RouterOS command on a specific device from the fleet inventory.
+
+    The device is looked up by its configured name.  The command is executed via
+    a new SSH connection; it does NOT run inside the active Safe Mode session (if
+    any) because Safe Mode is per-connection to the default device.
+
+    Args:
+        device_name: The ``name`` of the target device as defined in MIKROTIK_DEVICES.
+        command: A RouterOS CLI command string (e.g. ``/ip address print``).
+
+    Returns:
+        The command output prefixed with the device name, or an error message.
+    """
+    await ctx.info(f"Running command on device '{device_name}': {command}")
+
+    inventory = get_inventory()
+    device = inventory.get_device(device_name)
+
+    if device is None:
+        available = inventory.list_names()
+        hint = f"Available devices: {available}" if available else "No devices are configured."
+        return f"Device '{device_name}' not found in fleet inventory. {hint}"
+
+    result = await execute_command_on_device(device, command, ctx)
+    return f"{device_name}:\n{result}"
+
+
+@mcp.tool(name="run_command_on_tag", annotations=WRITE)
+async def mikrotik_run_command_on_tag(
+    ctx: Context,
+    tag: str,
+    command: str,
+) -> str:
+    """
+    Executes a RouterOS command in parallel on every device that carries the given tag.
+
+    Results are returned as a JSON object keyed by device name so the caller can
+    immediately see which devices succeeded and which failed.
+
+    Args:
+        tag: The tag to match against device tags (e.g. ``"eu"`` or ``"core"``).
+        command: A RouterOS CLI command string (e.g. ``/system resource print``).
+
+    Returns:
+        JSON object mapping device names to their command output or error message.
+        Example: ``{"mt-nl-1": "...", "mt-usa-1": "Error: ..."}``
+    """
+    await ctx.info(f"Running command on all devices tagged '{tag}': {command}")
+
+    inventory = get_inventory()
+    devices = inventory.get_devices_by_tag(tag)
+
+    if not devices:
+        all_tags: set[str] = set()
+        for d in inventory.get_all_devices():
+            all_tags.update(d.tags)
+        hint = f"Known tags: {sorted(all_tags)}" if all_tags else "No devices are configured."
+        return f"No devices found with tag '{tag}'. {hint}"
+
+    tasks = [execute_command_on_device(d, command, ctx) for d in devices]
+    raw_results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    aggregated: dict[str, str] = {}
+    for device, result in zip(devices, raw_results):
+        if isinstance(result, Exception):
+            aggregated[device.name] = f"Error: {result}"
+        else:
+            aggregated[device.name] = str(result)
+
+    return json.dumps(aggregated, indent=2)
+
+
+@mcp.tool(name="run_command_on_all_devices", annotations=WRITE)
+async def mikrotik_run_command_on_all_devices(
+    ctx: Context,
+    command: str,
+    tag_filter: Optional[str] = None,
+) -> str:
+    """
+    Executes a RouterOS command in parallel on all devices in the fleet inventory.
+
+    Optionally restrict execution to devices that carry a specific tag via the
+    ``tag_filter`` parameter.  Results are returned as a JSON object keyed by
+    device name.
+
+    Args:
+        command: A RouterOS CLI command string (e.g. ``/system resource print``).
+        tag_filter: Optional tag — when provided only devices carrying this tag
+                    are targeted (equivalent to ``run_command_on_tag``).
+
+    Returns:
+        JSON object mapping device names to their command output or error message.
+        Example: ``{"mt-nl-1": "...", "mt-usa-1": "timeout", "mt-uae-1": "..."}``
+    """
+    inventory = get_inventory()
+
+    if tag_filter:
+        devices = inventory.get_devices_by_tag(tag_filter)
+        await ctx.info(
+            f"Running command on all devices (tag='{tag_filter}'): {command}"
+        )
+        if not devices:
+            return f"No devices found with tag '{tag_filter}'."
+    else:
+        devices = inventory.get_all_devices()
+        await ctx.info(f"Running command on all {len(devices)} device(s): {command}")
+        if not devices:
+            return (
+                "No devices are configured in the fleet inventory. "
+                "Set MIKROTIK_DEVICES to define your fleet."
+            )
+
+    tasks = [execute_command_on_device(d, command, ctx) for d in devices]
+    raw_results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    aggregated: dict[str, str] = {}
+    for device, result in zip(devices, raw_results):
+        if isinstance(result, Exception):
+            aggregated[device.name] = f"Error: {result}"
+        else:
+            aggregated[device.name] = str(result)
+
+    return json.dumps(aggregated, indent=2)

--- a/src/mcp_mikrotik/scope/interfaces.py
+++ b/src/mcp_mikrotik/scope/interfaces.py
@@ -14,6 +14,7 @@ async def mikrotik_list_interfaces(
     name_filter: Optional[str] = None,
     running_only: bool = False,
     disabled_only: bool = False,
+    device: Optional[str] = None,
 ) -> str:
     """Lists all interfaces on the MikroTik device (ethernet, bridge, WireGuard,
     PPPoE, VLAN, WiFi, SFP, LTE, loopback, and any other type).
@@ -22,6 +23,7 @@ async def mikrotik_list_interfaces(
         type_filter: RouterOS interface type e.g. "ether", "bridge", "vlan",
             "wg", "pppoe-out", "wifi", "lte", "loopback"
         name_filter: partial name match e.g. "ether" matches ether1, ether2 …
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info("Listing all interfaces")
 
@@ -40,7 +42,7 @@ async def mikrotik_list_interfaces(
     if filters:
         cmd += " where " + " ".join(filters)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return "No interfaces found matching the criteria."
@@ -49,16 +51,17 @@ async def mikrotik_list_interfaces(
 
 
 @mcp.tool(name="get_interface", annotations=annotate(READ, "Get Interface"))
-async def mikrotik_get_interface(ctx: Context, name: str) -> str:
+async def mikrotik_get_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
     """Gets detailed information about a specific interface by name.
 
     Notes:
         name: exact interface name e.g. "ether1", "bridge", "pppoe-out1", "wg0"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Getting interface details: name={name}")
 
     cmd = f'/interface print detail where name="{name}"'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return f"Interface '{name}' not found."
@@ -67,23 +70,24 @@ async def mikrotik_get_interface(ctx: Context, name: str) -> str:
 
 
 @mcp.tool(name="enable_interface", annotations=annotate(WRITE_IDEMPOTENT, "Enable Interface"))
-async def mikrotik_enable_interface(ctx: Context, name: str) -> str:
+async def mikrotik_enable_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
     """Enables an interface on the MikroTik device.
 
     Notes:
         name: exact interface name e.g. "ether1", "bridge", "pppoe-out1"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Enabling interface: name={name}")
 
     cmd = f'/interface enable [find name="{name}"]'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to enable interface '{name}': {result}"
 
     # Verify the change
     check_cmd = f'/interface print detail where name="{name}"'
-    details = await execute_mikrotik_command(check_cmd, ctx)
+    details = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if not details.strip():
         return f"Interface '{name}' not found."
@@ -92,23 +96,24 @@ async def mikrotik_enable_interface(ctx: Context, name: str) -> str:
 
 
 @mcp.tool(name="disable_interface", annotations=annotate(WRITE_IDEMPOTENT, "Disable Interface"))
-async def mikrotik_disable_interface(ctx: Context, name: str) -> str:
+async def mikrotik_disable_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
     """Disables an interface on the MikroTik device.
 
     Notes:
         name: exact interface name e.g. "ether1", "bridge", "pppoe-out1"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Disabling interface: name={name}")
 
     cmd = f'/interface disable [find name="{name}"]'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to disable interface '{name}': {result}"
 
     # Verify the change
     check_cmd = f'/interface print detail where name="{name}"'
-    details = await execute_mikrotik_command(check_cmd, ctx)
+    details = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if not details.strip():
         return f"Interface '{name}' not found."

--- a/src/mcp_mikrotik/scope/interfaces.py
+++ b/src/mcp_mikrotik/scope/interfaces.py
@@ -23,7 +23,6 @@ async def mikrotik_list_interfaces(
         type_filter: RouterOS interface type e.g. "ether", "bridge", "vlan",
             "wg", "pppoe-out", "wifi", "lte", "loopback"
         name_filter: partial name match e.g. "ether" matches ether1, ether2 …
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info("Listing all interfaces")
 
@@ -56,7 +55,6 @@ async def mikrotik_get_interface(ctx: Context, name: str, device: Optional[str] 
 
     Notes:
         name: exact interface name e.g. "ether1", "bridge", "pppoe-out1", "wg0"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Getting interface details: name={name}")
 
@@ -75,7 +73,6 @@ async def mikrotik_enable_interface(ctx: Context, name: str, device: Optional[st
 
     Notes:
         name: exact interface name e.g. "ether1", "bridge", "pppoe-out1"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Enabling interface: name={name}")
 
@@ -101,7 +98,6 @@ async def mikrotik_disable_interface(ctx: Context, name: str, device: Optional[s
 
     Notes:
         name: exact interface name e.g. "ether1", "bridge", "pppoe-out1"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Disabling interface: name={name}")
 

--- a/src/mcp_mikrotik/scope/inventory.py
+++ b/src/mcp_mikrotik/scope/inventory.py
@@ -1,0 +1,47 @@
+from mcp.server.mcpserver import Context
+
+from ..app import mcp, READ, annotate
+from ..inventory import get_inventory
+
+
+@mcp.tool(name="list_devices", annotations=annotate(READ, "List Devices"))
+async def mikrotik_list_devices(ctx: Context) -> str:
+    """Lists the MikroTik devices this server manages.
+
+    Use this to discover which devices are available and what their titles are.
+    Every other tool takes an optional `device` argument that must be one of the
+    titles returned here. When only one device is configured, `device` may be
+    omitted and that device is used automatically.
+
+    Credentials are never returned.
+    """
+    await ctx.info("Listing inventory devices")
+
+    inventory = get_inventory()
+    devices = inventory.describe()
+
+    if not devices:
+        return "No MikroTik devices are configured."
+
+    lines = [f"MIKROTIK DEVICES ({len(devices)}):", ""]
+    for d in devices:
+        parts = [f"  title: {d['title']}", f"host: {d['host']}:{d['port']}", f"user: {d['username']}"]
+        if d.get("region"):
+            parts.append(f"region: {d['region']}")
+        if d.get("tags"):
+            parts.append(f"tags: {', '.join(d['tags'])}")
+        lines.append(" | ".join(parts))
+
+    if len(devices) == 1:
+        lines.append("")
+        lines.append(
+            "Only one device is configured, so the `device` argument can be omitted."
+        )
+    else:
+        lines.append("")
+        lines.append(
+            "Multiple devices are configured — pass the chosen title as the "
+            "`device` argument of each tool."
+        )
+
+    return "\n".join(lines)

--- a/src/mcp_mikrotik/scope/ip_address.py
+++ b/src/mcp_mikrotik/scope/ip_address.py
@@ -12,9 +12,14 @@ async def mikrotik_add_ip_address(
     network: Optional[str] = None,
     broadcast: Optional[str] = None,
     comment: Optional[str] = None,
-    disabled: bool = False
+    disabled: bool = False,
+    device: Optional[str] = None
 ) -> str:
-    """Adds an IP address to an interface on the MikroTik device."""
+    """Adds an IP address to an interface on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Adding IP address: address={address}, interface={interface}")
 
     # Build the command
@@ -33,14 +38,14 @@ async def mikrotik_add_ip_address(
     if disabled:
         cmd += " disabled=yes"
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to add IP address: {result}"
 
     # Get the created address details
     details_cmd = f'/ip address print detail where address="{address}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
     return f"IP address added successfully:\n\n{details}"
 
@@ -51,9 +56,14 @@ async def mikrotik_list_ip_addresses(
     address_filter: Optional[str] = None,
     network_filter: Optional[str] = None,
     disabled_only: bool = False,
-    dynamic_only: bool = False
+    dynamic_only: bool = False,
+    device: Optional[str] = None
 ) -> str:
-    """Lists IP addresses on the MikroTik device."""
+    """Lists IP addresses on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Listing IP addresses with filters: interface={interface_filter}, address={address_filter}")
 
     # Build the command
@@ -75,7 +85,7 @@ async def mikrotik_list_ip_addresses(
     if filters:
         cmd += " where " + " ".join(filters)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return "No IP addresses found matching the criteria."
@@ -83,18 +93,22 @@ async def mikrotik_list_ip_addresses(
     return f"IP ADDRESSES:\n\n{result}"
 
 @mcp.tool(name="get_ip_address", annotations=annotate(READ, "Get IP Address"))
-async def mikrotik_get_ip_address(ctx: Context, address_id: str) -> str:
-    """Gets detailed information about a specific IP address by ID or address value."""
+async def mikrotik_get_ip_address(ctx: Context, address_id: str, device: Optional[str] = None) -> str:
+    """Gets detailed information about a specific IP address by ID or address value.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Getting IP address details: address_id={address_id}")
 
     # Try to find by ID first, then by address
     cmd = f'/ip address print detail where .id="{address_id}"'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         # Try finding by address value
         cmd = f'/ip address print detail where address="{address_id}"'
-        result = await execute_mikrotik_command(cmd, ctx)
+        result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return f"IP address '{address_id}' not found."
@@ -102,18 +116,22 @@ async def mikrotik_get_ip_address(ctx: Context, address_id: str) -> str:
     return f"IP ADDRESS DETAILS:\n\n{result}"
 
 @mcp.tool(name="remove_ip_address", annotations=annotate(DESTRUCTIVE, "Remove IP Address"))
-async def mikrotik_remove_ip_address(ctx: Context, address_id: str) -> str:
-    """Removes an IP address from the MikroTik device by ID or address value."""
+async def mikrotik_remove_ip_address(ctx: Context, address_id: str, device: Optional[str] = None) -> str:
+    """Removes an IP address from the MikroTik device by ID or address value.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Removing IP address: address_id={address_id}")
 
     # Try to find by ID first
     check_cmd = f'/ip address print count-only where .id="{address_id}"'
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         # Try finding by address value
         check_cmd = f'/ip address print count-only where address="{address_id}"'
-        count = await execute_mikrotik_command(check_cmd, ctx)
+        count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
         if count.strip() == "0":
             return f"IP address '{address_id}' not found."
@@ -124,7 +142,7 @@ async def mikrotik_remove_ip_address(ctx: Context, address_id: str) -> str:
         # Remove by ID
         cmd = f'/ip address remove [find .id="{address_id}"]'
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to remove IP address: {result}"

--- a/src/mcp_mikrotik/scope/ip_address.py
+++ b/src/mcp_mikrotik/scope/ip_address.py
@@ -15,11 +15,7 @@ async def mikrotik_add_ip_address(
     disabled: bool = False,
     device: Optional[str] = None
 ) -> str:
-    """Adds an IP address to an interface on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Adds an IP address to an interface on the MikroTik device."""
     await ctx.info(f"Adding IP address: address={address}, interface={interface}")
 
     # Build the command
@@ -59,11 +55,7 @@ async def mikrotik_list_ip_addresses(
     dynamic_only: bool = False,
     device: Optional[str] = None
 ) -> str:
-    """Lists IP addresses on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Lists IP addresses on the MikroTik device."""
     await ctx.info(f"Listing IP addresses with filters: interface={interface_filter}, address={address_filter}")
 
     # Build the command
@@ -94,11 +86,7 @@ async def mikrotik_list_ip_addresses(
 
 @mcp.tool(name="get_ip_address", annotations=annotate(READ, "Get IP Address"))
 async def mikrotik_get_ip_address(ctx: Context, address_id: str, device: Optional[str] = None) -> str:
-    """Gets detailed information about a specific IP address by ID or address value.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets detailed information about a specific IP address by ID or address value."""
     await ctx.info(f"Getting IP address details: address_id={address_id}")
 
     # Try to find by ID first, then by address
@@ -117,11 +105,7 @@ async def mikrotik_get_ip_address(ctx: Context, address_id: str, device: Optiona
 
 @mcp.tool(name="remove_ip_address", annotations=annotate(DESTRUCTIVE, "Remove IP Address"))
 async def mikrotik_remove_ip_address(ctx: Context, address_id: str, device: Optional[str] = None) -> str:
-    """Removes an IP address from the MikroTik device by ID or address value.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Removes an IP address from the MikroTik device by ID or address value."""
     await ctx.info(f"Removing IP address: address_id={address_id}")
 
     # Try to find by ID first

--- a/src/mcp_mikrotik/scope/ip_pool.py
+++ b/src/mcp_mikrotik/scope/ip_pool.py
@@ -11,13 +11,15 @@ async def mikrotik_create_ip_pool(
     name: str,
     ranges: str,
     next_pool: Optional[str] = None,
-    comment: Optional[str] = None
+    comment: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
     """Creates an IP pool with the given address ranges on the MikroTik device.
 
     Notes:
         ranges: hyphen-separated range(s) e.g. "192.168.1.1-192.168.1.100"
             Multiple ranges comma-separated: "10.0.0.1-10.0.0.50,10.0.0.100-10.0.0.120"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Creating IP pool: name={name}, ranges={ranges}")
 
@@ -31,7 +33,7 @@ async def mikrotik_create_ip_pool(
     if comment:
         cmd += f' comment="{comment}"'
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     # Check if creation was successful
     if result.strip():
@@ -39,7 +41,7 @@ async def mikrotik_create_ip_pool(
         if "*" in result or result.strip().isdigit():
             # Success - get the details
             details_cmd = f'/ip pool print detail where name="{name}"'
-            details = await execute_mikrotik_command(details_cmd, ctx)
+            details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
             if details.strip():
                 return f"IP pool created successfully:\n\n{details}"
@@ -51,7 +53,7 @@ async def mikrotik_create_ip_pool(
     else:
         # No output might mean success, let's check
         details_cmd = f'/ip pool print detail where name="{name}"'
-        details = await execute_mikrotik_command(details_cmd, ctx)
+        details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
         if details.strip():
             return f"IP pool created successfully:\n\n{details}"
@@ -63,9 +65,14 @@ async def mikrotik_list_ip_pools(
     ctx: Context,
     name_filter: Optional[str] = None,
     ranges_filter: Optional[str] = None,
-    include_used: bool = False
+    include_used: bool = False,
+    device: Optional[str] = None
 ) -> str:
-    """Lists IP pools on the MikroTik device."""
+    """Lists IP pools on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Listing IP pools with filters: name={name_filter}, ranges={ranges_filter}")
 
     # Build the command
@@ -84,7 +91,7 @@ async def mikrotik_list_ip_pools(
     if filters:
         cmd += " where " + " ".join(filters)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     # Check for empty result
     if not result or result.strip() == "" or result.strip() == "no such item":
@@ -105,7 +112,7 @@ async def mikrotik_list_ip_pools(
                     pool_name = line[name_start:name_end]
                     # Get used addresses for this pool
                     used_cmd = f'/ip pool used print count-only where pool="{pool_name}"'
-                    used_count = await execute_mikrotik_command(used_cmd, ctx)
+                    used_count = await execute_mikrotik_command(used_cmd, ctx, device=device)
                     if used_count.strip().isdigit():
                         output_lines.append(f"      used-addresses={used_count.strip()}")
 
@@ -114,19 +121,23 @@ async def mikrotik_list_ip_pools(
     return f"IP POOLS:\n\n{result}"
 
 @mcp.tool(name="get_ip_pool", annotations=annotate(READ, "Get IP Pool"))
-async def mikrotik_get_ip_pool(ctx: Context, name: str) -> str:
-    """Gets detailed information about a specific IP pool including used address count."""
+async def mikrotik_get_ip_pool(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Gets detailed information about a specific IP pool including used address count.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Getting IP pool details: name={name}")
 
     cmd = f'/ip pool print detail where name="{name}"'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return f"IP pool '{name}' not found."
 
     # Get used addresses count
     used_cmd = f'/ip pool used print count-only where pool="{name}"'
-    used_count = await execute_mikrotik_command(used_cmd, ctx)
+    used_count = await execute_mikrotik_command(used_cmd, ctx, device=device)
 
     if used_count.strip().isdigit():
         return f"IP POOL DETAILS:\n\n{result}\n      used-addresses={used_count.strip()}"
@@ -140,7 +151,8 @@ async def mikrotik_update_ip_pool(
     new_name: Optional[str] = None,
     ranges: Optional[str] = None,
     next_pool: Optional[str] = None,
-    comment: Optional[str] = None
+    comment: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
     """Updates an existing IP pool's name, ranges, or next-pool reference.
 
@@ -148,6 +160,7 @@ async def mikrotik_update_ip_pool(
         ranges: hyphen-separated range(s) e.g. "192.168.1.1-192.168.1.100"
             Multiple ranges comma-separated: "10.0.0.1-10.0.0.50,10.0.0.100-10.0.0.120"
         Pass "" for next_pool to clear it.
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Updating IP pool: name={name}")
 
@@ -173,7 +186,7 @@ async def mikrotik_update_ip_pool(
 
     cmd += " " + " ".join(updates)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     # Check if update was successful
     if "failure:" in result.lower() or "error" in result.lower():
@@ -182,39 +195,43 @@ async def mikrotik_update_ip_pool(
     # Get the updated pool details
     details_name = new_name if new_name else name
     details_cmd = f'/ip pool print detail where name="{details_name}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
     return f"IP pool updated successfully:\n\n{details}"
 
 @mcp.tool(name="remove_ip_pool", annotations=annotate(DESTRUCTIVE, "Remove IP Pool"))
-async def mikrotik_remove_ip_pool(ctx: Context, name: str) -> str:
-    """Removes an IP pool from the MikroTik device (fails if pool is in use)."""
+async def mikrotik_remove_ip_pool(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Removes an IP pool from the MikroTik device (fails if pool is in use).
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Removing IP pool: name={name}")
 
     # First check if the pool exists
     check_cmd = f'/ip pool print count-only where name="{name}"'
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         return f"IP pool '{name}' not found."
 
     # Check if pool is in use
     pool_used_cmd = f'/ip pool used print count-only where pool="{name}"'
-    used_count = await execute_mikrotik_command(pool_used_cmd, ctx)
+    used_count = await execute_mikrotik_command(pool_used_cmd, ctx, device=device)
 
     if used_count.strip() != "0":
         return f"Cannot remove IP pool '{name}': {used_count.strip()} addresses are currently in use."
 
     # Check if pool is referenced by DHCP servers
     dhcp_check_cmd = f'/ip dhcp-server print count-only where address-pool="{name}"'
-    dhcp_count = await execute_mikrotik_command(dhcp_check_cmd, ctx)
+    dhcp_count = await execute_mikrotik_command(dhcp_check_cmd, ctx, device=device)
 
     if dhcp_count.strip() != "0":
         return f"Cannot remove IP pool '{name}': It is used by {dhcp_count.strip()} DHCP server(s)."
 
     # Remove the pool
     cmd = f'/ip pool remove [find name="{name}"]'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to remove IP pool: {result}"
@@ -227,9 +244,14 @@ async def mikrotik_list_ip_pool_used(
     pool_name: Optional[str] = None,
     address_filter: Optional[str] = None,
     mac_filter: Optional[str] = None,
-    info_filter: Optional[str] = None
+    info_filter: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
-    """Lists currently used (allocated) addresses from IP pools."""
+    """Lists currently used (allocated) addresses from IP pools.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Listing used IP pool addresses: pool={pool_name}, address={address_filter}")
 
     cmd = "/ip pool used print"
@@ -248,7 +270,7 @@ async def mikrotik_list_ip_pool_used(
     if filters:
         cmd += " where " + " ".join(filters)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "" or result.strip() == "no such item":
         return "No used addresses found matching the criteria."
@@ -256,18 +278,19 @@ async def mikrotik_list_ip_pool_used(
     return f"USED IP POOL ADDRESSES:\n\n{result}"
 
 @mcp.tool(name="expand_ip_pool", annotations=annotate(WRITE_IDEMPOTENT, "Expand IP Pool"))
-async def mikrotik_expand_ip_pool(ctx: Context, name: str, additional_ranges: str) -> str:
+async def mikrotik_expand_ip_pool(ctx: Context, name: str, additional_ranges: str, device: Optional[str] = None) -> str:
     """Expands an existing IP pool by appending additional address ranges.
 
     Notes:
         additional_ranges: hyphen-separated range(s) e.g. "192.168.1.101-192.168.1.150"
             Multiple ranges comma-separated: "10.0.0.51-10.0.0.60,10.0.0.70-10.0.0.80"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Expanding IP pool: name={name}, additional_ranges={additional_ranges}")
 
     # Get current ranges
     get_cmd = f'/ip pool print detail where name="{name}"'
-    current = await execute_mikrotik_command(get_cmd, ctx)
+    current = await execute_mikrotik_command(get_cmd, ctx, device=device)
 
     if not current or "no such item" in current:
         return f"IP pool '{name}' not found."
@@ -284,4 +307,4 @@ async def mikrotik_expand_ip_pool(ctx: Context, name: str, additional_ranges: st
     new_ranges = f"{current_ranges},{additional_ranges}"
 
     # Update the pool
-    return await mikrotik_update_ip_pool(name, ranges=new_ranges, ctx=ctx)
+    return await mikrotik_update_ip_pool(name, ranges=new_ranges, ctx=ctx, device=device)

--- a/src/mcp_mikrotik/scope/ip_pool.py
+++ b/src/mcp_mikrotik/scope/ip_pool.py
@@ -19,7 +19,6 @@ async def mikrotik_create_ip_pool(
     Notes:
         ranges: hyphen-separated range(s) e.g. "192.168.1.1-192.168.1.100"
             Multiple ranges comma-separated: "10.0.0.1-10.0.0.50,10.0.0.100-10.0.0.120"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Creating IP pool: name={name}, ranges={ranges}")
 
@@ -68,11 +67,7 @@ async def mikrotik_list_ip_pools(
     include_used: bool = False,
     device: Optional[str] = None
 ) -> str:
-    """Lists IP pools on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Lists IP pools on the MikroTik device."""
     await ctx.info(f"Listing IP pools with filters: name={name_filter}, ranges={ranges_filter}")
 
     # Build the command
@@ -122,11 +117,7 @@ async def mikrotik_list_ip_pools(
 
 @mcp.tool(name="get_ip_pool", annotations=annotate(READ, "Get IP Pool"))
 async def mikrotik_get_ip_pool(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Gets detailed information about a specific IP pool including used address count.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets detailed information about a specific IP pool including used address count."""
     await ctx.info(f"Getting IP pool details: name={name}")
 
     cmd = f'/ip pool print detail where name="{name}"'
@@ -160,7 +151,6 @@ async def mikrotik_update_ip_pool(
         ranges: hyphen-separated range(s) e.g. "192.168.1.1-192.168.1.100"
             Multiple ranges comma-separated: "10.0.0.1-10.0.0.50,10.0.0.100-10.0.0.120"
         Pass "" for next_pool to clear it.
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Updating IP pool: name={name}")
 
@@ -201,11 +191,7 @@ async def mikrotik_update_ip_pool(
 
 @mcp.tool(name="remove_ip_pool", annotations=annotate(DESTRUCTIVE, "Remove IP Pool"))
 async def mikrotik_remove_ip_pool(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Removes an IP pool from the MikroTik device (fails if pool is in use).
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Removes an IP pool from the MikroTik device (fails if pool is in use)."""
     await ctx.info(f"Removing IP pool: name={name}")
 
     # First check if the pool exists
@@ -247,11 +233,7 @@ async def mikrotik_list_ip_pool_used(
     info_filter: Optional[str] = None,
     device: Optional[str] = None
 ) -> str:
-    """Lists currently used (allocated) addresses from IP pools.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Lists currently used (allocated) addresses from IP pools."""
     await ctx.info(f"Listing used IP pool addresses: pool={pool_name}, address={address_filter}")
 
     cmd = "/ip pool used print"
@@ -284,7 +266,6 @@ async def mikrotik_expand_ip_pool(ctx: Context, name: str, additional_ranges: st
     Notes:
         additional_ranges: hyphen-separated range(s) e.g. "192.168.1.101-192.168.1.150"
             Multiple ranges comma-separated: "10.0.0.51-10.0.0.60,10.0.0.70-10.0.0.80"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Expanding IP pool: name={name}, additional_ranges={additional_ranges}")
 

--- a/src/mcp_mikrotik/scope/ipv6_address.py
+++ b/src/mcp_mikrotik/scope/ipv6_address.py
@@ -35,6 +35,7 @@ async def mikrotik_add_ipv6_address(
     no_dad: Optional[bool] = None,
     comment: Optional[str] = None,
     disabled: bool = False,
+    device: Optional[str] = None,
 ) -> str:
     """Adds an IPv6 address to an interface on the MikroTik device.
 
@@ -46,6 +47,7 @@ async def mikrotik_add_ipv6_address(
         eui_64: derive the host part of the address from the interface MAC.
         from_pool: name of an IPv6 pool to take the prefix from.
         no_dad: skip Duplicate Address Detection.
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Adding IPv6 address: address={address}, interface={interface}")
 
@@ -64,7 +66,7 @@ async def mikrotik_add_ipv6_address(
     if disabled:
         cmd += " disabled=yes"
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to add IPv6 address: {result}"
@@ -75,7 +77,7 @@ async def mikrotik_add_ipv6_address(
     # MAC — in both cases the stored address differs from the input, so a
     # by-address lookup would miss the very entry we just created.
     details_cmd = f'/ipv6 address print detail where interface="{interface}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
     if details.strip() and "address=" in details:
         return f"IPv6 address added successfully (addresses on {interface}):\n\n{details}"
@@ -91,6 +93,7 @@ async def mikrotik_list_ipv6_addresses(
     dynamic_only: bool = False,
     global_only: bool = False,
     link_local_only: bool = False,
+    device: Optional[str] = None,
 ) -> str:
     """Lists IPv6 addresses on the MikroTik device.
 
@@ -98,6 +101,7 @@ async def mikrotik_list_ipv6_addresses(
         address_filter: partial match on the address, e.g. "2001:db8" or "fe80".
         global_only: show only global (routable) addresses.
         link_local_only: show only link-local (fe80::/10) addresses.
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(
         f"Listing IPv6 addresses with filters: interface={interface_filter}, address={address_filter}"
@@ -122,7 +126,7 @@ async def mikrotik_list_ipv6_addresses(
     if filters:
         cmd += " where " + " ".join(filters)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return "No IPv6 addresses found matching the criteria."
@@ -131,12 +135,15 @@ async def mikrotik_list_ipv6_addresses(
 
 
 @mcp.tool(name="get_ipv6_address", annotations=annotate(READ, "Get IPv6 Address"))
-async def mikrotik_get_ipv6_address(ctx: Context, address_id: str) -> str:
+async def mikrotik_get_ipv6_address(
+    ctx: Context, address_id: str, device: Optional[str] = None
+) -> str:
     """Gets detailed information about a specific IPv6 address by ID or address value.
 
     Notes:
         address_id: a RouterOS internal id (e.g. "*1") or the address value
             (e.g. "2001:db8::1/64").
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Getting IPv6 address details: address_id={address_id}")
 
@@ -153,7 +160,7 @@ async def mikrotik_get_ipv6_address(ctx: Context, address_id: str) -> str:
 
     for where in queries:
         result = await execute_mikrotik_command(
-            f"/ipv6 address print detail where {where}", ctx
+            f"/ipv6 address print detail where {where}", ctx, device=device
         )
         if result and "address=" in result:
             return f"IPV6 ADDRESS DETAILS:\n\n{result}"
@@ -162,12 +169,15 @@ async def mikrotik_get_ipv6_address(ctx: Context, address_id: str) -> str:
 
 
 @mcp.tool(name="remove_ipv6_address", annotations=annotate(DESTRUCTIVE, "Remove IPv6 Address"))
-async def mikrotik_remove_ipv6_address(ctx: Context, address_id: str) -> str:
+async def mikrotik_remove_ipv6_address(
+    ctx: Context, address_id: str, device: Optional[str] = None
+) -> str:
     """Removes an IPv6 address from the MikroTik device by ID or address value.
 
     Notes:
         address_id: a RouterOS internal id (e.g. "*1") or the address value
             (e.g. "2001:db8::1/64").
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Removing IPv6 address: address_id={address_id}")
 
@@ -175,12 +185,12 @@ async def mikrotik_remove_ipv6_address(ctx: Context, address_id: str) -> str:
 
     # Try to find by ID first
     check_cmd = f'/ipv6 address print count-only where .id="{address_id}"'
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         # Try finding by (canonicalized) address value
         check_cmd = f'/ipv6 address print count-only where address="{addr}"'
-        count = await execute_mikrotik_command(check_cmd, ctx)
+        count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
         if count.strip() == "0":
             return f"IPv6 address '{address_id}' not found."
@@ -189,7 +199,7 @@ async def mikrotik_remove_ipv6_address(ctx: Context, address_id: str) -> str:
     else:
         cmd = f'/ipv6 address remove [find .id="{address_id}"]'
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to remove IPv6 address: {result}"

--- a/src/mcp_mikrotik/scope/ipv6_address.py
+++ b/src/mcp_mikrotik/scope/ipv6_address.py
@@ -47,7 +47,6 @@ async def mikrotik_add_ipv6_address(
         eui_64: derive the host part of the address from the interface MAC.
         from_pool: name of an IPv6 pool to take the prefix from.
         no_dad: skip Duplicate Address Detection.
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Adding IPv6 address: address={address}, interface={interface}")
 
@@ -101,7 +100,6 @@ async def mikrotik_list_ipv6_addresses(
         address_filter: partial match on the address, e.g. "2001:db8" or "fe80".
         global_only: show only global (routable) addresses.
         link_local_only: show only link-local (fe80::/10) addresses.
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(
         f"Listing IPv6 addresses with filters: interface={interface_filter}, address={address_filter}"
@@ -143,7 +141,6 @@ async def mikrotik_get_ipv6_address(
     Notes:
         address_id: a RouterOS internal id (e.g. "*1") or the address value
             (e.g. "2001:db8::1/64").
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Getting IPv6 address details: address_id={address_id}")
 
@@ -177,7 +174,6 @@ async def mikrotik_remove_ipv6_address(
     Notes:
         address_id: a RouterOS internal id (e.g. "*1") or the address value
             (e.g. "2001:db8::1/64").
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Removing IPv6 address: address_id={address_id}")
 

--- a/src/mcp_mikrotik/scope/logs.py
+++ b/src/mcp_mikrotik/scope/logs.py
@@ -19,11 +19,7 @@ async def mikrotik_get_logs(
     print_as: Literal["value", "detail", "terse"] = "value",
     device: Optional[str] = None
 ) -> str:
-    """Gets logs from the MikroTik device with optional topic, time, and message filters.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets logs from the MikroTik device with optional topic, time, and message filters."""
     await ctx.info(f"Getting logs with filters: topics={topics}, action={action}, time={time_filter}")
 
     # Build the command
@@ -78,11 +74,7 @@ async def mikrotik_get_logs_by_severity(
     limit: Optional[int] = None,
     device: Optional[str] = None
 ) -> str:
-    """Gets logs filtered by severity level (debug/info/warning/error/critical).
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets logs filtered by severity level (debug/info/warning/error/critical)."""
     await ctx.info(f"Getting logs by severity: severity={severity}")
 
     # Map severity to topics
@@ -112,11 +104,7 @@ async def mikrotik_get_logs_by_topic(
     limit: Optional[int] = None,
     device: Optional[str] = None
 ) -> str:
-    """Gets logs for a specific topic/facility (system, dhcp, interface, firewall, etc.).
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets logs for a specific topic/facility (system, dhcp, interface, firewall, etc.)."""
     await ctx.info(f"Getting logs by topic: topic={topic}")
 
     return await mikrotik_get_logs(
@@ -136,11 +124,7 @@ async def mikrotik_search_logs(
     limit: Optional[int] = None,
     device: Optional[str] = None
 ) -> str:
-    """Searches log messages for a specific term.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Searches log messages for a specific term."""
     await ctx.info(f"Searching logs for: term={search_term}")
 
     # Adjust search term for case sensitivity
@@ -167,11 +151,7 @@ async def mikrotik_get_system_events(
     limit: Optional[int] = None,
     device: Optional[str] = None
 ) -> str:
-    """Gets system-related log events (login, reboot, config-change, etc.).
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets system-related log events (login, reboot, config-change, etc.)."""
     await ctx.info(f"Getting system events: type={event_type}")
 
     # Build filter based on event type
@@ -210,11 +190,7 @@ async def mikrotik_get_security_logs(
     limit: Optional[int] = None,
     device: Optional[str] = None
 ) -> str:
-    """Gets security-related log entries (login failures, blocked connections, etc.).
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets security-related log entries (login failures, blocked connections, etc.)."""
     await ctx.info("Getting security logs")
 
     # Security-related topics and keywords
@@ -238,11 +214,7 @@ async def mikrotik_get_security_logs(
 
 @mcp.tool(name="clear_logs", annotations=annotate(DESTRUCTIVE, "Clear Logs"))
 async def mikrotik_clear_logs(ctx: Context, device: Optional[str] = None) -> str:
-    """Clears all logs from the MikroTik device. This action cannot be undone.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Clears all logs from the MikroTik device. This action cannot be undone."""
     await ctx.info("Clearing all logs")
 
     cmd = "/log print follow-only"
@@ -255,11 +227,7 @@ async def mikrotik_clear_logs(ctx: Context, device: Optional[str] = None) -> str
 
 @mcp.tool(name="get_log_statistics", annotations=annotate(READ, "Log Statistics"))
 async def mikrotik_get_log_statistics(ctx: Context, device: Optional[str] = None) -> str:
-    """Gets log entry counts by topic and severity from the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets log entry counts by topic and severity from the MikroTik device."""
     await ctx.info("Getting log statistics")
 
     # Get total count
@@ -297,11 +265,7 @@ async def mikrotik_export_logs(
     format: Literal["plain", "csv"] = "plain",
     device: Optional[str] = None
 ) -> str:
-    """Exports logs to a file on the MikroTik device with optional topic and time filters.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Exports logs to a file on the MikroTik device with optional topic and time filters."""
     if not filename:
         filename = f"logs_export_{int(time.time())}"
 
@@ -335,11 +299,7 @@ async def mikrotik_monitor_logs(
     duration: int = 10,
     device: Optional[str] = None
 ) -> str:
-    """Monitors MikroTik logs in near-real-time for a limited duration (max 60s).
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Monitors MikroTik logs in near-real-time for a limited duration (max 60s)."""
     await ctx.info(f"Monitoring logs for {duration} seconds")
 
     # Limit duration for safety

--- a/src/mcp_mikrotik/scope/logs.py
+++ b/src/mcp_mikrotik/scope/logs.py
@@ -16,9 +16,14 @@ async def mikrotik_get_logs(
     prefix_filter: Optional[str] = None,
     limit: Optional[int] = None,
     follow: bool = False,
-    print_as: Literal["value", "detail", "terse"] = "value"
+    print_as: Literal["value", "detail", "terse"] = "value",
+    device: Optional[str] = None
 ) -> str:
-    """Gets logs from the MikroTik device with optional topic, time, and message filters."""
+    """Gets logs from the MikroTik device with optional topic, time, and message filters.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Getting logs with filters: topics={topics}, action={action}, time={time_filter}")
 
     # Build the command
@@ -58,7 +63,7 @@ async def mikrotik_get_logs(
     if follow:
         cmd += " follow"
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "" or result.strip() == "no such item":
         return "No log entries found matching the criteria."
@@ -70,9 +75,14 @@ async def mikrotik_get_logs_by_severity(
     ctx: Context,
     severity: Literal["debug", "info", "warning", "error", "critical"],
     time_filter: Optional[str] = None,
-    limit: Optional[int] = None
+    limit: Optional[int] = None,
+    device: Optional[str] = None
 ) -> str:
-    """Gets logs filtered by severity level (debug/info/warning/error/critical)."""
+    """Gets logs filtered by severity level (debug/info/warning/error/critical).
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Getting logs by severity: severity={severity}")
 
     # Map severity to topics
@@ -90,7 +100,8 @@ async def mikrotik_get_logs_by_severity(
         topics=topics,
         time_filter=time_filter,
         limit=limit,
-        ctx=ctx
+        ctx=ctx,
+        device=device
     )
 
 @mcp.tool(name="get_logs_by_topic", annotations=annotate(READ, "Get Logs by Topic"))
@@ -98,16 +109,22 @@ async def mikrotik_get_logs_by_topic(
     ctx: Context,
     topic: str,
     time_filter: Optional[str] = None,
-    limit: Optional[int] = None
+    limit: Optional[int] = None,
+    device: Optional[str] = None
 ) -> str:
-    """Gets logs for a specific topic/facility (system, dhcp, interface, firewall, etc.)."""
+    """Gets logs for a specific topic/facility (system, dhcp, interface, firewall, etc.).
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Getting logs by topic: topic={topic}")
 
     return await mikrotik_get_logs(
         topics=topic,
         time_filter=time_filter,
         limit=limit,
-        ctx=ctx
+        ctx=ctx,
+        device=device
     )
 
 @mcp.tool(name="search_logs", annotations=annotate(READ, "Search Logs"))
@@ -116,9 +133,14 @@ async def mikrotik_search_logs(
     search_term: str,
     time_filter: Optional[str] = None,
     case_sensitive: bool = False,
-    limit: Optional[int] = None
+    limit: Optional[int] = None,
+    device: Optional[str] = None
 ) -> str:
-    """Searches log messages for a specific term."""
+    """Searches log messages for a specific term.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Searching logs for: term={search_term}")
 
     # Adjust search term for case sensitivity
@@ -133,7 +155,8 @@ async def mikrotik_search_logs(
         message_filter=message_filter,
         time_filter=time_filter,
         limit=limit,
-        ctx=ctx
+        ctx=ctx,
+        device=device
     )
 
 @mcp.tool(name="get_system_events", annotations=annotate(READ, "System Events"))
@@ -141,9 +164,14 @@ async def mikrotik_get_system_events(
     ctx: Context,
     event_type: Optional[str] = None,
     time_filter: Optional[str] = None,
-    limit: Optional[int] = None
+    limit: Optional[int] = None,
+    device: Optional[str] = None
 ) -> str:
-    """Gets system-related log events (login, reboot, config-change, etc.)."""
+    """Gets system-related log events (login, reboot, config-change, etc.).
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Getting system events: type={event_type}")
 
     # Build filter based on event type
@@ -171,16 +199,22 @@ async def mikrotik_get_system_events(
         message_filter=message_filter,
         time_filter=time_filter,
         limit=limit,
-        ctx=ctx
+        ctx=ctx,
+        device=device
     )
 
 @mcp.tool(name="get_security_logs", annotations=annotate(READ, "Security Logs"))
 async def mikrotik_get_security_logs(
     ctx: Context,
     time_filter: Optional[str] = None,
-    limit: Optional[int] = None
+    limit: Optional[int] = None,
+    device: Optional[str] = None
 ) -> str:
-    """Gets security-related log entries (login failures, blocked connections, etc.)."""
+    """Gets security-related log entries (login failures, blocked connections, etc.).
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Getting security logs")
 
     # Security-related topics and keywords
@@ -195,7 +229,7 @@ async def mikrotik_get_security_logs(
     if limit:
         cmd += f" limit={limit}"
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "" or result.strip() == "no such item":
         return "No security-related log entries found."
@@ -203,12 +237,16 @@ async def mikrotik_get_security_logs(
     return f"SECURITY LOG ENTRIES:\n\n{result}"
 
 @mcp.tool(name="clear_logs", annotations=annotate(DESTRUCTIVE, "Clear Logs"))
-async def mikrotik_clear_logs(ctx: Context) -> str:
-    """Clears all logs from the MikroTik device. This action cannot be undone."""
+async def mikrotik_clear_logs(ctx: Context, device: Optional[str] = None) -> str:
+    """Clears all logs from the MikroTik device. This action cannot be undone.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Clearing all logs")
 
     cmd = "/log print follow-only"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result.strip():
         return "Logs cleared successfully."
@@ -216,13 +254,17 @@ async def mikrotik_clear_logs(ctx: Context) -> str:
         return f"Log clear result: {result}"
 
 @mcp.tool(name="get_log_statistics", annotations=annotate(READ, "Log Statistics"))
-async def mikrotik_get_log_statistics(ctx: Context) -> str:
-    """Gets log entry counts by topic and severity from the MikroTik device."""
+async def mikrotik_get_log_statistics(ctx: Context, device: Optional[str] = None) -> str:
+    """Gets log entry counts by topic and severity from the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Getting log statistics")
 
     # Get total count
     total_cmd = "/log print count-only"
-    total_count = await execute_mikrotik_command(total_cmd, ctx)
+    total_count = await execute_mikrotik_command(total_cmd, ctx, device=device)
 
     stats = [f"Total log entries: {total_count.strip()}"]
 
@@ -230,18 +272,18 @@ async def mikrotik_get_log_statistics(ctx: Context) -> str:
     topics = ["info", "warning", "error", "system", "dhcp", "firewall", "interface"]
     for topic in topics:
         count_cmd = f'/log print count-only where topics~"{topic}"'
-        count = await execute_mikrotik_command(count_cmd, ctx)
+        count = await execute_mikrotik_command(count_cmd, ctx, device=device)
         if count.strip().isdigit() and int(count.strip()) > 0:
             stats.append(f"{topic.capitalize()}: {count.strip()}")
 
     # Get recent entries count (last hour)
     recent_cmd = "/log print count-only where time > ([:timestamp] - 1h)"
-    recent_count = await execute_mikrotik_command(recent_cmd, ctx)
+    recent_count = await execute_mikrotik_command(recent_cmd, ctx, device=device)
     stats.append(f"\nEntries in last hour: {recent_count.strip()}")
 
     # Get today's entries
     today_cmd = "/log print count-only where time > ([:timestamp] - 1d)"
-    today_count = await execute_mikrotik_command(today_cmd, ctx)
+    today_count = await execute_mikrotik_command(today_cmd, ctx, device=device)
     stats.append(f"Entries in last 24 hours: {today_count.strip()}")
 
     return "LOG STATISTICS:\n\n" + "\n".join(stats)
@@ -252,9 +294,14 @@ async def mikrotik_export_logs(
     filename: Optional[str] = None,
     topics: Optional[str] = None,
     time_filter: Optional[str] = None,
-    format: Literal["plain", "csv"] = "plain"
+    format: Literal["plain", "csv"] = "plain",
+    device: Optional[str] = None
 ) -> str:
-    """Exports logs to a file on the MikroTik device with optional topic and time filters."""
+    """Exports logs to a file on the MikroTik device with optional topic and time filters.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     if not filename:
         filename = f"logs_export_{int(time.time())}"
 
@@ -273,7 +320,7 @@ async def mikrotik_export_logs(
     if filters:
         cmd += " where " + " and ".join(filters)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result.strip():
         return f"Logs exported to file: {filename}.txt"
@@ -285,9 +332,14 @@ async def mikrotik_monitor_logs(
     ctx: Context,
     topics: Optional[str] = None,
     action: Optional[str] = None,
-    duration: int = 10
+    duration: int = 10,
+    device: Optional[str] = None
 ) -> str:
-    """Monitors MikroTik logs in near-real-time for a limited duration (max 60s)."""
+    """Monitors MikroTik logs in near-real-time for a limited duration (max 60s).
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Monitoring logs for {duration} seconds")
 
     # Limit duration for safety
@@ -307,6 +359,6 @@ async def mikrotik_monitor_logs(
     # Add a limit to prevent overwhelming output
     cmd += " limit=100"
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     return f"LOG MONITOR (last {duration} seconds):\n\n{result}"

--- a/src/mcp_mikrotik/scope/poe.py
+++ b/src/mcp_mikrotik/scope/poe.py
@@ -14,7 +14,6 @@ async def mikrotik_get_poe_monitor(ctx: Context, interfaces: str, device: Option
     Notes:
         interfaces: comma-separated ethernet interface name(s), e.g.
             "ether1" or "ether9-ap,ether10-ap,ether11-ap,ether12-ap"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Reading PoE monitor for: {interfaces}")
 
@@ -41,7 +40,6 @@ async def mikrotik_list_poe(ctx: Context, interface_filter: Optional[str] = None
 
     Notes:
         interface_filter: partial name match, e.g. "ether" matches ether1, ether2 …
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info("Listing PoE configuration")
 
@@ -69,7 +67,6 @@ async def mikrotik_get_poe_settings(ctx: Context, name: str, device: Optional[st
 
     Notes:
         name: exact ethernet interface name, e.g. "ether1"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Getting PoE settings for: {name}")
 

--- a/src/mcp_mikrotik/scope/poe.py
+++ b/src/mcp_mikrotik/scope/poe.py
@@ -5,7 +5,7 @@ from ..app import mcp, READ, annotate
 
 
 @mcp.tool(name="get_poe_monitor", annotations=annotate(READ, "PoE Monitor"))
-async def mikrotik_get_poe_monitor(ctx: Context, interfaces: str) -> str:
+async def mikrotik_get_poe_monitor(ctx: Context, interfaces: str, device: Optional[str] = None) -> str:
     """Reads real-time Power-over-Ethernet (PoE) monitor data for one or more
     ethernet interfaces — PoE-out status, voltage, current, and power.
 
@@ -14,13 +14,14 @@ async def mikrotik_get_poe_monitor(ctx: Context, interfaces: str) -> str:
     Notes:
         interfaces: comma-separated ethernet interface name(s), e.g.
             "ether1" or "ether9-ap,ether10-ap,ether11-ap,ether12-ap"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Reading PoE monitor for: {interfaces}")
 
     # `once` is required — without it the monitor streams continuously and the
     # command never returns (it would hang the SSH session).
     cmd = f"/interface ethernet poe monitor {interfaces} once"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or not result.strip():
         return (
@@ -32,7 +33,7 @@ async def mikrotik_get_poe_monitor(ctx: Context, interfaces: str) -> str:
 
 
 @mcp.tool(name="list_poe", annotations=annotate(READ, "List PoE"))
-async def mikrotik_list_poe(ctx: Context, interface_filter: Optional[str] = None) -> str:
+async def mikrotik_list_poe(ctx: Context, interface_filter: Optional[str] = None, device: Optional[str] = None) -> str:
     """Lists the Power-over-Ethernet (PoE) configuration of PoE-capable
     ethernet interfaces (PoE-out mode, priority).
 
@@ -40,6 +41,7 @@ async def mikrotik_list_poe(ctx: Context, interface_filter: Optional[str] = None
 
     Notes:
         interface_filter: partial name match, e.g. "ether" matches ether1, ether2 …
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info("Listing PoE configuration")
 
@@ -47,7 +49,7 @@ async def mikrotik_list_poe(ctx: Context, interface_filter: Optional[str] = None
     if interface_filter:
         cmd += f' where name~"{interface_filter}"'
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or not result.strip():
         return (
@@ -59,7 +61,7 @@ async def mikrotik_list_poe(ctx: Context, interface_filter: Optional[str] = None
 
 
 @mcp.tool(name="get_poe_settings", annotations=annotate(READ, "PoE Settings"))
-async def mikrotik_get_poe_settings(ctx: Context, name: str) -> str:
+async def mikrotik_get_poe_settings(ctx: Context, name: str, device: Optional[str] = None) -> str:
     """Gets the detailed PoE-out settings of a specific ethernet interface
     (PoE-out mode, priority, voltage, low/high thresholds, …).
 
@@ -67,11 +69,12 @@ async def mikrotik_get_poe_settings(ctx: Context, name: str) -> str:
 
     Notes:
         name: exact ethernet interface name, e.g. "ether1"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Getting PoE settings for: {name}")
 
     cmd = f'/interface ethernet poe print detail where name="{name}"'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or not result.strip():
         return f"No PoE settings found for interface '{name}'."

--- a/src/mcp_mikrotik/scope/queue.py
+++ b/src/mcp_mikrotik/scope/queue.py
@@ -49,7 +49,6 @@ async def mikrotik_create_queue_type(
         pcq_classifier: comma-separated classifiers e.g. "src-address,dst-address"
         cake_rtt: round-trip time e.g. "50ms", "100ms"
         fq_codel_target / fq_codel_interval: time e.g. "5ms", "100ms"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Creating queue type: name={name}, kind={kind}")
 
@@ -145,11 +144,7 @@ async def mikrotik_list_queue_types(
     kind_filter: Optional[str] = None,
     device: Optional[str] = None,
 ) -> str:
-    """Lists queue types on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Lists queue types on the MikroTik device."""
     await ctx.info("Listing queue types")
 
     cmd = "/queue type print"
@@ -170,11 +165,7 @@ async def mikrotik_list_queue_types(
 
 @mcp.tool(name="get_queue_type", annotations=annotate(READ, "Get Queue Type"))
 async def mikrotik_get_queue_type(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Gets detailed information about a specific queue type.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets detailed information about a specific queue type."""
     await ctx.info(f"Getting queue type details: name={name}")
 
     cmd = f'/queue type print detail where name="{name}"'
@@ -203,11 +194,7 @@ async def mikrotik_update_queue_type(
     pcq_classifier: Optional[str] = None,
     device: Optional[str] = None,
 ) -> str:
-    """Updates an existing queue type's discipline-specific settings.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Updates an existing queue type's discipline-specific settings."""
     await ctx.info(f"Updating queue type: name={name}")
 
     cmd = f'/queue type set [find name="{name}"]'
@@ -257,11 +244,7 @@ async def mikrotik_update_queue_type(
 
 @mcp.tool(name="remove_queue_type", annotations=annotate(DESTRUCTIVE, "Remove Queue Type"))
 async def mikrotik_remove_queue_type(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Removes a queue type from the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Removes a queue type from the MikroTik device."""
     await ctx.info(f"Removing queue type: name={name}")
 
     cmd = f'/queue type remove [find name="{name}"]'
@@ -301,7 +284,6 @@ async def mikrotik_create_queue_tree(
         burst_time: duration e.g. "8s"
         parent: interface name e.g. "ether1" or parent queue name
         priority: 1 (highest) – 8 (lowest)
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Creating queue tree: name={name}, parent={parent}")
 
@@ -359,11 +341,7 @@ async def mikrotik_list_queue_trees(
     invalid_only: bool = False,
     device: Optional[str] = None,
 ) -> str:
-    """Lists queue trees on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Lists queue trees on the MikroTik device."""
     await ctx.info("Listing queue trees")
 
     cmd = "/queue tree print"
@@ -388,11 +366,7 @@ async def mikrotik_list_queue_trees(
 
 @mcp.tool(name="get_queue_tree", annotations=annotate(READ, "Get Queue Tree"))
 async def mikrotik_get_queue_tree(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Gets detailed information about a specific queue tree.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets detailed information about a specific queue tree."""
     await ctx.info(f"Getting queue tree details: name={name}")
 
     cmd = f'/queue tree print detail where name="{name}"'
@@ -427,7 +401,6 @@ async def mikrotik_update_queue_tree(
         max_limit / limit_at / burst_limit / burst_threshold: bandwidth e.g. "10M", "512k"
         burst_time: duration e.g. "8s"
         priority: 1 (highest) – 8 (lowest)
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Updating queue tree: name={name}")
 
@@ -478,11 +451,7 @@ async def mikrotik_update_queue_tree(
 
 @mcp.tool(name="remove_queue_tree", annotations=annotate(DESTRUCTIVE, "Remove Queue Tree"))
 async def mikrotik_remove_queue_tree(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Removes a queue tree from the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Removes a queue tree from the MikroTik device."""
     await ctx.info(f"Removing queue tree: name={name}")
 
     cmd = f'/queue tree remove [find name="{name}"]'
@@ -495,11 +464,7 @@ async def mikrotik_remove_queue_tree(ctx: Context, name: str, device: Optional[s
 
 @mcp.tool(name="enable_queue_tree", annotations=annotate(WRITE_IDEMPOTENT, "Enable Queue Tree"))
 async def mikrotik_enable_queue_tree(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Enables a queue tree.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Enables a queue tree."""
     await ctx.info(f"Enabling queue tree: name={name}")
 
     cmd = f'/queue tree set [find name="{name}"] disabled=no'
@@ -515,11 +480,7 @@ async def mikrotik_enable_queue_tree(ctx: Context, name: str, device: Optional[s
 
 @mcp.tool(name="disable_queue_tree", annotations=annotate(WRITE_IDEMPOTENT, "Disable Queue Tree"))
 async def mikrotik_disable_queue_tree(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Disables a queue tree.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Disables a queue tree."""
     await ctx.info(f"Disabling queue tree: name={name}")
 
     cmd = f'/queue tree set [find name="{name}"] disabled=yes'
@@ -565,7 +526,6 @@ async def mikrotik_create_simple_queue(
             as "UL/DL" e.g. "10M/10M", or single value e.g. "10M"
         burst_time: duration e.g. "8s"
         priority: 1 (highest) – 8 (lowest)
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Creating simple queue: name={name}, target={target}")
 
@@ -627,11 +587,7 @@ async def mikrotik_list_simple_queues(
     invalid_only: bool = False,
     device: Optional[str] = None,
 ) -> str:
-    """Lists simple queues on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Lists simple queues on the MikroTik device."""
     await ctx.info("Listing simple queues")
 
     cmd = "/queue simple print"
@@ -656,11 +612,7 @@ async def mikrotik_list_simple_queues(
 
 @mcp.tool(name="get_simple_queue", annotations=annotate(READ, "Get Simple Queue"))
 async def mikrotik_get_simple_queue(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Gets detailed information about a specific simple queue.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets detailed information about a specific simple queue."""
     await ctx.info(f"Getting simple queue details: name={name}")
 
     cmd = f'/queue simple print detail where name="{name}"'
@@ -699,7 +651,6 @@ async def mikrotik_update_simple_queue(
             as "UL/DL" e.g. "10M/10M", or single value e.g. "10M"
         burst_time: duration e.g. "8s"
         priority: 1 (highest) – 8 (lowest)
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Updating simple queue: name={name}")
 
@@ -754,11 +705,7 @@ async def mikrotik_update_simple_queue(
 
 @mcp.tool(name="remove_simple_queue", annotations=annotate(DESTRUCTIVE, "Remove Simple Queue"))
 async def mikrotik_remove_simple_queue(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Removes a simple queue from the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Removes a simple queue from the MikroTik device."""
     await ctx.info(f"Removing simple queue: name={name}")
 
     cmd = f'/queue simple remove [find name="{name}"]'
@@ -771,11 +718,7 @@ async def mikrotik_remove_simple_queue(ctx: Context, name: str, device: Optional
 
 @mcp.tool(name="enable_simple_queue", annotations=annotate(WRITE_IDEMPOTENT, "Enable Simple Queue"))
 async def mikrotik_enable_simple_queue(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Enables a simple queue.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Enables a simple queue."""
     await ctx.info(f"Enabling simple queue: name={name}")
 
     cmd = f'/queue simple set [find name="{name}"] disabled=no'
@@ -791,11 +734,7 @@ async def mikrotik_enable_simple_queue(ctx: Context, name: str, device: Optional
 
 @mcp.tool(name="disable_simple_queue", annotations=annotate(WRITE_IDEMPOTENT, "Disable Simple Queue"))
 async def mikrotik_disable_simple_queue(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Disables a simple queue.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Disables a simple queue."""
     await ctx.info(f"Disabling simple queue: name={name}")
 
     cmd = f'/queue simple set [find name="{name}"] disabled=yes'

--- a/src/mcp_mikrotik/scope/queue.py
+++ b/src/mcp_mikrotik/scope/queue.py
@@ -40,6 +40,7 @@ async def mikrotik_create_queue_type(
     red_max_threshold: Optional[int] = None,
     red_burst: Optional[int] = None,
     red_avg_packet: Optional[int] = None,
+    device: Optional[str] = None,
 ) -> str:
     """Creates a queue type (qdisc). kind selects the discipline (cake, fq-codel, sfq, red, pcq, pfifo, bfifo); remaining params are per-discipline options.
 
@@ -48,6 +49,7 @@ async def mikrotik_create_queue_type(
         pcq_classifier: comma-separated classifiers e.g. "src-address,dst-address"
         cake_rtt: round-trip time e.g. "50ms", "100ms"
         fq_codel_target / fq_codel_interval: time e.g. "5ms", "100ms"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Creating queue type: name={name}, kind={kind}")
 
@@ -115,13 +117,13 @@ async def mikrotik_create_queue_type(
     if red_avg_packet is not None:
         cmd += f" red-avg-packet={red_avg_packet}"
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if result.strip():
         if "*" in result or result.strip().isdigit():
             type_id = result.strip()
             details_cmd = f"/queue type print detail where .id={type_id}"
-            details = await execute_mikrotik_command(details_cmd, ctx)
+            details = await execute_mikrotik_command(details_cmd, ctx, device=device)
             if details.strip():
                 return f"Queue type created successfully:\n\n{details}"
             return f"Queue type created with ID: {type_id}"
@@ -130,7 +132,7 @@ async def mikrotik_create_queue_type(
 
     # Verify by fetching by name
     details_cmd = f'/queue type print detail where name="{name}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
     if details.strip():
         return f"Queue type created successfully:\n\n{details}"
     return "Queue type creation completed but unable to verify."
@@ -141,8 +143,13 @@ async def mikrotik_list_queue_types(
     ctx: Context,
     name_filter: Optional[str] = None,
     kind_filter: Optional[str] = None,
+    device: Optional[str] = None,
 ) -> str:
-    """Lists queue types on the MikroTik device."""
+    """Lists queue types on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Listing queue types")
 
     cmd = "/queue type print"
@@ -155,19 +162,23 @@ async def mikrotik_list_queue_types(
     if filters:
         cmd += " where " + " ".join(filters)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
     if not result or result.strip() == "":
         return "No queue types found matching the criteria."
     return f"QUEUE TYPES:\n\n{result}"
 
 
 @mcp.tool(name="get_queue_type", annotations=annotate(READ, "Get Queue Type"))
-async def mikrotik_get_queue_type(ctx: Context, name: str) -> str:
-    """Gets detailed information about a specific queue type."""
+async def mikrotik_get_queue_type(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Gets detailed information about a specific queue type.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Getting queue type details: name={name}")
 
     cmd = f'/queue type print detail where name="{name}"'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
     if not result or result.strip() == "":
         return f"Queue type '{name}' not found."
     return f"QUEUE TYPE DETAILS:\n\n{result}"
@@ -190,8 +201,13 @@ async def mikrotik_update_queue_type(
     pcq_rate: Optional[str] = None,
     pcq_limit: Optional[int] = None,
     pcq_classifier: Optional[str] = None,
+    device: Optional[str] = None,
 ) -> str:
-    """Updates an existing queue type's discipline-specific settings."""
+    """Updates an existing queue type's discipline-specific settings.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Updating queue type: name={name}")
 
     cmd = f'/queue type set [find name="{name}"]'
@@ -228,24 +244,28 @@ async def mikrotik_update_queue_type(
         return "No updates specified."
 
     cmd += " " + " ".join(updates)
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to update queue type: {result}"
 
     lookup_name = new_name if new_name else name
     details_cmd = f'/queue type print detail where name="{lookup_name}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
     return f"Queue type updated successfully:\n\n{details}"
 
 
 @mcp.tool(name="remove_queue_type", annotations=annotate(DESTRUCTIVE, "Remove Queue Type"))
-async def mikrotik_remove_queue_type(ctx: Context, name: str) -> str:
-    """Removes a queue type from the MikroTik device."""
+async def mikrotik_remove_queue_type(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Removes a queue type from the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Removing queue type: name={name}")
 
     cmd = f'/queue type remove [find name="{name}"]'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to remove queue type: {result}"
@@ -272,6 +292,7 @@ async def mikrotik_create_queue_tree(
     priority: Optional[int] = None,
     comment: Optional[str] = None,
     disabled: bool = False,
+    device: Optional[str] = None,
 ) -> str:
     """Creates a hierarchical queue tree entry attached to a parent interface or queue.
 
@@ -280,6 +301,7 @@ async def mikrotik_create_queue_tree(
         burst_time: duration e.g. "8s"
         parent: interface name e.g. "ether1" or parent queue name
         priority: 1 (highest) – 8 (lowest)
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Creating queue tree: name={name}, parent={parent}")
 
@@ -308,13 +330,13 @@ async def mikrotik_create_queue_tree(
     if disabled:
         cmd += " disabled=yes"
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if result.strip():
         if "*" in result or result.strip().isdigit():
             tree_id = result.strip()
             details_cmd = f"/queue tree print detail where .id={tree_id}"
-            details = await execute_mikrotik_command(details_cmd, ctx)
+            details = await execute_mikrotik_command(details_cmd, ctx, device=device)
             if details.strip():
                 return f"Queue tree created successfully:\n\n{details}"
             return f"Queue tree created with ID: {tree_id}"
@@ -322,7 +344,7 @@ async def mikrotik_create_queue_tree(
             return f"Failed to create queue tree: {result}"
 
     details_cmd = f'/queue tree print detail where name="{name}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
     if details.strip():
         return f"Queue tree created successfully:\n\n{details}"
     return "Queue tree creation completed but unable to verify."
@@ -335,8 +357,13 @@ async def mikrotik_list_queue_trees(
     parent_filter: Optional[str] = None,
     disabled_only: bool = False,
     invalid_only: bool = False,
+    device: Optional[str] = None,
 ) -> str:
-    """Lists queue trees on the MikroTik device."""
+    """Lists queue trees on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Listing queue trees")
 
     cmd = "/queue tree print"
@@ -353,19 +380,23 @@ async def mikrotik_list_queue_trees(
     if filters:
         cmd += " where " + " ".join(filters)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
     if not result or result.strip() == "":
         return "No queue trees found matching the criteria."
     return f"QUEUE TREES:\n\n{result}"
 
 
 @mcp.tool(name="get_queue_tree", annotations=annotate(READ, "Get Queue Tree"))
-async def mikrotik_get_queue_tree(ctx: Context, name: str) -> str:
-    """Gets detailed information about a specific queue tree."""
+async def mikrotik_get_queue_tree(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Gets detailed information about a specific queue tree.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Getting queue tree details: name={name}")
 
     cmd = f'/queue tree print detail where name="{name}"'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
     if not result or result.strip() == "":
         return f"Queue tree '{name}' not found."
     return f"QUEUE TREE DETAILS:\n\n{result}"
@@ -388,6 +419,7 @@ async def mikrotik_update_queue_tree(
     priority: Optional[int] = None,
     comment: Optional[str] = None,
     disabled: Optional[bool] = None,
+    device: Optional[str] = None,
 ) -> str:
     """Updates an existing queue tree entry (bandwidth limits, parent, priority, etc.).
 
@@ -395,6 +427,7 @@ async def mikrotik_update_queue_tree(
         max_limit / limit_at / burst_limit / burst_threshold: bandwidth e.g. "10M", "512k"
         burst_time: duration e.g. "8s"
         priority: 1 (highest) – 8 (lowest)
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Updating queue tree: name={name}")
 
@@ -432,24 +465,28 @@ async def mikrotik_update_queue_tree(
         return "No updates specified."
 
     cmd += " " + " ".join(updates)
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to update queue tree: {result}"
 
     lookup_name = new_name if new_name else name
     details_cmd = f'/queue tree print detail where name="{lookup_name}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
     return f"Queue tree updated successfully:\n\n{details}"
 
 
 @mcp.tool(name="remove_queue_tree", annotations=annotate(DESTRUCTIVE, "Remove Queue Tree"))
-async def mikrotik_remove_queue_tree(ctx: Context, name: str) -> str:
-    """Removes a queue tree from the MikroTik device."""
+async def mikrotik_remove_queue_tree(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Removes a queue tree from the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Removing queue tree: name={name}")
 
     cmd = f'/queue tree remove [find name="{name}"]'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to remove queue tree: {result}"
@@ -457,34 +494,42 @@ async def mikrotik_remove_queue_tree(ctx: Context, name: str) -> str:
 
 
 @mcp.tool(name="enable_queue_tree", annotations=annotate(WRITE_IDEMPOTENT, "Enable Queue Tree"))
-async def mikrotik_enable_queue_tree(ctx: Context, name: str) -> str:
-    """Enables a queue tree."""
+async def mikrotik_enable_queue_tree(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Enables a queue tree.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Enabling queue tree: name={name}")
 
     cmd = f'/queue tree set [find name="{name}"] disabled=no'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to enable queue tree: {result}"
 
     details_cmd = f'/queue tree print detail where name="{name}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
     return f"Queue tree enabled:\n\n{details}"
 
 
 @mcp.tool(name="disable_queue_tree", annotations=annotate(WRITE_IDEMPOTENT, "Disable Queue Tree"))
-async def mikrotik_disable_queue_tree(ctx: Context, name: str) -> str:
-    """Disables a queue tree."""
+async def mikrotik_disable_queue_tree(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Disables a queue tree.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Disabling queue tree: name={name}")
 
     cmd = f'/queue tree set [find name="{name}"] disabled=yes'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to disable queue tree: {result}"
 
     details_cmd = f'/queue tree print detail where name="{name}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
     return f"Queue tree disabled:\n\n{details}"
 
 
@@ -510,6 +555,7 @@ async def mikrotik_create_simple_queue(
     packet_marks: Optional[str] = None,
     comment: Optional[str] = None,
     disabled: bool = False,
+    device: Optional[str] = None,
 ) -> str:
     """Creates a simple queue to rate-limit a target address or interface.
 
@@ -519,6 +565,7 @@ async def mikrotik_create_simple_queue(
             as "UL/DL" e.g. "10M/10M", or single value e.g. "10M"
         burst_time: duration e.g. "8s"
         priority: 1 (highest) – 8 (lowest)
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Creating simple queue: name={name}, target={target}")
 
@@ -551,13 +598,13 @@ async def mikrotik_create_simple_queue(
     if disabled:
         cmd += " disabled=yes"
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if result.strip():
         if "*" in result or result.strip().isdigit():
             queue_id = result.strip()
             details_cmd = f"/queue simple print detail where .id={queue_id}"
-            details = await execute_mikrotik_command(details_cmd, ctx)
+            details = await execute_mikrotik_command(details_cmd, ctx, device=device)
             if details.strip():
                 return f"Simple queue created successfully:\n\n{details}"
             return f"Simple queue created with ID: {queue_id}"
@@ -565,7 +612,7 @@ async def mikrotik_create_simple_queue(
             return f"Failed to create simple queue: {result}"
 
     details_cmd = f'/queue simple print detail where name="{name}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
     if details.strip():
         return f"Simple queue created successfully:\n\n{details}"
     return "Simple queue creation completed but unable to verify."
@@ -578,8 +625,13 @@ async def mikrotik_list_simple_queues(
     target_filter: Optional[str] = None,
     disabled_only: bool = False,
     invalid_only: bool = False,
+    device: Optional[str] = None,
 ) -> str:
-    """Lists simple queues on the MikroTik device."""
+    """Lists simple queues on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Listing simple queues")
 
     cmd = "/queue simple print"
@@ -596,19 +648,23 @@ async def mikrotik_list_simple_queues(
     if filters:
         cmd += " where " + " ".join(filters)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
     if not result or result.strip() == "":
         return "No simple queues found matching the criteria."
     return f"SIMPLE QUEUES:\n\n{result}"
 
 
 @mcp.tool(name="get_simple_queue", annotations=annotate(READ, "Get Simple Queue"))
-async def mikrotik_get_simple_queue(ctx: Context, name: str) -> str:
-    """Gets detailed information about a specific simple queue."""
+async def mikrotik_get_simple_queue(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Gets detailed information about a specific simple queue.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Getting simple queue details: name={name}")
 
     cmd = f'/queue simple print detail where name="{name}"'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
     if not result or result.strip() == "":
         return f"Simple queue '{name}' not found."
     return f"SIMPLE QUEUE DETAILS:\n\n{result}"
@@ -633,6 +689,7 @@ async def mikrotik_update_simple_queue(
     packet_marks: Optional[str] = None,
     comment: Optional[str] = None,
     disabled: Optional[bool] = None,
+    device: Optional[str] = None,
 ) -> str:
     """Updates an existing simple queue's rate limits, target, or scheduling settings.
 
@@ -642,6 +699,7 @@ async def mikrotik_update_simple_queue(
             as "UL/DL" e.g. "10M/10M", or single value e.g. "10M"
         burst_time: duration e.g. "8s"
         priority: 1 (highest) – 8 (lowest)
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Updating simple queue: name={name}")
 
@@ -683,24 +741,28 @@ async def mikrotik_update_simple_queue(
         return "No updates specified."
 
     cmd += " " + " ".join(updates)
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to update simple queue: {result}"
 
     lookup_name = new_name if new_name else name
     details_cmd = f'/queue simple print detail where name="{lookup_name}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
     return f"Simple queue updated successfully:\n\n{details}"
 
 
 @mcp.tool(name="remove_simple_queue", annotations=annotate(DESTRUCTIVE, "Remove Simple Queue"))
-async def mikrotik_remove_simple_queue(ctx: Context, name: str) -> str:
-    """Removes a simple queue from the MikroTik device."""
+async def mikrotik_remove_simple_queue(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Removes a simple queue from the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Removing simple queue: name={name}")
 
     cmd = f'/queue simple remove [find name="{name}"]'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to remove simple queue: {result}"
@@ -708,32 +770,40 @@ async def mikrotik_remove_simple_queue(ctx: Context, name: str) -> str:
 
 
 @mcp.tool(name="enable_simple_queue", annotations=annotate(WRITE_IDEMPOTENT, "Enable Simple Queue"))
-async def mikrotik_enable_simple_queue(ctx: Context, name: str) -> str:
-    """Enables a simple queue."""
+async def mikrotik_enable_simple_queue(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Enables a simple queue.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Enabling simple queue: name={name}")
 
     cmd = f'/queue simple set [find name="{name}"] disabled=no'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to enable simple queue: {result}"
 
     details_cmd = f'/queue simple print detail where name="{name}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
     return f"Simple queue enabled:\n\n{details}"
 
 
 @mcp.tool(name="disable_simple_queue", annotations=annotate(WRITE_IDEMPOTENT, "Disable Simple Queue"))
-async def mikrotik_disable_simple_queue(ctx: Context, name: str) -> str:
-    """Disables a simple queue."""
+async def mikrotik_disable_simple_queue(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Disables a simple queue.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Disabling simple queue: name={name}")
 
     cmd = f'/queue simple set [find name="{name}"] disabled=yes'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to disable simple queue: {result}"
 
     details_cmd = f'/queue simple print detail where name="{name}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
     return f"Simple queue disabled:\n\n{details}"

--- a/src/mcp_mikrotik/scope/routes.py
+++ b/src/mcp_mikrotik/scope/routes.py
@@ -25,7 +25,6 @@ async def mikrotik_add_route(
         dst_address: CIDR e.g. "0.0.0.0/0", "192.168.1.0/24"
         check_gateway: "ping" or "arp"
         distance: 1-255 (lower = higher priority)
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Adding route: dst={dst_address}, gateway={gateway}")
 
@@ -86,11 +85,7 @@ async def mikrotik_list_routes(
     static_only: bool = False,
     device: Optional[str] = None
 ) -> str:
-    """Lists routes in MikroTik routing table.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Lists routes in MikroTik routing table."""
     await ctx.info(f"Listing routes with filters: dst={dst_filter}, gateway={gateway_filter}")
 
     cmd = "/ip route print"
@@ -129,7 +124,6 @@ async def mikrotik_get_route(ctx: Context, route_id: str, device: Optional[str] 
 
     Notes:
         route_id: "*N" or "N" from list output e.g. "*3"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Getting route details: route_id={route_id}")
 
@@ -166,7 +160,6 @@ async def mikrotik_update_route(
         check_gateway: "ping" or "arp"
         distance: 1-255
         Pass "" to routing_mark, vrf_interface, or pref_src to clear them.
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Updating route: route_id={route_id}")
 
@@ -226,7 +219,6 @@ async def mikrotik_remove_route(ctx: Context, route_id: str, device: Optional[st
 
     Notes:
         route_id: "*N" or "N" from list output e.g. "*3"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Removing route: route_id={route_id}")
 
@@ -250,7 +242,6 @@ async def mikrotik_enable_route(ctx: Context, route_id: str, device: Optional[st
 
     Notes:
         route_id: "*N" or "N" from list output e.g. "*3"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     return await mikrotik_update_route(route_id, disabled=False, ctx=ctx, device=device)
 
@@ -260,7 +251,6 @@ async def mikrotik_disable_route(ctx: Context, route_id: str, device: Optional[s
 
     Notes:
         route_id: "*N" or "N" from list output e.g. "*3"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     return await mikrotik_update_route(route_id, disabled=True, ctx=ctx, device=device)
 
@@ -272,11 +262,7 @@ async def mikrotik_get_routing_table(
     active_only: bool = True,
     device: Optional[str] = None
 ) -> str:
-    """Gets a specific routing table.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets a specific routing table."""
     await ctx.info(f"Getting routing table: table={table_name}")
 
     cmd = "/ip route print"
@@ -307,11 +293,7 @@ async def mikrotik_check_route_path(
     routing_mark: Optional[str] = None,
     device: Optional[str] = None
 ) -> str:
-    """Checks the route path to a destination.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Checks the route path to a destination."""
     await ctx.info(f"Checking route path to: {destination}")
 
     cmd = f"/ip route check {destination}"
@@ -330,11 +312,7 @@ async def mikrotik_check_route_path(
 
 @mcp.tool(name="get_route_cache", annotations=annotate(READ, "Get Route Cache"))
 async def mikrotik_get_route_cache(ctx: Context, device: Optional[str] = None) -> str:
-    """Gets the route cache.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets the route cache."""
     await ctx.info("Getting route cache")
 
     cmd = "/ip route cache print"
@@ -347,11 +325,7 @@ async def mikrotik_get_route_cache(ctx: Context, device: Optional[str] = None) -
 
 @mcp.tool(name="flush_route_cache", annotations=annotate(DESTRUCTIVE, "Flush Route Cache"))
 async def mikrotik_flush_route_cache(ctx: Context, device: Optional[str] = None) -> str:
-    """Flushes the route cache.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Flushes the route cache."""
     await ctx.info("Flushing route cache")
 
     cmd = "/ip route cache flush"
@@ -371,11 +345,7 @@ async def mikrotik_add_default_route(
     check_gateway: str = "ping",
     device: Optional[str] = None
 ) -> str:
-    """Adds a default route.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Adds a default route."""
     return await mikrotik_add_route(
         dst_address="0.0.0.0/0",
         gateway=gateway,
@@ -399,7 +369,6 @@ async def mikrotik_add_blackhole_route(
     Notes:
         dst_address: CIDR e.g. "10.0.0.0/8"
         distance: 1-255
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Adding blackhole route: dst={dst_address}")
 
@@ -420,11 +389,7 @@ async def mikrotik_add_blackhole_route(
 
 @mcp.tool(name="get_route_statistics", annotations=annotate(READ, "Route Statistics"))
 async def mikrotik_get_route_statistics(ctx: Context, device: Optional[str] = None) -> str:
-    """Gets routing table statistics.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets routing table statistics."""
     await ctx.info("Getting route statistics")
 
     total_cmd = "/ip route print count-only"

--- a/src/mcp_mikrotik/scope/routes.py
+++ b/src/mcp_mikrotik/scope/routes.py
@@ -16,7 +16,8 @@ async def mikrotik_add_route(
     disabled: bool = False,
     vrf_interface: Optional[str] = None,
     pref_src: Optional[str] = None,
-    check_gateway: Optional[str] = None
+    check_gateway: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
     """Adds a route to the routing table.
 
@@ -24,6 +25,7 @@ async def mikrotik_add_route(
         dst_address: CIDR e.g. "0.0.0.0/0", "192.168.1.0/24"
         check_gateway: "ping" or "arp"
         distance: 1-255 (lower = higher priority)
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Adding route: dst={dst_address}, gateway={gateway}")
 
@@ -48,13 +50,13 @@ async def mikrotik_add_route(
     if check_gateway:
         cmd += f" check-gateway={check_gateway}"
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if result.strip():
         if "*" in result or result.strip().isdigit():
             route_id = result.strip()
             details_cmd = f"/ip route print detail where .id={route_id}"
-            details = await execute_mikrotik_command(details_cmd, ctx)
+            details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
             if details.strip():
                 return f"Route added successfully:\n\n{details}"
@@ -64,7 +66,7 @@ async def mikrotik_add_route(
             return f"Failed to add route: {result}"
     else:
         details_cmd = f'/ip route print detail where dst-address="{dst_address}" and gateway="{gateway}"'
-        details = await execute_mikrotik_command(details_cmd, ctx)
+        details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
         if details.strip():
             return f"Route added successfully:\n\n{details}"
@@ -81,9 +83,14 @@ async def mikrotik_list_routes(
     active_only: bool = False,
     disabled_only: bool = False,
     dynamic_only: bool = False,
-    static_only: bool = False
+    static_only: bool = False,
+    device: Optional[str] = None
 ) -> str:
-    """Lists routes in MikroTik routing table."""
+    """Lists routes in MikroTik routing table.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Listing routes with filters: dst={dst_filter}, gateway={gateway_filter}")
 
     cmd = "/ip route print"
@@ -109,7 +116,7 @@ async def mikrotik_list_routes(
     if filters:
         cmd += " where " + " ".join(filters)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "" or result.strip() == "no such item":
         return "No routes found matching the criteria."
@@ -117,16 +124,17 @@ async def mikrotik_list_routes(
     return f"ROUTES:\n\n{result}"
 
 @mcp.tool(name="get_route", annotations=annotate(READ, "Get Route"))
-async def mikrotik_get_route(ctx: Context, route_id: str) -> str:
+async def mikrotik_get_route(ctx: Context, route_id: str, device: Optional[str] = None) -> str:
     """Gets detailed information about a specific route.
 
     Notes:
         route_id: "*N" or "N" from list output e.g. "*3"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Getting route details: route_id={route_id}")
 
     cmd = f"/ip route print detail where .id={route_id}"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return f"Route with ID '{route_id}' not found."
@@ -147,7 +155,8 @@ async def mikrotik_update_route(
     disabled: Optional[bool] = None,
     vrf_interface: Optional[str] = None,
     pref_src: Optional[str] = None,
-    check_gateway: Optional[str] = None
+    check_gateway: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
     """Updates a route.
 
@@ -157,6 +166,7 @@ async def mikrotik_update_route(
         check_gateway: "ping" or "arp"
         distance: 1-255
         Pass "" to routing_mark, vrf_interface, or pref_src to clear them.
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Updating route: route_id={route_id}")
 
@@ -200,33 +210,34 @@ async def mikrotik_update_route(
 
     cmd += " " + " ".join(updates)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to update route: {result}"
 
     details_cmd = f"/ip route print detail where .id={route_id}"
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
     return f"Route updated successfully:\n\n{details}"
 
 @mcp.tool(name="remove_route", annotations=annotate(DESTRUCTIVE, "Remove Route"))
-async def mikrotik_remove_route(ctx: Context, route_id: str) -> str:
+async def mikrotik_remove_route(ctx: Context, route_id: str, device: Optional[str] = None) -> str:
     """Removes a route.
 
     Notes:
         route_id: "*N" or "N" from list output e.g. "*3"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Removing route: route_id={route_id}")
 
     check_cmd = f"/ip route print count-only where .id={route_id}"
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         return f"Route with ID '{route_id}' not found."
 
     cmd = f"/ip route remove {route_id}"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to remove route: {result}"
@@ -234,31 +245,38 @@ async def mikrotik_remove_route(ctx: Context, route_id: str) -> str:
     return f"Route with ID '{route_id}' removed successfully."
 
 @mcp.tool(name="enable_route", annotations=annotate(WRITE_IDEMPOTENT, "Enable Route"))
-async def mikrotik_enable_route(ctx: Context, route_id: str) -> str:
+async def mikrotik_enable_route(ctx: Context, route_id: str, device: Optional[str] = None) -> str:
     """Enables a route.
 
     Notes:
         route_id: "*N" or "N" from list output e.g. "*3"
+        device: Device title from the inventory; omit when only one device is configured.
     """
-    return await mikrotik_update_route(route_id, disabled=False, ctx=ctx)
+    return await mikrotik_update_route(route_id, disabled=False, ctx=ctx, device=device)
 
 @mcp.tool(name="disable_route", annotations=annotate(WRITE_IDEMPOTENT, "Disable Route"))
-async def mikrotik_disable_route(ctx: Context, route_id: str) -> str:
+async def mikrotik_disable_route(ctx: Context, route_id: str, device: Optional[str] = None) -> str:
     """Disables a route.
 
     Notes:
         route_id: "*N" or "N" from list output e.g. "*3"
+        device: Device title from the inventory; omit when only one device is configured.
     """
-    return await mikrotik_update_route(route_id, disabled=True, ctx=ctx)
+    return await mikrotik_update_route(route_id, disabled=True, ctx=ctx, device=device)
 
 @mcp.tool(name="get_routing_table", annotations=annotate(READ, "Routing Table"))
 async def mikrotik_get_routing_table(
     ctx: Context,
     table_name: Optional[str] = "main",
     protocol_filter: Optional[str] = None,
-    active_only: bool = True
+    active_only: bool = True,
+    device: Optional[str] = None
 ) -> str:
-    """Gets a specific routing table."""
+    """Gets a specific routing table.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Getting routing table: table={table_name}")
 
     cmd = "/ip route print"
@@ -274,7 +292,7 @@ async def mikrotik_get_routing_table(
     if filters:
         cmd += " where " + " ".join(filters)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return f"No routes found in table '{table_name}'."
@@ -286,9 +304,14 @@ async def mikrotik_check_route_path(
     ctx: Context,
     destination: str,
     source: Optional[str] = None,
-    routing_mark: Optional[str] = None
+    routing_mark: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
-    """Checks the route path to a destination."""
+    """Checks the route path to a destination.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Checking route path to: {destination}")
 
     cmd = f"/ip route check {destination}"
@@ -298,7 +321,7 @@ async def mikrotik_check_route_path(
     if routing_mark:
         cmd += f' routing-mark="{routing_mark}"'
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result:
         return f"Unable to check route to {destination}"
@@ -306,12 +329,16 @@ async def mikrotik_check_route_path(
     return f"ROUTE PATH TO {destination}:\n\n{result}"
 
 @mcp.tool(name="get_route_cache", annotations=annotate(READ, "Get Route Cache"))
-async def mikrotik_get_route_cache(ctx: Context) -> str:
-    """Gets the route cache."""
+async def mikrotik_get_route_cache(ctx: Context, device: Optional[str] = None) -> str:
+    """Gets the route cache.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Getting route cache")
 
     cmd = "/ip route cache print"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return "Route cache is empty."
@@ -319,12 +346,16 @@ async def mikrotik_get_route_cache(ctx: Context) -> str:
     return f"ROUTE CACHE:\n\n{result}"
 
 @mcp.tool(name="flush_route_cache", annotations=annotate(DESTRUCTIVE, "Flush Route Cache"))
-async def mikrotik_flush_route_cache(ctx: Context) -> str:
-    """Flushes the route cache."""
+async def mikrotik_flush_route_cache(ctx: Context, device: Optional[str] = None) -> str:
+    """Flushes the route cache.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Flushing route cache")
 
     cmd = "/ip route cache flush"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result.strip():
         return "Route cache flushed successfully."
@@ -337,16 +368,22 @@ async def mikrotik_add_default_route(
     gateway: str,
     distance: int = 1,
     comment: Optional[str] = None,
-    check_gateway: str = "ping"
+    check_gateway: str = "ping",
+    device: Optional[str] = None
 ) -> str:
-    """Adds a default route."""
+    """Adds a default route.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     return await mikrotik_add_route(
         dst_address="0.0.0.0/0",
         gateway=gateway,
         distance=distance,
         comment=comment or "Default route",
         check_gateway=check_gateway,
-        ctx=ctx
+        ctx=ctx,
+        device=device
     )
 
 @mcp.tool(name="add_blackhole_route", annotations=annotate(WRITE, "Add Blackhole Route"))
@@ -354,13 +391,15 @@ async def mikrotik_add_blackhole_route(
     ctx: Context,
     dst_address: str,
     distance: int = 1,
-    comment: Optional[str] = None
+    comment: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
     """Adds a blackhole route.
 
     Notes:
         dst_address: CIDR e.g. "10.0.0.0/8"
         distance: 1-255
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Adding blackhole route: dst={dst_address}")
 
@@ -369,7 +408,7 @@ async def mikrotik_add_blackhole_route(
     if comment:
         cmd += f' comment="{comment}"'
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if result.strip():
         if "*" in result or result.strip().isdigit():
@@ -380,24 +419,28 @@ async def mikrotik_add_blackhole_route(
         return "Blackhole route added successfully."
 
 @mcp.tool(name="get_route_statistics", annotations=annotate(READ, "Route Statistics"))
-async def mikrotik_get_route_statistics(ctx: Context) -> str:
-    """Gets routing table statistics."""
+async def mikrotik_get_route_statistics(ctx: Context, device: Optional[str] = None) -> str:
+    """Gets routing table statistics.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Getting route statistics")
 
     total_cmd = "/ip route print count-only"
-    total_count = await execute_mikrotik_command(total_cmd, ctx)
+    total_count = await execute_mikrotik_command(total_cmd, ctx, device=device)
 
     active_cmd = "/ip route print count-only where active=yes"
-    active_count = await execute_mikrotik_command(active_cmd, ctx)
+    active_count = await execute_mikrotik_command(active_cmd, ctx, device=device)
 
     dynamic_cmd = "/ip route print count-only where dynamic=yes"
-    dynamic_count = await execute_mikrotik_command(dynamic_cmd, ctx)
+    dynamic_count = await execute_mikrotik_command(dynamic_cmd, ctx, device=device)
 
     static_cmd = "/ip route print count-only where static=yes"
-    static_count = await execute_mikrotik_command(static_cmd, ctx)
+    static_count = await execute_mikrotik_command(static_cmd, ctx, device=device)
 
     disabled_cmd = "/ip route print count-only where disabled=yes"
-    disabled_count = await execute_mikrotik_command(disabled_cmd, ctx)
+    disabled_count = await execute_mikrotik_command(disabled_cmd, ctx, device=device)
 
     stats = [
         f"Total routes: {total_count.strip()}",

--- a/src/mcp_mikrotik/scope/safe_mode.py
+++ b/src/mcp_mikrotik/scope/safe_mode.py
@@ -6,27 +6,17 @@ from mcp.server.mcpserver import Context
 from ..app import mcp, READ, WRITE, annotate
 from ..safe_mode import get_safe_mode_manager
 
-_DEVICE_HELP = "Device title from the inventory; omit when only one device is configured."
-
 
 @mcp.tool(name="safe_mode_status", annotations=annotate(READ, "Safe Mode Status"))
 async def mikrotik_safe_mode_status(ctx: Context, device: Optional[str] = None) -> str:
-    """Returns whether MikroTik Safe Mode is currently active.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Returns whether MikroTik Safe Mode is currently active."""
     await ctx.info(f"Checking safe mode status (device={device})")
     return get_safe_mode_manager(device).status()
 
 
 @mcp.tool(name="enable_safe_mode", annotations=annotate(WRITE, "Enable Safe Mode"))
 async def mikrotik_enable_safe_mode(ctx: Context, device: Optional[str] = None) -> str:
-    """Activates MikroTik Safe Mode; changes are held in memory and auto-reverted on disconnect until committed.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Activates MikroTik Safe Mode; changes are held in memory and auto-reverted on disconnect until committed."""
     await ctx.info(f"Enabling MikroTik safe mode (device={device})")
     result = await asyncio.to_thread(get_safe_mode_manager(device).enable)
     return result
@@ -34,11 +24,7 @@ async def mikrotik_enable_safe_mode(ctx: Context, device: Optional[str] = None) 
 
 @mcp.tool(name="commit_safe_mode", annotations=annotate(WRITE, "Commit Safe Mode"))
 async def mikrotik_commit_safe_mode(ctx: Context, device: Optional[str] = None) -> str:
-    """Commits all pending Safe Mode changes to persistent storage and exits Safe Mode.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Commits all pending Safe Mode changes to persistent storage and exits Safe Mode."""
     await ctx.info(f"Committing safe mode changes (device={device})")
     result = await asyncio.to_thread(get_safe_mode_manager(device).commit)
     return result
@@ -46,11 +32,7 @@ async def mikrotik_commit_safe_mode(ctx: Context, device: Optional[str] = None) 
 
 @mcp.tool(name="rollback_safe_mode", annotations=annotate(WRITE, "Rollback Safe Mode"))
 async def mikrotik_rollback_safe_mode(ctx: Context, device: Optional[str] = None) -> str:
-    """Discards all pending Safe Mode changes by closing the SSH session, triggering automatic rollback.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Discards all pending Safe Mode changes by closing the SSH session, triggering automatic rollback."""
     await ctx.info(f"Rolling back safe mode changes (device={device})")
     result = await asyncio.to_thread(get_safe_mode_manager(device).rollback)
     return result

--- a/src/mcp_mikrotik/scope/safe_mode.py
+++ b/src/mcp_mikrotik/scope/safe_mode.py
@@ -1,37 +1,56 @@
 import asyncio
+from typing import Optional
 
 from mcp.server.mcpserver import Context
 
 from ..app import mcp, READ, WRITE, annotate
 from ..safe_mode import get_safe_mode_manager
 
+_DEVICE_HELP = "Device title from the inventory; omit when only one device is configured."
+
 
 @mcp.tool(name="safe_mode_status", annotations=annotate(READ, "Safe Mode Status"))
-async def mikrotik_safe_mode_status(ctx: Context) -> str:
-    """Returns whether MikroTik Safe Mode is currently active."""
-    await ctx.info("Checking safe mode status")
-    return get_safe_mode_manager().status()
+async def mikrotik_safe_mode_status(ctx: Context, device: Optional[str] = None) -> str:
+    """Returns whether MikroTik Safe Mode is currently active.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
+    await ctx.info(f"Checking safe mode status (device={device})")
+    return get_safe_mode_manager(device).status()
 
 
 @mcp.tool(name="enable_safe_mode", annotations=annotate(WRITE, "Enable Safe Mode"))
-async def mikrotik_enable_safe_mode(ctx: Context) -> str:
-    """Activates MikroTik Safe Mode; changes are held in memory and auto-reverted on disconnect until committed."""
-    await ctx.info("Enabling MikroTik safe mode")
-    result = await asyncio.to_thread(get_safe_mode_manager().enable)
+async def mikrotik_enable_safe_mode(ctx: Context, device: Optional[str] = None) -> str:
+    """Activates MikroTik Safe Mode; changes are held in memory and auto-reverted on disconnect until committed.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
+    await ctx.info(f"Enabling MikroTik safe mode (device={device})")
+    result = await asyncio.to_thread(get_safe_mode_manager(device).enable)
     return result
 
 
 @mcp.tool(name="commit_safe_mode", annotations=annotate(WRITE, "Commit Safe Mode"))
-async def mikrotik_commit_safe_mode(ctx: Context) -> str:
-    """Commits all pending Safe Mode changes to persistent storage and exits Safe Mode."""
-    await ctx.info("Committing safe mode changes")
-    result = await asyncio.to_thread(get_safe_mode_manager().commit)
+async def mikrotik_commit_safe_mode(ctx: Context, device: Optional[str] = None) -> str:
+    """Commits all pending Safe Mode changes to persistent storage and exits Safe Mode.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
+    await ctx.info(f"Committing safe mode changes (device={device})")
+    result = await asyncio.to_thread(get_safe_mode_manager(device).commit)
     return result
 
 
 @mcp.tool(name="rollback_safe_mode", annotations=annotate(WRITE, "Rollback Safe Mode"))
-async def mikrotik_rollback_safe_mode(ctx: Context) -> str:
-    """Discards all pending Safe Mode changes by closing the SSH session, triggering automatic rollback."""
-    await ctx.info("Rolling back safe mode changes")
-    result = await asyncio.to_thread(get_safe_mode_manager().rollback)
+async def mikrotik_rollback_safe_mode(ctx: Context, device: Optional[str] = None) -> str:
+    """Discards all pending Safe Mode changes by closing the SSH session, triggering automatic rollback.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
+    await ctx.info(f"Rolling back safe mode changes (device={device})")
+    result = await asyncio.to_thread(get_safe_mode_manager(device).rollback)
     return result

--- a/src/mcp_mikrotik/scope/safe_mode.py
+++ b/src/mcp_mikrotik/scope/safe_mode.py
@@ -4,6 +4,7 @@ from typing import Optional
 from mcp.server.mcpserver import Context
 
 from ..app import mcp, READ, WRITE, annotate
+from ..inventory import DeviceNotFoundError
 from ..safe_mode import get_safe_mode_manager
 
 
@@ -11,28 +12,41 @@ from ..safe_mode import get_safe_mode_manager
 async def mikrotik_safe_mode_status(ctx: Context, device: Optional[str] = None) -> str:
     """Returns whether MikroTik Safe Mode is currently active."""
     await ctx.info(f"Checking safe mode status (device={device})")
-    return get_safe_mode_manager(device).status()
+    try:
+        manager = get_safe_mode_manager(device)
+    except DeviceNotFoundError as exc:
+        return f"Error: {exc}"
+    return manager.status()
 
 
 @mcp.tool(name="enable_safe_mode", annotations=annotate(WRITE, "Enable Safe Mode"))
 async def mikrotik_enable_safe_mode(ctx: Context, device: Optional[str] = None) -> str:
     """Activates MikroTik Safe Mode; changes are held in memory and auto-reverted on disconnect until committed."""
     await ctx.info(f"Enabling MikroTik safe mode (device={device})")
-    result = await asyncio.to_thread(get_safe_mode_manager(device).enable)
-    return result
+    try:
+        manager = get_safe_mode_manager(device)
+    except DeviceNotFoundError as exc:
+        return f"Error: {exc}"
+    return await asyncio.to_thread(manager.enable)
 
 
 @mcp.tool(name="commit_safe_mode", annotations=annotate(WRITE, "Commit Safe Mode"))
 async def mikrotik_commit_safe_mode(ctx: Context, device: Optional[str] = None) -> str:
     """Commits all pending Safe Mode changes to persistent storage and exits Safe Mode."""
     await ctx.info(f"Committing safe mode changes (device={device})")
-    result = await asyncio.to_thread(get_safe_mode_manager(device).commit)
-    return result
+    try:
+        manager = get_safe_mode_manager(device)
+    except DeviceNotFoundError as exc:
+        return f"Error: {exc}"
+    return await asyncio.to_thread(manager.commit)
 
 
 @mcp.tool(name="rollback_safe_mode", annotations=annotate(WRITE, "Rollback Safe Mode"))
 async def mikrotik_rollback_safe_mode(ctx: Context, device: Optional[str] = None) -> str:
     """Discards all pending Safe Mode changes by closing the SSH session, triggering automatic rollback."""
     await ctx.info(f"Rolling back safe mode changes (device={device})")
-    result = await asyncio.to_thread(get_safe_mode_manager(device).rollback)
-    return result
+    try:
+        manager = get_safe_mode_manager(device)
+    except DeviceNotFoundError as exc:
+        return f"Error: {exc}"
+    return await asyncio.to_thread(manager.rollback)

--- a/src/mcp_mikrotik/scope/users.py
+++ b/src/mcp_mikrotik/scope/users.py
@@ -15,11 +15,7 @@ async def mikrotik_add_user(
     disabled: bool = False,
     device: Optional[str] = None
 ) -> str:
-    """Adds a user to MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Adds a user to MikroTik device."""
     await ctx.info(f"Adding user: name={name}, group={group}")
 
     cmd = f'/user add name="{name}" password="{password}" group={group}'
@@ -68,11 +64,7 @@ async def mikrotik_list_users(
     active_only: bool = False,
     device: Optional[str] = None
 ) -> str:
-    """Lists users on MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Lists users on MikroTik device."""
     await ctx.info(f"Listing users with filters: name={name_filter}, group={group_filter}")
 
     cmd = "/user print"
@@ -100,11 +92,7 @@ async def mikrotik_list_users(
 
 @mcp.tool(name="get_user", annotations=annotate(READ, "Get User"))
 async def mikrotik_get_user(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Gets detailed information about a specific user.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets detailed information about a specific user."""
     await ctx.info(f"Getting user details: name={name}")
 
     cmd = f'/user print detail where name="{name}"'
@@ -130,11 +118,7 @@ async def mikrotik_update_user(
     disabled: Optional[bool] = None,
     device: Optional[str] = None
 ) -> str:
-    """Updates a user.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Updates a user."""
     await ctx.info(f"Updating user: name={name}")
 
     cmd = f'/user set [find name="{name}"]'
@@ -177,11 +161,7 @@ async def mikrotik_update_user(
 
 @mcp.tool(name="remove_user", annotations=annotate(DESTRUCTIVE, "Remove User"))
 async def mikrotik_remove_user(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Removes a user.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Removes a user."""
     await ctx.info(f"Removing user: name={name}")
 
     # Don't allow removal of admin user
@@ -204,20 +184,12 @@ async def mikrotik_remove_user(ctx: Context, name: str, device: Optional[str] = 
 
 @mcp.tool(name="disable_user", annotations=annotate(WRITE_IDEMPOTENT, "Disable User"))
 async def mikrotik_disable_user(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Disables a user.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Disables a user."""
     return await mikrotik_update_user(name, disabled=True, ctx=ctx, device=device)
 
 @mcp.tool(name="enable_user", annotations=annotate(WRITE_IDEMPOTENT, "Enable User"))
 async def mikrotik_enable_user(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Enables a user.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Enables a user."""
     return await mikrotik_update_user(name, disabled=False, ctx=ctx, device=device)
 
 @mcp.tool(name="add_user_group", annotations=annotate(WRITE, "Add User Group"))
@@ -229,11 +201,7 @@ async def mikrotik_add_user_group(
     comment: Optional[str] = None,
     device: Optional[str] = None
 ) -> str:
-    """Adds a user group.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Adds a user group."""
     await ctx.info(f"Adding user group: name={name}")
 
     # Valid policies
@@ -286,11 +254,7 @@ async def mikrotik_list_user_groups(
     policy_filter: Optional[str] = None,
     device: Optional[str] = None
 ) -> str:
-    """Lists user groups on MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Lists user groups on MikroTik device."""
     await ctx.info(f"Listing user groups with filters: name={name_filter}")
 
     cmd = "/user group print"
@@ -313,11 +277,7 @@ async def mikrotik_list_user_groups(
 
 @mcp.tool(name="get_user_group", annotations=annotate(READ, "Get User Group"))
 async def mikrotik_get_user_group(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Gets detailed information about a specific user group.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets detailed information about a specific user group."""
     await ctx.info(f"Getting user group details: name={name}")
 
     cmd = f'/user group print detail where name="{name}"'
@@ -338,11 +298,7 @@ async def mikrotik_update_user_group(
     comment: Optional[str] = None,
     device: Optional[str] = None
 ) -> str:
-    """Updates a user group.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Updates a user group."""
     await ctx.info(f"Updating user group: name={name}")
 
     # Don't allow modification of built-in groups
@@ -382,11 +338,7 @@ async def mikrotik_update_user_group(
 
 @mcp.tool(name="remove_user_group", annotations=annotate(DESTRUCTIVE, "Remove User Group"))
 async def mikrotik_remove_user_group(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Removes a user group.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Removes a user group."""
     await ctx.info(f"Removing user group: name={name}")
 
     # Don't allow removal of built-in groups
@@ -416,11 +368,7 @@ async def mikrotik_remove_user_group(ctx: Context, name: str, device: Optional[s
 
 @mcp.tool(name="get_active_users", annotations=annotate(READ, "Active Users"))
 async def mikrotik_get_active_users(ctx: Context, device: Optional[str] = None) -> str:
-    """Gets currently active/logged-in users.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets currently active/logged-in users."""
     await ctx.info("Getting active users")
 
     cmd = "/user active print"
@@ -433,11 +381,7 @@ async def mikrotik_get_active_users(ctx: Context, device: Optional[str] = None) 
 
 @mcp.tool(name="disconnect_user", annotations=annotate(DESTRUCTIVE, "Disconnect User"))
 async def mikrotik_disconnect_user(ctx: Context, user_id: str, device: Optional[str] = None) -> str:
-    """Disconnects an active user session.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Disconnects an active user session."""
     await ctx.info(f"Disconnecting user: user_id={user_id}")
 
     cmd = f"/user active remove {user_id}"
@@ -450,11 +394,7 @@ async def mikrotik_disconnect_user(ctx: Context, user_id: str, device: Optional[
 
 @mcp.tool(name="export_user_config", annotations=annotate(READ, "Export User Config"))
 async def mikrotik_export_user_config(ctx: Context, filename: Optional[str] = None, device: Optional[str] = None) -> str:
-    """Exports user configuration to a file.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Exports user configuration to a file."""
     await ctx.info("Exporting user configuration")
 
     if not filename:
@@ -475,11 +415,7 @@ async def mikrotik_set_user_ssh_keys(
     key_file: str,
     device: Optional[str] = None
 ) -> str:
-    """Sets SSH keys for a specific user.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Sets SSH keys for a specific user."""
     await ctx.info(f"Setting SSH keys for user: {username}")
 
     cmd = f'/user ssh-keys import user="{username}" public-key-file="{key_file}"'
@@ -492,11 +428,7 @@ async def mikrotik_set_user_ssh_keys(
 
 @mcp.tool(name="list_user_ssh_keys", annotations=annotate(READ, "List User SSH Keys"))
 async def mikrotik_list_user_ssh_keys(ctx: Context, username: str, device: Optional[str] = None) -> str:
-    """Lists SSH keys for a specific user.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Lists SSH keys for a specific user."""
     await ctx.info(f"Listing SSH keys for user: {username}")
 
     cmd = f'/user ssh-keys print where user="{username}"'
@@ -509,11 +441,7 @@ async def mikrotik_list_user_ssh_keys(ctx: Context, username: str, device: Optio
 
 @mcp.tool(name="remove_user_ssh_key", annotations=annotate(DESTRUCTIVE, "Remove User SSH Key"))
 async def mikrotik_remove_user_ssh_key(ctx: Context, key_id: str, device: Optional[str] = None) -> str:
-    """Removes an SSH key.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Removes an SSH key."""
     await ctx.info(f"Removing SSH key: key_id={key_id}")
 
     cmd = f"/user ssh-keys remove {key_id}"

--- a/src/mcp_mikrotik/scope/users.py
+++ b/src/mcp_mikrotik/scope/users.py
@@ -12,9 +12,14 @@ async def mikrotik_add_user(
     group: str = "read",
     address: Optional[str] = None,
     comment: Optional[str] = None,
-    disabled: bool = False
+    disabled: bool = False,
+    device: Optional[str] = None
 ) -> str:
-    """Adds a user to MikroTik device."""
+    """Adds a user to MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Adding user: name={name}, group={group}")
 
     cmd = f'/user add name="{name}" password="{password}" group={group}'
@@ -28,13 +33,13 @@ async def mikrotik_add_user(
     if disabled:
         cmd += " disabled=yes"
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if result.strip():
         if "*" in result or result.strip().isdigit():
             user_id = result.strip()
             details_cmd = f"/user print detail where .id={user_id}"
-            details = await execute_mikrotik_command(details_cmd, ctx)
+            details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
             if details.strip():
                 # Remove password from output for security
@@ -46,7 +51,7 @@ async def mikrotik_add_user(
             return f"Failed to create user: {result}"
     else:
         details_cmd = f'/user print detail where name="{name}"'
-        details = await execute_mikrotik_command(details_cmd, ctx)
+        details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
         if details.strip():
             details = re.sub(r'password="[^"]*"', 'password="***"', details)
@@ -60,9 +65,14 @@ async def mikrotik_list_users(
     name_filter: Optional[str] = None,
     group_filter: Optional[str] = None,
     disabled_only: bool = False,
-    active_only: bool = False
+    active_only: bool = False,
+    device: Optional[str] = None
 ) -> str:
-    """Lists users on MikroTik device."""
+    """Lists users on MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Listing users with filters: name={name_filter}, group={group_filter}")
 
     cmd = "/user print"
@@ -78,7 +88,7 @@ async def mikrotik_list_users(
     if filters:
         cmd += " where " + " ".join(filters)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "" or result.strip() == "no such item":
         return "No users found matching the criteria."
@@ -89,12 +99,16 @@ async def mikrotik_list_users(
     return f"USERS:\n\n{result}"
 
 @mcp.tool(name="get_user", annotations=annotate(READ, "Get User"))
-async def mikrotik_get_user(ctx: Context, name: str) -> str:
-    """Gets detailed information about a specific user."""
+async def mikrotik_get_user(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Gets detailed information about a specific user.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Getting user details: name={name}")
 
     cmd = f'/user print detail where name="{name}"'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return f"User '{name}' not found."
@@ -113,9 +127,14 @@ async def mikrotik_update_user(
     group: Optional[str] = None,
     address: Optional[str] = None,
     comment: Optional[str] = None,
-    disabled: Optional[bool] = None
+    disabled: Optional[bool] = None,
+    device: Optional[str] = None
 ) -> str:
-    """Updates a user."""
+    """Updates a user.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Updating user: name={name}")
 
     cmd = f'/user set [find name="{name}"]'
@@ -142,14 +161,14 @@ async def mikrotik_update_user(
 
     cmd += " " + " ".join(updates)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to update user: {result}"
 
     details_name = new_name if new_name else name
     details_cmd = f'/user print detail where name="{details_name}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
     # Remove password from output
     details = re.sub(r'password="[^"]*"', 'password="***"', details)
@@ -157,8 +176,12 @@ async def mikrotik_update_user(
     return f"User updated successfully:\n\n{details}"
 
 @mcp.tool(name="remove_user", annotations=annotate(DESTRUCTIVE, "Remove User"))
-async def mikrotik_remove_user(ctx: Context, name: str) -> str:
-    """Removes a user."""
+async def mikrotik_remove_user(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Removes a user.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Removing user: name={name}")
 
     # Don't allow removal of admin user
@@ -166,13 +189,13 @@ async def mikrotik_remove_user(ctx: Context, name: str) -> str:
         return "Cannot remove the admin user."
 
     check_cmd = f'/user print count-only where name="{name}"'
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         return f"User '{name}' not found."
 
     cmd = f'/user remove [find name="{name}"]'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to remove user: {result}"
@@ -180,14 +203,22 @@ async def mikrotik_remove_user(ctx: Context, name: str) -> str:
     return f"User '{name}' removed successfully."
 
 @mcp.tool(name="disable_user", annotations=annotate(WRITE_IDEMPOTENT, "Disable User"))
-async def mikrotik_disable_user(ctx: Context, name: str) -> str:
-    """Disables a user."""
-    return await mikrotik_update_user(name, disabled=True, ctx=ctx)
+async def mikrotik_disable_user(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Disables a user.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
+    return await mikrotik_update_user(name, disabled=True, ctx=ctx, device=device)
 
 @mcp.tool(name="enable_user", annotations=annotate(WRITE_IDEMPOTENT, "Enable User"))
-async def mikrotik_enable_user(ctx: Context, name: str) -> str:
-    """Enables a user."""
-    return await mikrotik_update_user(name, disabled=False, ctx=ctx)
+async def mikrotik_enable_user(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Enables a user.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
+    return await mikrotik_update_user(name, disabled=False, ctx=ctx, device=device)
 
 @mcp.tool(name="add_user_group", annotations=annotate(WRITE, "Add User Group"))
 async def mikrotik_add_user_group(
@@ -195,9 +226,14 @@ async def mikrotik_add_user_group(
     name: str,
     policy: List[str],
     skin: Optional[str] = None,
-    comment: Optional[str] = None
+    comment: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
-    """Adds a user group."""
+    """Adds a user group.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Adding user group: name={name}")
 
     # Valid policies
@@ -220,13 +256,13 @@ async def mikrotik_add_user_group(
     if comment:
         cmd += f' comment="{comment}"'
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if result.strip():
         if "*" in result or result.strip().isdigit():
             group_id = result.strip()
             details_cmd = f"/user group print detail where .id={group_id}"
-            details = await execute_mikrotik_command(details_cmd, ctx)
+            details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
             if details.strip():
                 return f"User group created successfully:\n\n{details}"
@@ -236,7 +272,7 @@ async def mikrotik_add_user_group(
             return f"Failed to create user group: {result}"
     else:
         details_cmd = f'/user group print detail where name="{name}"'
-        details = await execute_mikrotik_command(details_cmd, ctx)
+        details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
         if details.strip():
             return f"User group created successfully:\n\n{details}"
@@ -247,9 +283,14 @@ async def mikrotik_add_user_group(
 async def mikrotik_list_user_groups(
     ctx: Context,
     name_filter: Optional[str] = None,
-    policy_filter: Optional[str] = None
+    policy_filter: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
-    """Lists user groups on MikroTik device."""
+    """Lists user groups on MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Listing user groups with filters: name={name_filter}")
 
     cmd = "/user group print"
@@ -263,7 +304,7 @@ async def mikrotik_list_user_groups(
     if filters:
         cmd += " where " + " ".join(filters)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "" or result.strip() == "no such item":
         return "No user groups found matching the criteria."
@@ -271,12 +312,16 @@ async def mikrotik_list_user_groups(
     return f"USER GROUPS:\n\n{result}"
 
 @mcp.tool(name="get_user_group", annotations=annotate(READ, "Get User Group"))
-async def mikrotik_get_user_group(ctx: Context, name: str) -> str:
-    """Gets detailed information about a specific user group."""
+async def mikrotik_get_user_group(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Gets detailed information about a specific user group.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Getting user group details: name={name}")
 
     cmd = f'/user group print detail where name="{name}"'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return f"User group '{name}' not found."
@@ -290,9 +335,14 @@ async def mikrotik_update_user_group(
     new_name: Optional[str] = None,
     policy: Optional[List[str]] = None,
     skin: Optional[str] = None,
-    comment: Optional[str] = None
+    comment: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
-    """Updates a user group."""
+    """Updates a user group.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Updating user group: name={name}")
 
     # Don't allow modification of built-in groups
@@ -319,20 +369,24 @@ async def mikrotik_update_user_group(
 
     cmd += " " + " ".join(updates)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to update user group: {result}"
 
     details_name = new_name if new_name else name
     details_cmd = f'/user group print detail where name="{details_name}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
     return f"User group updated successfully:\n\n{details}"
 
 @mcp.tool(name="remove_user_group", annotations=annotate(DESTRUCTIVE, "Remove User Group"))
-async def mikrotik_remove_user_group(ctx: Context, name: str) -> str:
-    """Removes a user group."""
+async def mikrotik_remove_user_group(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Removes a user group.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Removing user group: name={name}")
 
     # Don't allow removal of built-in groups
@@ -340,20 +394,20 @@ async def mikrotik_remove_user_group(ctx: Context, name: str) -> str:
         return f"Cannot remove built-in group '{name}'."
 
     check_cmd = f'/user group print count-only where name="{name}"'
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         return f"User group '{name}' not found."
 
     # Check if group is in use
     users_cmd = f'/user print count-only where group="{name}"'
-    users_count = await execute_mikrotik_command(users_cmd, ctx)
+    users_count = await execute_mikrotik_command(users_cmd, ctx, device=device)
 
     if users_count.strip() != "0":
         return f"Cannot remove group '{name}': {users_count.strip()} users are using this group."
 
     cmd = f'/user group remove [find name="{name}"]'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to remove user group: {result}"
@@ -361,12 +415,16 @@ async def mikrotik_remove_user_group(ctx: Context, name: str) -> str:
     return f"User group '{name}' removed successfully."
 
 @mcp.tool(name="get_active_users", annotations=annotate(READ, "Active Users"))
-async def mikrotik_get_active_users(ctx: Context) -> str:
-    """Gets currently active/logged-in users."""
+async def mikrotik_get_active_users(ctx: Context, device: Optional[str] = None) -> str:
+    """Gets currently active/logged-in users.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Getting active users")
 
     cmd = "/user active print"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return "No active users found."
@@ -374,12 +432,16 @@ async def mikrotik_get_active_users(ctx: Context) -> str:
     return f"ACTIVE USERS:\n\n{result}"
 
 @mcp.tool(name="disconnect_user", annotations=annotate(DESTRUCTIVE, "Disconnect User"))
-async def mikrotik_disconnect_user(ctx: Context, user_id: str) -> str:
-    """Disconnects an active user session."""
+async def mikrotik_disconnect_user(ctx: Context, user_id: str, device: Optional[str] = None) -> str:
+    """Disconnects an active user session.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Disconnecting user: user_id={user_id}")
 
     cmd = f"/user active remove {user_id}"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to disconnect user: {result}"
@@ -387,15 +449,19 @@ async def mikrotik_disconnect_user(ctx: Context, user_id: str) -> str:
     return f"User session {user_id} disconnected successfully."
 
 @mcp.tool(name="export_user_config", annotations=annotate(READ, "Export User Config"))
-async def mikrotik_export_user_config(ctx: Context, filename: Optional[str] = None) -> str:
-    """Exports user configuration to a file."""
+async def mikrotik_export_user_config(ctx: Context, filename: Optional[str] = None, device: Optional[str] = None) -> str:
+    """Exports user configuration to a file.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Exporting user configuration")
 
     if not filename:
         filename = "user_config"
 
     cmd = f"/user export file={filename}"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result.strip():
         return f"User configuration exported to {filename}.rsc"
@@ -406,13 +472,18 @@ async def mikrotik_export_user_config(ctx: Context, filename: Optional[str] = No
 async def mikrotik_set_user_ssh_keys(
     ctx: Context,
     username: str,
-    key_file: str
+    key_file: str,
+    device: Optional[str] = None
 ) -> str:
-    """Sets SSH keys for a specific user."""
+    """Sets SSH keys for a specific user.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Setting SSH keys for user: {username}")
 
     cmd = f'/user ssh-keys import user="{username}" public-key-file="{key_file}"'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result.strip() or "imported" in result.lower():
         return f"SSH key imported successfully for user '{username}'."
@@ -420,12 +491,16 @@ async def mikrotik_set_user_ssh_keys(
         return f"Failed to import SSH key: {result}"
 
 @mcp.tool(name="list_user_ssh_keys", annotations=annotate(READ, "List User SSH Keys"))
-async def mikrotik_list_user_ssh_keys(ctx: Context, username: str) -> str:
-    """Lists SSH keys for a specific user."""
+async def mikrotik_list_user_ssh_keys(ctx: Context, username: str, device: Optional[str] = None) -> str:
+    """Lists SSH keys for a specific user.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Listing SSH keys for user: {username}")
 
     cmd = f'/user ssh-keys print where user="{username}"'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return f"No SSH keys found for user '{username}'."
@@ -433,12 +508,16 @@ async def mikrotik_list_user_ssh_keys(ctx: Context, username: str) -> str:
     return f"SSH KEYS for {username}:\n\n{result}"
 
 @mcp.tool(name="remove_user_ssh_key", annotations=annotate(DESTRUCTIVE, "Remove User SSH Key"))
-async def mikrotik_remove_user_ssh_key(ctx: Context, key_id: str) -> str:
-    """Removes an SSH key."""
+async def mikrotik_remove_user_ssh_key(ctx: Context, key_id: str, device: Optional[str] = None) -> str:
+    """Removes an SSH key.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Removing SSH key: key_id={key_id}")
 
     cmd = f"/user ssh-keys remove {key_id}"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to remove SSH key: {result}"

--- a/src/mcp_mikrotik/scope/vlan.py
+++ b/src/mcp_mikrotik/scope/vlan.py
@@ -18,11 +18,7 @@ async def mikrotik_create_vlan_interface(
     arp_timeout: Optional[str] = None,
     device: Optional[str] = None
 ) -> str:
-    """Creates a VLAN interface on the MikroTik device with the given VLAN ID and parent interface.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Creates a VLAN interface on the MikroTik device with the given VLAN ID and parent interface."""
     await ctx.info(f"Creating VLAN interface: name={name}, vlan_id={vlan_id}, interface={interface}")
 
     # Build the command
@@ -83,11 +79,7 @@ async def mikrotik_list_vlan_interfaces(
     disabled_only: bool = False,
     device: Optional[str] = None
 ) -> str:
-    """Lists VLAN interfaces on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Lists VLAN interfaces on the MikroTik device."""
     await ctx.info(f"Listing VLAN interfaces with filters: name={name_filter}, vlan_id={vlan_id_filter}, interface={interface_filter}")
 
     # Build the command
@@ -117,11 +109,7 @@ async def mikrotik_list_vlan_interfaces(
 
 @mcp.tool(name="get_vlan_interface", annotations=annotate(READ, "Get VLAN"))
 async def mikrotik_get_vlan_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Gets detailed information about a specific VLAN interface.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets detailed information about a specific VLAN interface."""
     await ctx.info(f"Getting VLAN interface details: name={name}")
 
     cmd = f'/interface vlan print detail where name="{name}"'
@@ -147,11 +135,7 @@ async def mikrotik_update_vlan_interface(
     arp_timeout: Optional[str] = None,
     device: Optional[str] = None
 ) -> str:
-    """Updates an existing VLAN interface's settings on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Updates an existing VLAN interface's settings on the MikroTik device."""
     await ctx.info(f"Updating VLAN interface: name={name}")
 
     # Build the command
@@ -198,11 +182,7 @@ async def mikrotik_update_vlan_interface(
 
 @mcp.tool(name="remove_vlan_interface", annotations=annotate(DESTRUCTIVE, "Remove VLAN"))
 async def mikrotik_remove_vlan_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Removes a VLAN interface from the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Removes a VLAN interface from the MikroTik device."""
     await ctx.info(f"Removing VLAN interface: name={name}")
 
     # First check if the interface exists

--- a/src/mcp_mikrotik/scope/vlan.py
+++ b/src/mcp_mikrotik/scope/vlan.py
@@ -15,9 +15,14 @@ async def mikrotik_create_vlan_interface(
     mtu: Optional[int] = None,
     use_service_tag: bool = False,
     arp: Literal["enabled", "disabled", "proxy-arp", "reply-only"] = "enabled",
-    arp_timeout: Optional[str] = None
+    arp_timeout: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
-    """Creates a VLAN interface on the MikroTik device with the given VLAN ID and parent interface."""
+    """Creates a VLAN interface on the MikroTik device with the given VLAN ID and parent interface.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Creating VLAN interface: name={name}, vlan_id={vlan_id}, interface={interface}")
 
     # Build the command
@@ -42,7 +47,7 @@ async def mikrotik_create_vlan_interface(
     if arp_timeout:
         cmd += f" arp-timeout={arp_timeout}"
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     # Check if creation was successful
     if result.strip():
@@ -50,7 +55,7 @@ async def mikrotik_create_vlan_interface(
         if "*" in result or result.strip().isdigit():
             # Success - get the details
             details_cmd = f"/interface vlan print detail where name={name}"
-            details = await execute_mikrotik_command(details_cmd, ctx)
+            details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
             if details.strip():
                 return f"VLAN interface created successfully:\n\n{details}"
@@ -62,7 +67,7 @@ async def mikrotik_create_vlan_interface(
     else:
         # No output might mean success, let's check
         details_cmd = f"/interface vlan print detail where name={name}"
-        details = await execute_mikrotik_command(details_cmd, ctx)
+        details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
         if details.strip():
             return f"VLAN interface created successfully:\n\n{details}"
@@ -75,9 +80,14 @@ async def mikrotik_list_vlan_interfaces(
     name_filter: Optional[str] = None,
     vlan_id_filter: Optional[int] = None,
     interface_filter: Optional[str] = None,
-    disabled_only: bool = False
+    disabled_only: bool = False,
+    device: Optional[str] = None
 ) -> str:
-    """Lists VLAN interfaces on the MikroTik device."""
+    """Lists VLAN interfaces on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Listing VLAN interfaces with filters: name={name_filter}, vlan_id={vlan_id_filter}, interface={interface_filter}")
 
     # Build the command
@@ -97,7 +107,7 @@ async def mikrotik_list_vlan_interfaces(
     if filters:
         cmd += " where " + " ".join(filters)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     # Check for empty result
     if not result or result.strip() == "" or result.strip() == "no such item":
@@ -106,12 +116,16 @@ async def mikrotik_list_vlan_interfaces(
     return f"VLAN INTERFACES:\n\n{result}"
 
 @mcp.tool(name="get_vlan_interface", annotations=annotate(READ, "Get VLAN"))
-async def mikrotik_get_vlan_interface(ctx: Context, name: str) -> str:
-    """Gets detailed information about a specific VLAN interface."""
+async def mikrotik_get_vlan_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Gets detailed information about a specific VLAN interface.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Getting VLAN interface details: name={name}")
 
     cmd = f'/interface vlan print detail where name="{name}"'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return f"VLAN interface '{name}' not found."
@@ -130,9 +144,14 @@ async def mikrotik_update_vlan_interface(
     mtu: Optional[int] = None,
     use_service_tag: Optional[bool] = None,
     arp: Optional[Literal["enabled", "disabled", "proxy-arp", "reply-only"]] = None,
-    arp_timeout: Optional[str] = None
+    arp_timeout: Optional[str] = None,
+    device: Optional[str] = None
 ) -> str:
-    """Updates an existing VLAN interface's settings on the MikroTik device."""
+    """Updates an existing VLAN interface's settings on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Updating VLAN interface: name={name}")
 
     # Build the command
@@ -164,7 +183,7 @@ async def mikrotik_update_vlan_interface(
 
     cmd += " " + " ".join(updates)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     # Check if update was successful
     if "failure:" in result.lower() or "error" in result.lower():
@@ -173,25 +192,29 @@ async def mikrotik_update_vlan_interface(
     # Get the updated interface details
     details_name = new_name if new_name else name
     details_cmd = f'/interface vlan print detail where name="{details_name}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
     return f"VLAN interface updated successfully:\n\n{details}"
 
 @mcp.tool(name="remove_vlan_interface", annotations=annotate(DESTRUCTIVE, "Remove VLAN"))
-async def mikrotik_remove_vlan_interface(ctx: Context, name: str) -> str:
-    """Removes a VLAN interface from the MikroTik device."""
+async def mikrotik_remove_vlan_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Removes a VLAN interface from the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Removing VLAN interface: name={name}")
 
     # First check if the interface exists
     check_cmd = f'/interface vlan print count-only where name="{name}"'
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         return f"VLAN interface '{name}' not found."
 
     # Remove the interface
     cmd = f'/interface vlan remove [find name="{name}"]'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to remove VLAN interface: {result}"

--- a/src/mcp_mikrotik/scope/wireguard.py
+++ b/src/mcp_mikrotik/scope/wireguard.py
@@ -19,8 +19,13 @@ async def mikrotik_create_wireguard_interface(
     mtu: Optional[int] = None,
     comment: Optional[str] = None,
     disabled: bool = False,
+    device: Optional[str] = None,
 ) -> str:
-    """Creates a WireGuard interface on the MikroTik device."""
+    """Creates a WireGuard interface on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Creating WireGuard interface: name={name}")
 
     cmd = f"/interface wireguard add name={name}"
@@ -36,13 +41,13 @@ async def mikrotik_create_wireguard_interface(
     if disabled:
         cmd += " disabled=yes"
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to create WireGuard interface: {result}"
 
     details_cmd = f'/interface wireguard print detail where name="{name}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
     if details.strip():
         return f"WireGuard interface created successfully:\n\n{details}"
@@ -55,8 +60,13 @@ async def mikrotik_list_wireguard_interfaces(
     name_filter: Optional[str] = None,
     disabled_only: bool = False,
     running_only: bool = False,
+    device: Optional[str] = None,
 ) -> str:
-    """Lists WireGuard interfaces on the MikroTik device."""
+    """Lists WireGuard interfaces on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Listing WireGuard interfaces")
 
     cmd = "/interface wireguard print"
@@ -72,7 +82,7 @@ async def mikrotik_list_wireguard_interfaces(
     if filters:
         cmd += " where " + " ".join(filters)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "" or result.strip() == "no such item":
         return "No WireGuard interfaces found."
@@ -81,12 +91,16 @@ async def mikrotik_list_wireguard_interfaces(
 
 
 @mcp.tool(name="get_wireguard_interface", annotations=annotate(READ, "Get WireGuard Interface"))
-async def mikrotik_get_wireguard_interface(ctx: Context, name: str) -> str:
-    """Gets detailed information about a specific WireGuard interface."""
+async def mikrotik_get_wireguard_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Gets detailed information about a specific WireGuard interface.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Getting WireGuard interface details: name={name}")
 
     cmd = f'/interface wireguard print detail where name="{name}"'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return f"WireGuard interface '{name}' not found."
@@ -104,8 +118,13 @@ async def mikrotik_update_wireguard_interface(
     mtu: Optional[int] = None,
     comment: Optional[str] = None,
     disabled: Optional[bool] = None,
+    device: Optional[str] = None,
 ) -> str:
-    """Updates an existing WireGuard interface's settings on the MikroTik device."""
+    """Updates an existing WireGuard interface's settings on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Updating WireGuard interface: name={name}")
 
     updates = []
@@ -126,31 +145,35 @@ async def mikrotik_update_wireguard_interface(
         return "No updates specified."
 
     cmd = f'/interface wireguard set [find name="{name}"] ' + " ".join(updates)
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to update WireGuard interface: {result}"
 
     lookup_name = new_name if new_name else name
     details_cmd = f'/interface wireguard print detail where name="{lookup_name}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
     return f"WireGuard interface updated successfully:\n\n{details}"
 
 
 @mcp.tool(name="remove_wireguard_interface", annotations=annotate(DESTRUCTIVE, "Remove WireGuard Interface"))
-async def mikrotik_remove_wireguard_interface(ctx: Context, name: str) -> str:
-    """Removes a WireGuard interface from the MikroTik device."""
+async def mikrotik_remove_wireguard_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Removes a WireGuard interface from the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Removing WireGuard interface: name={name}")
 
     check_cmd = f'/interface wireguard print count-only where name="{name}"'
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         return f"WireGuard interface '{name}' not found."
 
     cmd = f'/interface wireguard remove [find name="{name}"]'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to remove WireGuard interface: {result}"
@@ -159,12 +182,16 @@ async def mikrotik_remove_wireguard_interface(ctx: Context, name: str) -> str:
 
 
 @mcp.tool(name="enable_wireguard_interface", annotations=annotate(WRITE_IDEMPOTENT, "Enable WireGuard Interface"))
-async def mikrotik_enable_wireguard_interface(ctx: Context, name: str) -> str:
-    """Enables a WireGuard interface."""
+async def mikrotik_enable_wireguard_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Enables a WireGuard interface.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Enabling WireGuard interface: name={name}")
 
     cmd = f'/interface wireguard enable [find name="{name}"]'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to enable WireGuard interface: {result}"
@@ -173,12 +200,16 @@ async def mikrotik_enable_wireguard_interface(ctx: Context, name: str) -> str:
 
 
 @mcp.tool(name="disable_wireguard_interface", annotations=annotate(WRITE_IDEMPOTENT, "Disable WireGuard Interface"))
-async def mikrotik_disable_wireguard_interface(ctx: Context, name: str) -> str:
-    """Disables a WireGuard interface."""
+async def mikrotik_disable_wireguard_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Disables a WireGuard interface.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Disabling WireGuard interface: name={name}")
 
     cmd = f'/interface wireguard disable [find name="{name}"]'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to disable WireGuard interface: {result}"
@@ -202,6 +233,7 @@ async def mikrotik_add_wireguard_peer(
     persistent_keepalive: Optional[str] = None,
     comment: Optional[str] = None,
     disabled: bool = False,
+    device: Optional[str] = None,
 ) -> str:
     """Adds a WireGuard peer (with public key and allowed addresses) to an interface on the MikroTik device.
 
@@ -209,6 +241,7 @@ async def mikrotik_add_wireguard_peer(
         allowed_address: CIDR, comma-separated for multiple e.g. "10.0.0.2/32" or "10.0.0.0/24,192.168.0.0/24"
         endpoint_address: remote host IP or hostname e.g. "203.0.113.1"
         persistent_keepalive: seconds as string e.g. "25"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Adding WireGuard peer: interface={interface}, public_key={public_key[:12]}...")
 
@@ -231,7 +264,7 @@ async def mikrotik_add_wireguard_peer(
     if disabled:
         cmd += " disabled=yes"
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to add WireGuard peer: {result}"
@@ -240,7 +273,7 @@ async def mikrotik_add_wireguard_peer(
         f'/interface wireguard peers print detail where'
         f' interface="{interface}" public-key="{public_key}"'
     )
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
     if details.strip():
         return f"WireGuard peer added successfully:\n\n{details}"
@@ -252,8 +285,13 @@ async def mikrotik_list_wireguard_peers(
     ctx: Context,
     interface_filter: Optional[str] = None,
     disabled_only: bool = False,
+    device: Optional[str] = None,
 ) -> str:
-    """Lists WireGuard peers on the MikroTik device."""
+    """Lists WireGuard peers on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Listing WireGuard peers")
 
     cmd = "/interface wireguard peers print"
@@ -267,7 +305,7 @@ async def mikrotik_list_wireguard_peers(
     if filters:
         cmd += " where " + " ".join(filters)
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "" or result.strip() == "no such item":
         return "No WireGuard peers found."
@@ -276,16 +314,17 @@ async def mikrotik_list_wireguard_peers(
 
 
 @mcp.tool(name="get_wireguard_peer", annotations=annotate(READ, "Get WireGuard Peer"))
-async def mikrotik_get_wireguard_peer(ctx: Context, peer_id: str) -> str:
+async def mikrotik_get_wireguard_peer(ctx: Context, peer_id: str, device: Optional[str] = None) -> str:
     """Gets detailed information about a specific WireGuard peer by ID.
 
     Notes:
         peer_id: "*N" or "N" from list output e.g. "*2"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Getting WireGuard peer details: peer_id={peer_id}")
 
     cmd = f"/interface wireguard peers print detail where .id={peer_id}"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return f"WireGuard peer with ID '{peer_id}' not found."
@@ -304,6 +343,7 @@ async def mikrotik_update_wireguard_peer(
     persistent_keepalive: Optional[str] = None,
     comment: Optional[str] = None,
     disabled: Optional[bool] = None,
+    device: Optional[str] = None,
 ) -> str:
     """Updates an existing WireGuard peer's allowed addresses, endpoint, keepalive, or enabled state.
 
@@ -312,6 +352,7 @@ async def mikrotik_update_wireguard_peer(
         allowed_address: CIDR, comma-separated e.g. "10.0.0.2/32" or "10.0.0.0/24,192.168.0.0/24"
         persistent_keepalive: seconds as string e.g. "25"
         Pass "" for endpoint_address or preshared_key to clear them.
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Updating WireGuard peer: peer_id={peer_id}")
 
@@ -341,34 +382,35 @@ async def mikrotik_update_wireguard_peer(
         return "No updates specified."
 
     cmd = f"/interface wireguard peers set {peer_id} " + " ".join(updates)
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to update WireGuard peer: {result}"
 
     details_cmd = f"/interface wireguard peers print detail where .id={peer_id}"
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
     return f"WireGuard peer updated successfully:\n\n{details}"
 
 
 @mcp.tool(name="remove_wireguard_peer", annotations=annotate(DESTRUCTIVE, "Remove WireGuard Peer"))
-async def mikrotik_remove_wireguard_peer(ctx: Context, peer_id: str) -> str:
+async def mikrotik_remove_wireguard_peer(ctx: Context, peer_id: str, device: Optional[str] = None) -> str:
     """Removes a WireGuard peer from the MikroTik device.
 
     Notes:
         peer_id: "*N" or "N" from list output e.g. "*2"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Removing WireGuard peer: peer_id={peer_id}")
 
     check_cmd = f"/interface wireguard peers print count-only where .id={peer_id}"
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         return f"WireGuard peer with ID '{peer_id}' not found."
 
     cmd = f"/interface wireguard peers remove {peer_id}"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to remove WireGuard peer: {result}"
@@ -377,16 +419,17 @@ async def mikrotik_remove_wireguard_peer(ctx: Context, peer_id: str) -> str:
 
 
 @mcp.tool(name="enable_wireguard_peer", annotations=annotate(WRITE_IDEMPOTENT, "Enable WireGuard Peer"))
-async def mikrotik_enable_wireguard_peer(ctx: Context, peer_id: str) -> str:
+async def mikrotik_enable_wireguard_peer(ctx: Context, peer_id: str, device: Optional[str] = None) -> str:
     """Enables a WireGuard peer.
 
     Notes:
         peer_id: "*N" or "N" from list output e.g. "*2"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Enabling WireGuard peer: peer_id={peer_id}")
 
     cmd = f"/interface wireguard peers enable {peer_id}"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to enable WireGuard peer: {result}"
@@ -395,16 +438,17 @@ async def mikrotik_enable_wireguard_peer(ctx: Context, peer_id: str) -> str:
 
 
 @mcp.tool(name="disable_wireguard_peer", annotations=annotate(WRITE_IDEMPOTENT, "Disable WireGuard Peer"))
-async def mikrotik_disable_wireguard_peer(ctx: Context, peer_id: str) -> str:
+async def mikrotik_disable_wireguard_peer(ctx: Context, peer_id: str, device: Optional[str] = None) -> str:
     """Disables a WireGuard peer.
 
     Notes:
         peer_id: "*N" or "N" from list output e.g. "*2"
+        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Disabling WireGuard peer: peer_id={peer_id}")
 
     cmd = f"/interface wireguard peers disable {peer_id}"
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to disable WireGuard peer: {result}"
@@ -423,8 +467,13 @@ async def mikrotik_generate_wireguard_client_config(
     allowed_ips: str = "0.0.0.0/0",
     dns: Optional[str] = None,
     persistent_keepalive: int = 25,
+    device: Optional[str] = None,
 ) -> str:
-    """Generates a wg0.conf client config string from the given keys and server endpoint. Does not communicate with the router."""
+    """Generates a wg0.conf client config string from the given keys and server endpoint. Does not communicate with the router.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Generating WireGuard client configuration")
 
     lines = [

--- a/src/mcp_mikrotik/scope/wireguard.py
+++ b/src/mcp_mikrotik/scope/wireguard.py
@@ -21,11 +21,7 @@ async def mikrotik_create_wireguard_interface(
     disabled: bool = False,
     device: Optional[str] = None,
 ) -> str:
-    """Creates a WireGuard interface on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Creates a WireGuard interface on the MikroTik device."""
     await ctx.info(f"Creating WireGuard interface: name={name}")
 
     cmd = f"/interface wireguard add name={name}"
@@ -62,11 +58,7 @@ async def mikrotik_list_wireguard_interfaces(
     running_only: bool = False,
     device: Optional[str] = None,
 ) -> str:
-    """Lists WireGuard interfaces on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Lists WireGuard interfaces on the MikroTik device."""
     await ctx.info("Listing WireGuard interfaces")
 
     cmd = "/interface wireguard print"
@@ -92,11 +84,7 @@ async def mikrotik_list_wireguard_interfaces(
 
 @mcp.tool(name="get_wireguard_interface", annotations=annotate(READ, "Get WireGuard Interface"))
 async def mikrotik_get_wireguard_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Gets detailed information about a specific WireGuard interface.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets detailed information about a specific WireGuard interface."""
     await ctx.info(f"Getting WireGuard interface details: name={name}")
 
     cmd = f'/interface wireguard print detail where name="{name}"'
@@ -120,11 +108,7 @@ async def mikrotik_update_wireguard_interface(
     disabled: Optional[bool] = None,
     device: Optional[str] = None,
 ) -> str:
-    """Updates an existing WireGuard interface's settings on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Updates an existing WireGuard interface's settings on the MikroTik device."""
     await ctx.info(f"Updating WireGuard interface: name={name}")
 
     updates = []
@@ -159,11 +143,7 @@ async def mikrotik_update_wireguard_interface(
 
 @mcp.tool(name="remove_wireguard_interface", annotations=annotate(DESTRUCTIVE, "Remove WireGuard Interface"))
 async def mikrotik_remove_wireguard_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Removes a WireGuard interface from the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Removes a WireGuard interface from the MikroTik device."""
     await ctx.info(f"Removing WireGuard interface: name={name}")
 
     check_cmd = f'/interface wireguard print count-only where name="{name}"'
@@ -183,11 +163,7 @@ async def mikrotik_remove_wireguard_interface(ctx: Context, name: str, device: O
 
 @mcp.tool(name="enable_wireguard_interface", annotations=annotate(WRITE_IDEMPOTENT, "Enable WireGuard Interface"))
 async def mikrotik_enable_wireguard_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Enables a WireGuard interface.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Enables a WireGuard interface."""
     await ctx.info(f"Enabling WireGuard interface: name={name}")
 
     cmd = f'/interface wireguard enable [find name="{name}"]'
@@ -201,11 +177,7 @@ async def mikrotik_enable_wireguard_interface(ctx: Context, name: str, device: O
 
 @mcp.tool(name="disable_wireguard_interface", annotations=annotate(WRITE_IDEMPOTENT, "Disable WireGuard Interface"))
 async def mikrotik_disable_wireguard_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Disables a WireGuard interface.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Disables a WireGuard interface."""
     await ctx.info(f"Disabling WireGuard interface: name={name}")
 
     cmd = f'/interface wireguard disable [find name="{name}"]'
@@ -241,7 +213,6 @@ async def mikrotik_add_wireguard_peer(
         allowed_address: CIDR, comma-separated for multiple e.g. "10.0.0.2/32" or "10.0.0.0/24,192.168.0.0/24"
         endpoint_address: remote host IP or hostname e.g. "203.0.113.1"
         persistent_keepalive: seconds as string e.g. "25"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Adding WireGuard peer: interface={interface}, public_key={public_key[:12]}...")
 
@@ -287,11 +258,7 @@ async def mikrotik_list_wireguard_peers(
     disabled_only: bool = False,
     device: Optional[str] = None,
 ) -> str:
-    """Lists WireGuard peers on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Lists WireGuard peers on the MikroTik device."""
     await ctx.info("Listing WireGuard peers")
 
     cmd = "/interface wireguard peers print"
@@ -319,7 +286,6 @@ async def mikrotik_get_wireguard_peer(ctx: Context, peer_id: str, device: Option
 
     Notes:
         peer_id: "*N" or "N" from list output e.g. "*2"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Getting WireGuard peer details: peer_id={peer_id}")
 
@@ -352,7 +318,6 @@ async def mikrotik_update_wireguard_peer(
         allowed_address: CIDR, comma-separated e.g. "10.0.0.2/32" or "10.0.0.0/24,192.168.0.0/24"
         persistent_keepalive: seconds as string e.g. "25"
         Pass "" for endpoint_address or preshared_key to clear them.
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Updating WireGuard peer: peer_id={peer_id}")
 
@@ -399,7 +364,6 @@ async def mikrotik_remove_wireguard_peer(ctx: Context, peer_id: str, device: Opt
 
     Notes:
         peer_id: "*N" or "N" from list output e.g. "*2"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Removing WireGuard peer: peer_id={peer_id}")
 
@@ -424,7 +388,6 @@ async def mikrotik_enable_wireguard_peer(ctx: Context, peer_id: str, device: Opt
 
     Notes:
         peer_id: "*N" or "N" from list output e.g. "*2"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Enabling WireGuard peer: peer_id={peer_id}")
 
@@ -443,7 +406,6 @@ async def mikrotik_disable_wireguard_peer(ctx: Context, peer_id: str, device: Op
 
     Notes:
         peer_id: "*N" or "N" from list output e.g. "*2"
-        device: Device title from the inventory; omit when only one device is configured.
     """
     await ctx.info(f"Disabling WireGuard peer: peer_id={peer_id}")
 
@@ -469,11 +431,7 @@ async def mikrotik_generate_wireguard_client_config(
     persistent_keepalive: int = 25,
     device: Optional[str] = None,
 ) -> str:
-    """Generates a wg0.conf client config string from the given keys and server endpoint. Does not communicate with the router.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Generates a wg0.conf client config string from the given keys and server endpoint. Does not communicate with the router."""
     await ctx.info("Generating WireGuard client configuration")
 
     lines = [

--- a/src/mcp_mikrotik/scope/wireless.py
+++ b/src/mcp_mikrotik/scope/wireless.py
@@ -70,11 +70,7 @@ async def mikrotik_create_wireless_interface(
         security_profile: Optional[str] = None,
         device: Optional[str] = None,
 ) -> str:
-    """Creates a wireless interface on the MikroTik device (auto-detects RouterOS v6/v7 syntax).
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Creates a wireless interface on the MikroTik device (auto-detects RouterOS v6/v7 syntax)."""
     await ctx.info(f"Creating wireless interface: name={name}, ssid={ssid}")
 
     # Detect wireless interface type
@@ -149,11 +145,7 @@ async def mikrotik_list_wireless_interfaces(
         running_only: bool = False,
         device: Optional[str] = None
 ) -> str:
-    """Lists wireless interfaces on the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Lists wireless interfaces on the MikroTik device."""
     await ctx.info(f"Listing wireless interfaces with filters: name={name_filter}")
 
     # Try multiple interface types to ensure we find all wireless interfaces
@@ -223,11 +215,7 @@ NOTE: If you see wireless interfaces above, they might be using a different comm
 
 @mcp.tool(name="get_wireless_interface", annotations=annotate(READ, "Get Wireless Interface"))
 async def mikrotik_get_wireless_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Gets detailed information about a specific wireless interface.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets detailed information about a specific wireless interface."""
     await ctx.info(f"Getting wireless interface details: name={name}")
 
     # Detect wireless interface type
@@ -247,11 +235,7 @@ async def mikrotik_get_wireless_interface(ctx: Context, name: str, device: Optio
 
 @mcp.tool(name="remove_wireless_interface", annotations=annotate(DESTRUCTIVE, "Remove Wireless Interface"))
 async def mikrotik_remove_wireless_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Removes a wireless interface from the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Removes a wireless interface from the MikroTik device."""
     await ctx.info(f"Removing wireless interface: name={name}")
 
     # Detect wireless interface type
@@ -279,11 +263,7 @@ async def mikrotik_remove_wireless_interface(ctx: Context, name: str, device: Op
 
 @mcp.tool(name="enable_wireless_interface", annotations=annotate(WRITE_IDEMPOTENT, "Enable Wireless Interface"))
 async def mikrotik_enable_wireless_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Enables a wireless interface.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Enables a wireless interface."""
     await ctx.info(f"Enabling wireless interface: {name}")
 
     # Detect wireless interface type
@@ -303,11 +283,7 @@ async def mikrotik_enable_wireless_interface(ctx: Context, name: str, device: Op
 
 @mcp.tool(name="disable_wireless_interface", annotations=annotate(WRITE_IDEMPOTENT, "Disable Wireless Interface"))
 async def mikrotik_disable_wireless_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Disables a wireless interface.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Disables a wireless interface."""
     await ctx.info(f"Disabling wireless interface: {name}")
 
     # Detect wireless interface type
@@ -332,11 +308,7 @@ async def mikrotik_scan_wireless_networks(
         duration: int = 5,
         device: Optional[str] = None
 ) -> str:
-    """Scans for nearby wireless networks using the specified interface.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Scans for nearby wireless networks using the specified interface."""
     await ctx.info(f"Scanning wireless networks on interface: {interface}")
 
     # Detect wireless interface type
@@ -362,11 +334,7 @@ async def mikrotik_get_wireless_registration_table(
         interface: Optional[str] = None,
         device: Optional[str] = None
 ) -> str:
-    """Gets the wireless registration table (connected clients) from the MikroTik device.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Gets the wireless registration table (connected clients) from the MikroTik device."""
     await ctx.info(f"Getting wireless registration table for interface: {interface}")
 
     # Detect wireless interface type
@@ -391,11 +359,7 @@ async def mikrotik_get_wireless_registration_table(
 
 @mcp.tool(name="check_wireless_support", annotations=annotate(READ, "Check Wireless Support"))
 async def mikrotik_check_wireless_support(ctx: Context, device: Optional[str] = None) -> str:
-    """Checks if the device supports wireless and reports the RouterOS version and wireless interface type.
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Checks if the device supports wireless and reports the RouterOS version and wireless interface type."""
     await ctx.info("Checking wireless support")
 
     # Check RouterOS version
@@ -446,11 +410,7 @@ For legacy systems:
 # Legacy compatibility functions (simplified versions for older RouterOS)
 @mcp.tool(name="create_wireless_security_profile", annotations=annotate(WRITE, "Create Wireless Security Profile"))
 async def mikrotik_create_wireless_security_profile(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Legacy function - not supported in RouterOS v7.x
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Legacy function - not supported in RouterOS v7.x"""
     interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
     if interface_type in ["/interface wifi", "/interface wifiwave2"]:
         return "Security profiles are not used in RouterOS v7.x. Configure security directly on the wireless interface."
@@ -459,11 +419,7 @@ async def mikrotik_create_wireless_security_profile(ctx: Context, name: str, dev
 
 @mcp.tool(name="list_wireless_security_profiles", annotations=annotate(READ, "List Wireless Security Profiles"))
 async def mikrotik_list_wireless_security_profiles(ctx: Context, device: Optional[str] = None) -> str:
-    """Legacy function - not supported in RouterOS v7.x
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Legacy function - not supported in RouterOS v7.x"""
     interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
     if interface_type in ["/interface wifi", "/interface wifiwave2"]:
         return "Security profiles are not used in RouterOS v7.x. Security is configured directly on wireless interfaces."
@@ -472,11 +428,7 @@ async def mikrotik_list_wireless_security_profiles(ctx: Context, device: Optiona
 
 @mcp.tool(name="get_wireless_security_profile", annotations=annotate(READ, "Get Wireless Security Profile"))
 async def mikrotik_get_wireless_security_profile(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Legacy function - not supported in RouterOS v7.x
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Legacy function - not supported in RouterOS v7.x"""
     interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
     if interface_type in ["/interface wifi", "/interface wifiwave2"]:
         return "Security profiles are not used in RouterOS v7.x. Check security configuration on wireless interfaces directly."
@@ -485,11 +437,7 @@ async def mikrotik_get_wireless_security_profile(ctx: Context, name: str, device
 
 @mcp.tool(name="remove_wireless_security_profile", annotations=annotate(DESTRUCTIVE, "Remove Wireless Security Profile"))
 async def mikrotik_remove_wireless_security_profile(ctx: Context, name: str, device: Optional[str] = None) -> str:
-    """Legacy function - not supported in RouterOS v7.x
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Legacy function - not supported in RouterOS v7.x"""
     interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
     if interface_type in ["/interface wifi", "/interface wifiwave2"]:
         return "Security profiles are not used in RouterOS v7.x. Security is configured directly on wireless interfaces."
@@ -498,11 +446,7 @@ async def mikrotik_remove_wireless_security_profile(ctx: Context, name: str, dev
 
 @mcp.tool(name="set_wireless_security_profile", annotations=annotate(WRITE, "Set Wireless Security Profile"))
 async def mikrotik_set_wireless_security_profile(ctx: Context, interface_name: str, security_profile: str, device: Optional[str] = None) -> str:
-    """Legacy function - not supported in RouterOS v7.x
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Legacy function - not supported in RouterOS v7.x"""
     interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
     if interface_type in ["/interface wifi", "/interface wifiwave2"]:
         return "Security profiles are not used in RouterOS v7.x. Configure security directly on the wireless interface."
@@ -511,11 +455,7 @@ async def mikrotik_set_wireless_security_profile(ctx: Context, interface_name: s
 
 @mcp.tool(name="create_wireless_access_list", annotations=annotate(WRITE, "Create Wireless Access List"))
 async def mikrotik_create_wireless_access_list(ctx: Context, device: Optional[str] = None) -> str:
-    """Legacy function - different in RouterOS v7.x
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Legacy function - different in RouterOS v7.x"""
     interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
     if interface_type in ["/interface wifi", "/interface wifiwave2"]:
         return "Access lists are configured differently in RouterOS v7.x. Use firewall rules or other access control methods."
@@ -524,11 +464,7 @@ async def mikrotik_create_wireless_access_list(ctx: Context, device: Optional[st
 
 @mcp.tool(name="list_wireless_access_list", annotations=annotate(READ, "List Wireless Access List"))
 async def mikrotik_list_wireless_access_list(ctx: Context, device: Optional[str] = None) -> str:
-    """Legacy function - different in RouterOS v7.x
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Legacy function - different in RouterOS v7.x"""
     interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
     if interface_type in ["/interface wifi", "/interface wifiwave2"]:
         return "Access lists are configured differently in RouterOS v7.x. Check firewall rules or other access control configurations."
@@ -537,11 +473,7 @@ async def mikrotik_list_wireless_access_list(ctx: Context, device: Optional[str]
 
 @mcp.tool(name="remove_wireless_access_list_entry", annotations=annotate(DESTRUCTIVE, "Remove Wireless Access List Entry"))
 async def mikrotik_remove_wireless_access_list_entry(ctx: Context, entry_id: str, device: Optional[str] = None) -> str:
-    """Legacy function - different in RouterOS v7.x
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Legacy function - different in RouterOS v7.x"""
     interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
     if interface_type in ["/interface wifi", "/interface wifiwave2"]:
         return "Access lists are configured differently in RouterOS v7.x."
@@ -558,11 +490,7 @@ async def mikrotik_update_wireless_interface(
         comment: Optional[str] = None,
         device: Optional[str] = None,
 ) -> str:
-    """Updates an existing wireless interface's settings (name, SSID, enabled state, etc.).
-
-    Notes:
-        device: Device title from the inventory; omit when only one device is configured.
-    """
+    """Updates an existing wireless interface's settings (name, SSID, enabled state, etc.)."""
     await ctx.info(f"Updating wireless interface: name={name}")
 
     # Detect wireless interface type

--- a/src/mcp_mikrotik/scope/wireless.py
+++ b/src/mcp_mikrotik/scope/wireless.py
@@ -5,7 +5,7 @@ from mcp.server.mcpserver import Context
 from ..app import mcp, READ, WRITE, WRITE_IDEMPOTENT, DESTRUCTIVE, annotate
 
 
-async def mikrotik_detect_wireless_interface_type(ctx: Context) -> Optional[str]:
+async def mikrotik_detect_wireless_interface_type(ctx: Context, device: Optional[str] = None) -> Optional[str]:
     """
     Detects the wireless interface type based on RouterOS version.
 
@@ -28,7 +28,7 @@ async def mikrotik_detect_wireless_interface_type(ctx: Context) -> Optional[str]
 
             # Use a simpler test command that's less likely to hang
             test_cmd = f"{interface_type} print count-only"
-            result = await execute_mikrotik_command(test_cmd, ctx)
+            result = await execute_mikrotik_command(test_cmd, ctx, device=device)
 
             await ctx.debug(f"Result for {interface_type}: {result}")
 
@@ -68,12 +68,17 @@ async def mikrotik_create_wireless_interface(
         band: Optional[Literal["2ghz-b", "2ghz-b/g", "2ghz-b/g/n", "5ghz-a", "5ghz-a/n", "5ghz-a/n/ac", "2ghz-g", "2ghz-n", "5ghz-n", "5ghz-ac"]] = None,
         channel_width: Optional[Literal["20mhz", "40mhz", "80mhz", "160mhz", "20/40mhz-eC", "20/40mhz-Ce"]] = None,
         security_profile: Optional[str] = None,
+        device: Optional[str] = None,
 ) -> str:
-    """Creates a wireless interface on the MikroTik device (auto-detects RouterOS v6/v7 syntax)."""
+    """Creates a wireless interface on the MikroTik device (auto-detects RouterOS v6/v7 syntax).
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Creating wireless interface: name={name}, ssid={ssid}")
 
     # Detect wireless interface type
-    interface_type = await mikrotik_detect_wireless_interface_type(ctx)
+    interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
 
     if not interface_type:
         return "Error: No wireless interface support detected on this device."
@@ -124,14 +129,14 @@ async def mikrotik_create_wireless_interface(
                 cmd += f" {param_name}={param_value}"
 
     await ctx.info(f"Executing command: {cmd}")
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to create wireless interface: {result}"
 
     # Get the created interface details
     details_cmd = f'{interface_type} print detail where name="{name}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
     return f"Wireless interface created successfully using {interface_type}:\n\n{details}"
 
@@ -141,9 +146,14 @@ async def mikrotik_list_wireless_interfaces(
         ctx: Context,
         name_filter: Optional[str] = None,
         disabled_only: bool = False,
-        running_only: bool = False
+        running_only: bool = False,
+        device: Optional[str] = None
 ) -> str:
-    """Lists wireless interfaces on the MikroTik device."""
+    """Lists wireless interfaces on the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Listing wireless interfaces with filters: name={name_filter}")
 
     # Try multiple interface types to ensure we find all wireless interfaces
@@ -174,7 +184,7 @@ async def mikrotik_list_wireless_interfaces(
             if filters:
                 cmd += " where " + " and ".join(filters)
 
-            result = await execute_mikrotik_command(cmd, ctx)
+            result = await execute_mikrotik_command(cmd, ctx, device=device)
 
             # Check if command worked and has results
             if (result and
@@ -196,7 +206,7 @@ async def mikrotik_list_wireless_interfaces(
     # If no results found, try to show all interfaces to help debug
     try:
         all_interfaces_cmd = "/interface print"
-        all_interfaces = await execute_mikrotik_command(all_interfaces_cmd, ctx)
+        all_interfaces = await execute_mikrotik_command(all_interfaces_cmd, ctx, device=device)
         return f"""No wireless interfaces found matching the criteria.
 
 DEBUGGING INFO:
@@ -212,18 +222,22 @@ NOTE: If you see wireless interfaces above, they might be using a different comm
 
 
 @mcp.tool(name="get_wireless_interface", annotations=annotate(READ, "Get Wireless Interface"))
-async def mikrotik_get_wireless_interface(ctx: Context, name: str) -> str:
-    """Gets detailed information about a specific wireless interface."""
+async def mikrotik_get_wireless_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Gets detailed information about a specific wireless interface.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Getting wireless interface details: name={name}")
 
     # Detect wireless interface type
-    interface_type = await mikrotik_detect_wireless_interface_type(ctx)
+    interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
 
     if not interface_type:
         return "Error: No wireless interface support detected on this device."
 
     cmd = f'{interface_type} print detail where name="{name}"'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return f"Wireless interface '{name}' not found."
@@ -232,26 +246,30 @@ async def mikrotik_get_wireless_interface(ctx: Context, name: str) -> str:
 
 
 @mcp.tool(name="remove_wireless_interface", annotations=annotate(DESTRUCTIVE, "Remove Wireless Interface"))
-async def mikrotik_remove_wireless_interface(ctx: Context, name: str) -> str:
-    """Removes a wireless interface from the MikroTik device."""
+async def mikrotik_remove_wireless_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Removes a wireless interface from the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Removing wireless interface: name={name}")
 
     # Detect wireless interface type
-    interface_type = await mikrotik_detect_wireless_interface_type(ctx)
+    interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
 
     if not interface_type:
         return "Error: No wireless interface support detected on this device."
 
     # Check if interface exists
     check_cmd = f'{interface_type} print count-only where name="{name}"'
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         return f"Wireless interface '{name}' not found."
 
     # Remove the interface
     cmd = f'{interface_type} remove [find name="{name}"]'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to remove wireless interface: {result}"
@@ -260,18 +278,22 @@ async def mikrotik_remove_wireless_interface(ctx: Context, name: str) -> str:
 
 
 @mcp.tool(name="enable_wireless_interface", annotations=annotate(WRITE_IDEMPOTENT, "Enable Wireless Interface"))
-async def mikrotik_enable_wireless_interface(ctx: Context, name: str) -> str:
-    """Enables a wireless interface."""
+async def mikrotik_enable_wireless_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Enables a wireless interface.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Enabling wireless interface: {name}")
 
     # Detect wireless interface type
-    interface_type = await mikrotik_detect_wireless_interface_type(ctx)
+    interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
 
     if not interface_type:
         return "Error: No wireless interface support detected on this device."
 
     cmd = f'{interface_type} enable [find name="{name}"]'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to enable wireless interface: {result}"
@@ -280,18 +302,22 @@ async def mikrotik_enable_wireless_interface(ctx: Context, name: str) -> str:
 
 
 @mcp.tool(name="disable_wireless_interface", annotations=annotate(WRITE_IDEMPOTENT, "Disable Wireless Interface"))
-async def mikrotik_disable_wireless_interface(ctx: Context, name: str) -> str:
-    """Disables a wireless interface."""
+async def mikrotik_disable_wireless_interface(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Disables a wireless interface.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Disabling wireless interface: {name}")
 
     # Detect wireless interface type
-    interface_type = await mikrotik_detect_wireless_interface_type(ctx)
+    interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
 
     if not interface_type:
         return "Error: No wireless interface support detected on this device."
 
     cmd = f'{interface_type} disable [find name="{name}"]'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to disable wireless interface: {result}"
@@ -303,13 +329,18 @@ async def mikrotik_disable_wireless_interface(ctx: Context, name: str) -> str:
 async def mikrotik_scan_wireless_networks(
         ctx: Context,
         interface: str,
-        duration: int = 5
+        duration: int = 5,
+        device: Optional[str] = None
 ) -> str:
-    """Scans for nearby wireless networks using the specified interface."""
+    """Scans for nearby wireless networks using the specified interface.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Scanning wireless networks on interface: {interface}")
 
     # Detect wireless interface type
-    interface_type = await mikrotik_detect_wireless_interface_type(ctx)
+    interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
 
     if not interface_type:
         return "Error: No wireless interface support detected on this device."
@@ -317,7 +348,7 @@ async def mikrotik_scan_wireless_networks(
     # Different scan commands for different versions
     scan_cmd = f'{interface_type} scan {interface} duration={duration}'
 
-    result = await execute_mikrotik_command(scan_cmd, ctx)
+    result = await execute_mikrotik_command(scan_cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to scan wireless networks: {result}"
@@ -328,13 +359,18 @@ async def mikrotik_scan_wireless_networks(
 @mcp.tool(name="get_wireless_registration_table", annotations=annotate(READ, "Wireless Registration Table"))
 async def mikrotik_get_wireless_registration_table(
         ctx: Context,
-        interface: Optional[str] = None
+        interface: Optional[str] = None,
+        device: Optional[str] = None
 ) -> str:
-    """Gets the wireless registration table (connected clients) from the MikroTik device."""
+    """Gets the wireless registration table (connected clients) from the MikroTik device.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Getting wireless registration table for interface: {interface}")
 
     # Detect wireless interface type
-    interface_type = await mikrotik_detect_wireless_interface_type(ctx)
+    interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
 
     if not interface_type:
         return "Error: No wireless interface support detected on this device."
@@ -345,7 +381,7 @@ async def mikrotik_get_wireless_registration_table(
     if interface:
         cmd += f' where interface="{interface}"'
 
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if not result or result.strip() == "":
         return "No wireless clients registered."
@@ -354,24 +390,28 @@ async def mikrotik_get_wireless_registration_table(
 
 
 @mcp.tool(name="check_wireless_support", annotations=annotate(READ, "Check Wireless Support"))
-async def mikrotik_check_wireless_support(ctx: Context) -> str:
-    """Checks if the device supports wireless and reports the RouterOS version and wireless interface type."""
+async def mikrotik_check_wireless_support(ctx: Context, device: Optional[str] = None) -> str:
+    """Checks if the device supports wireless and reports the RouterOS version and wireless interface type.
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info("Checking wireless support")
 
     # Check RouterOS version
     version_cmd = "/system resource print"
-    version_result = await execute_mikrotik_command(version_cmd, ctx)
+    version_result = await execute_mikrotik_command(version_cmd, ctx, device=device)
 
     # Check installed packages
     package_cmd = "/system package print"
-    package_result = await execute_mikrotik_command(package_cmd, ctx)
+    package_result = await execute_mikrotik_command(package_cmd, ctx, device=device)
 
     # Check available interfaces
     interface_cmd = "/interface print"
-    interface_result = await execute_mikrotik_command(interface_cmd, ctx)
+    interface_result = await execute_mikrotik_command(interface_cmd, ctx, device=device)
 
     # Detect wireless interface type
-    wireless_type = await mikrotik_detect_wireless_interface_type(ctx)
+    wireless_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
 
     report = f"""WIRELESS SUPPORT CHECK:
 
@@ -405,72 +445,104 @@ For legacy systems:
 
 # Legacy compatibility functions (simplified versions for older RouterOS)
 @mcp.tool(name="create_wireless_security_profile", annotations=annotate(WRITE, "Create Wireless Security Profile"))
-async def mikrotik_create_wireless_security_profile(ctx: Context, name: str) -> str:
-    """Legacy function - not supported in RouterOS v7.x"""
-    interface_type = await mikrotik_detect_wireless_interface_type(ctx)
+async def mikrotik_create_wireless_security_profile(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Legacy function - not supported in RouterOS v7.x
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
+    interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
     if interface_type in ["/interface wifi", "/interface wifiwave2"]:
         return "Security profiles are not used in RouterOS v7.x. Configure security directly on the wireless interface."
     return "Legacy security profile creation not implemented in this version."
 
 
 @mcp.tool(name="list_wireless_security_profiles", annotations=annotate(READ, "List Wireless Security Profiles"))
-async def mikrotik_list_wireless_security_profiles(ctx: Context) -> str:
-    """Legacy function - not supported in RouterOS v7.x"""
-    interface_type = await mikrotik_detect_wireless_interface_type(ctx)
+async def mikrotik_list_wireless_security_profiles(ctx: Context, device: Optional[str] = None) -> str:
+    """Legacy function - not supported in RouterOS v7.x
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
+    interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
     if interface_type in ["/interface wifi", "/interface wifiwave2"]:
         return "Security profiles are not used in RouterOS v7.x. Security is configured directly on wireless interfaces."
     return "Legacy security profile listing not implemented in this version."
 
 
 @mcp.tool(name="get_wireless_security_profile", annotations=annotate(READ, "Get Wireless Security Profile"))
-async def mikrotik_get_wireless_security_profile(ctx: Context, name: str) -> str:
-    """Legacy function - not supported in RouterOS v7.x"""
-    interface_type = await mikrotik_detect_wireless_interface_type(ctx)
+async def mikrotik_get_wireless_security_profile(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Legacy function - not supported in RouterOS v7.x
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
+    interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
     if interface_type in ["/interface wifi", "/interface wifiwave2"]:
         return "Security profiles are not used in RouterOS v7.x. Check security configuration on wireless interfaces directly."
     return "Legacy security profile details not implemented in this version."
 
 
 @mcp.tool(name="remove_wireless_security_profile", annotations=annotate(DESTRUCTIVE, "Remove Wireless Security Profile"))
-async def mikrotik_remove_wireless_security_profile(ctx: Context, name: str) -> str:
-    """Legacy function - not supported in RouterOS v7.x"""
-    interface_type = await mikrotik_detect_wireless_interface_type(ctx)
+async def mikrotik_remove_wireless_security_profile(ctx: Context, name: str, device: Optional[str] = None) -> str:
+    """Legacy function - not supported in RouterOS v7.x
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
+    interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
     if interface_type in ["/interface wifi", "/interface wifiwave2"]:
         return "Security profiles are not used in RouterOS v7.x. Security is configured directly on wireless interfaces."
     return "Legacy security profile removal not implemented in this version."
 
 
 @mcp.tool(name="set_wireless_security_profile", annotations=annotate(WRITE, "Set Wireless Security Profile"))
-async def mikrotik_set_wireless_security_profile(ctx: Context, interface_name: str, security_profile: str) -> str:
-    """Legacy function - not supported in RouterOS v7.x"""
-    interface_type = await mikrotik_detect_wireless_interface_type(ctx)
+async def mikrotik_set_wireless_security_profile(ctx: Context, interface_name: str, security_profile: str, device: Optional[str] = None) -> str:
+    """Legacy function - not supported in RouterOS v7.x
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
+    interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
     if interface_type in ["/interface wifi", "/interface wifiwave2"]:
         return "Security profiles are not used in RouterOS v7.x. Configure security directly on the wireless interface."
     return "Legacy security profile setting not implemented in this version."
 
 
 @mcp.tool(name="create_wireless_access_list", annotations=annotate(WRITE, "Create Wireless Access List"))
-async def mikrotik_create_wireless_access_list(ctx: Context) -> str:
-    """Legacy function - different in RouterOS v7.x"""
-    interface_type = await mikrotik_detect_wireless_interface_type(ctx)
+async def mikrotik_create_wireless_access_list(ctx: Context, device: Optional[str] = None) -> str:
+    """Legacy function - different in RouterOS v7.x
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
+    interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
     if interface_type in ["/interface wifi", "/interface wifiwave2"]:
         return "Access lists are configured differently in RouterOS v7.x. Use firewall rules or other access control methods."
     return "Legacy access list creation not implemented in this version."
 
 
 @mcp.tool(name="list_wireless_access_list", annotations=annotate(READ, "List Wireless Access List"))
-async def mikrotik_list_wireless_access_list(ctx: Context) -> str:
-    """Legacy function - different in RouterOS v7.x"""
-    interface_type = await mikrotik_detect_wireless_interface_type(ctx)
+async def mikrotik_list_wireless_access_list(ctx: Context, device: Optional[str] = None) -> str:
+    """Legacy function - different in RouterOS v7.x
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
+    interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
     if interface_type in ["/interface wifi", "/interface wifiwave2"]:
         return "Access lists are configured differently in RouterOS v7.x. Check firewall rules or other access control configurations."
     return "Legacy access list listing not implemented in this version."
 
 
 @mcp.tool(name="remove_wireless_access_list_entry", annotations=annotate(DESTRUCTIVE, "Remove Wireless Access List Entry"))
-async def mikrotik_remove_wireless_access_list_entry(ctx: Context, entry_id: str) -> str:
-    """Legacy function - different in RouterOS v7.x"""
-    interface_type = await mikrotik_detect_wireless_interface_type(ctx)
+async def mikrotik_remove_wireless_access_list_entry(ctx: Context, entry_id: str, device: Optional[str] = None) -> str:
+    """Legacy function - different in RouterOS v7.x
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
+    interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
     if interface_type in ["/interface wifi", "/interface wifiwave2"]:
         return "Access lists are configured differently in RouterOS v7.x."
     return "Legacy access list removal not implemented in this version."
@@ -484,19 +556,24 @@ async def mikrotik_update_wireless_interface(
         ssid: Optional[str] = None,
         disabled: Optional[bool] = None,
         comment: Optional[str] = None,
+        device: Optional[str] = None,
 ) -> str:
-    """Updates an existing wireless interface's settings (name, SSID, enabled state, etc.)."""
+    """Updates an existing wireless interface's settings (name, SSID, enabled state, etc.).
+
+    Notes:
+        device: Device title from the inventory; omit when only one device is configured.
+    """
     await ctx.info(f"Updating wireless interface: name={name}")
 
     # Detect wireless interface type
-    interface_type = await mikrotik_detect_wireless_interface_type(ctx)
+    interface_type = await mikrotik_detect_wireless_interface_type(ctx, device=device)
 
     if not interface_type:
         return "Error: No wireless interface support detected on this device."
 
     # Check if interface exists
     check_cmd = f'{interface_type} print count-only where name="{name}"'
-    count = await execute_mikrotik_command(check_cmd, ctx)
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
 
     if count.strip() == "0":
         return f"Wireless interface '{name}' not found."
@@ -517,7 +594,7 @@ async def mikrotik_update_wireless_interface(
         return "No updates specified."
 
     cmd = f'{interface_type} set [find name="{name}"] {" ".join(updates)}'
-    result = await execute_mikrotik_command(cmd, ctx)
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
 
     if "failure:" in result.lower() or "error" in result.lower():
         return f"Failed to update wireless interface: {result}"
@@ -525,6 +602,6 @@ async def mikrotik_update_wireless_interface(
     # Get updated details
     target_name = new_name or name
     details_cmd = f'{interface_type} print detail where name="{target_name}"'
-    details = await execute_mikrotik_command(details_cmd, ctx)
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
 
     return f"Wireless interface updated successfully:\n\n{details}"

--- a/src/mcp_mikrotik/server.py
+++ b/src/mcp_mikrotik/server.py
@@ -3,10 +3,28 @@ import os
 import sys
 
 from mcp.server.transport_security import TransportSecuritySettings
+from pydantic import ValidationError
 
-from mcp_mikrotik import config
-from mcp_mikrotik.app import mcp
-from mcp_mikrotik.config import McpServerSettings, MikrotikConfig
+
+def _config_error_message(exc: ValidationError) -> str:
+    """One readable line per problem, without echoing any input values."""
+    problems = "; ".join(
+        f"{'.'.join(str(p) for p in err['loc']) or 'config'}: {err['msg']}"
+        for err in exc.errors()
+    )
+    return f"Invalid MikroTik configuration: {problems}"
+
+
+# An inline MIKROTIK_INVENTORY is parsed the moment MikrotikConfig is built,
+# which happens at import — so a broken one must be caught here to die with
+# one clear message rather than a raw traceback.
+try:
+    from mcp_mikrotik import config
+    from mcp_mikrotik.app import mcp
+    from mcp_mikrotik.config import McpServerSettings, MikrotikConfig
+except ValidationError as _exc:
+    print(_config_error_message(_exc), file=sys.stderr)
+    sys.exit(1)
 
 _LOCALHOST_HOSTS = ("127.0.0.1", "localhost", "::1")
 
@@ -89,9 +107,13 @@ def main():
     """
     Entry point for the MCP MikroTik server when run as a command-line program.
     """
-    config.mikrotik_config = MikrotikConfig(_cli_parse_args=True)
-
     logger = logging.getLogger(__name__)
+
+    try:
+        config.mikrotik_config = MikrotikConfig(_cli_parse_args=True)
+    except ValidationError as e:
+        logger.error(_config_error_message(e))
+        sys.exit(1)
 
     logger.info("Starting MCP MikroTik server")
 

--- a/src/mcp_mikrotik/server.py
+++ b/src/mcp_mikrotik/server.py
@@ -94,10 +94,20 @@ def main():
     logger = logging.getLogger(__name__)
 
     logger.info("Starting MCP MikroTik server")
-    logger.info(f"Using host: {config.mikrotik_config.host}")
-    logger.info(f"Using username: {config.mikrotik_config.username}")
-    if config.mikrotik_config.key_filename:
-        logger.info(f"Using key from: {config.mikrotik_config.key_filename}")
+
+    # Build the inventory now rather than at the first tool call, so a broken
+    # inventory (unreadable file, bad YAML, invalid entry) stops the server at
+    # startup with one clear message instead of failing every tool call later.
+    # No connections are opened here — those stay lazy, per command.
+    from mcp_mikrotik.inventory import get_inventory, reset_inventory
+
+    reset_inventory()
+    try:
+        inventory = get_inventory()
+    except ValueError as e:
+        logger.error(f"Invalid MikroTik inventory: {e}")
+        sys.exit(1)
+    logger.info(f"Managing {len(inventory)} device(s): {', '.join(inventory.titles)}")
 
     _warn_if_plaintext_password_in_container(config.mikrotik_config, logger)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,9 +36,11 @@ class FakeExecutor:
 
     def __init__(self):
         self.commands: list[str] = []
+        self.devices: list[Any] = []
 
-    async def __call__(self, command: str, _ctx: Any) -> str:
+    async def __call__(self, command: str, _ctx: Any, device: Any = None) -> str:
         self.commands.append(command)
+        self.devices.append(device)
 
         cmd = command.lower()
         if "count-only" in cmd:

--- a/tests/smoke_multi_device.py
+++ b/tests/smoke_multi_device.py
@@ -6,6 +6,10 @@ lands on the device named by the `device` argument.
 
     docker-compose -f routeros-docker/docker-compose.yml up -d
     python tests/smoke_multi_device.py
+
+Every check is self-establishing: nothing here depends on state left behind by
+earlier runs (fresh containers boot with default identities, and RouterOS may
+rename NICs across container recreations, so neither can be assumed).
 """
 
 import asyncio
@@ -13,6 +17,7 @@ import json
 import os
 import re
 import sys
+import tempfile
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(REPO, "src"))
@@ -21,14 +26,23 @@ from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
 # Matches the compose file: routeros-a -> 2222, routeros-b -> 2223
-INVENTORY = [
-    {"title": "RouterA", "host": "127.0.0.1", "port": 2222,
-     "username": "admin", "password": os.environ.get("ROUTEROS_PASS", ""),
-     "tags": ["lab", "primary"], "region": "NL"},
-    {"title": "RouterB", "host": "127.0.0.1", "port": 2223,
-     "username": "admin", "password": os.environ.get("ROUTEROS_PASS", ""),
-     "tags": ["lab", "secondary"], "region": "DE"},
-]
+PASSWORD = os.environ.get("ROUTEROS_PASS", "")
+INVENTORY_YAML = f"""\
+- title: RouterA
+  host: 127.0.0.1
+  port: 2222
+  username: admin
+  password: "{PASSWORD}"
+  tags: [lab, primary]
+  region: NL
+- title: RouterB
+  host: 127.0.0.1
+  port: 2223
+  username: admin
+  password: "{PASSWORD}"
+  tags: [lab, secondary]
+  region: DE
+"""
 
 results = []
 
@@ -40,10 +54,11 @@ def check(label, ok, detail=""):
         print("        " + str(detail).replace("\n", " ")[:160])
 
 
-def env():
+def env(inventory_file):
     e = dict(os.environ)
+    e.pop("MIKROTIK_INVENTORY", None)
     e.update({
-        "MIKROTIK_INVENTORY": json.dumps(INVENTORY),
+        "MIKROTIK_INVENTORY_FILE": inventory_file,
         "MIKROTIK_MCP__TRANSPORT": "stdio",
         "PYTHONPATH": os.path.join(REPO, "src"),
     })
@@ -54,101 +69,125 @@ def txt(res):
     return "\n".join(getattr(c, "text", "") for c in res.content)
 
 
-def ether2_mac(output):
-    """Pull ether2's MAC from a list_interfaces response.
-
-    Each container generates its own ether2 MAC, so the MAC in a response
-    identifies which router actually produced it.
-    """
-    m = re.search(r"ether2\s+\S+\s+\d+\s+([0-9A-Fa-f:]{17})", output)
-    return m.group(1) if m else ""
+def macs(list_interfaces_output):
+    """Map interface name -> MAC from a list_interfaces response."""
+    return dict(re.findall(
+        r"(\S+)\s+\S+\s+\d+\s+([0-9A-Fa-f:]{17})", list_interfaces_output
+    ))
 
 
 async def main():
-    params = StdioServerParameters(
-        command=sys.executable, args=["-m", "mcp_mikrotik.server"], env=env(), cwd=REPO
-    )
-    async with stdio_client(params) as (read, write):
-        async with ClientSession(read, write) as s:
-            await s.initialize()
+    with tempfile.TemporaryDirectory() as tmp:
+        inv_path = os.path.join(tmp, "inventory.yaml")
+        with open(inv_path, "w", encoding="utf-8") as fh:
+            fh.write(INVENTORY_YAML)
 
-            tools = (await s.list_tools()).tools
-            names = [t.name for t in tools]
-            check(f"server exposes {len(tools)} tools incl. list_devices",
-                  "list_devices" in names)
+        params = StdioServerParameters(
+            command=sys.executable, args=["-m", "mcp_mikrotik.server"],
+            env=env(inv_path), cwd=REPO,
+        )
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(read, write) as s:
+                await s.initialize()
 
-            # every device-scoped tool advertises the device argument
-            sample = [t for t in tools if t.name == "list_interfaces"][0]
-            check("tools advertise a `device` argument",
-                  "device" in (sample.input_schema.get("properties") or {}))
+                tools = (await s.list_tools()).tools
+                names = [t.name for t in tools]
+                check(f"server exposes {len(tools)} tools incl. list_devices",
+                      "list_devices" in names)
 
-            # ── Tool D ────────────────────────────────────────────────────
-            out = txt(await s.call_tool("list_devices", {}))
-            check("list_devices shows both devices",
-                  "RouterA" in out and "RouterB" in out, out)
-            check("list_devices leaks no credentials",
-                  "password" not in out.lower(), out)
+                sample = [t for t in tools if t.name == "list_interfaces"][0]
+                check("tools advertise a `device` argument",
+                      "device" in (sample.input_schema.get("properties") or {}))
 
-            # ── Targeting ─────────────────────────────────────────────────
-            a = txt(await s.call_tool("list_interfaces", {"device": "RouterA"}))
-            check("command routed to RouterA", "Failed to connect" not in a and "Error" not in a[:20], a)
+                # ── Tool D (inventory loaded from the YAML file) ──────────
+                out = txt(await s.call_tool("list_devices", {}))
+                check("YAML inventory loaded: list_devices shows both devices",
+                      "RouterA" in out and "RouterB" in out, out)
+                check("list_devices leaks no credentials",
+                      "password" not in out.lower(), out)
 
-            b = txt(await s.call_tool("list_interfaces", {"device": "RouterB"}))
-            check("command routed to RouterB", "Failed to connect" not in b and "Error" not in b[:20], b)
+                # ── Fingerprint the two boxes ─────────────────────────────
+                a = txt(await s.call_tool("list_interfaces", {"device": "RouterA"}))
+                b = txt(await s.call_tool("list_interfaces", {"device": "RouterB"}))
+                check("command routed to RouterA", "Error" not in a[:20], a)
+                check("command routed to RouterB", "Error" not in b[:20], b)
 
-            # Decisive proof: each router carries a distinct system identity, so
-            # exporting it shows which box actually executed the command.
-            ia = txt(await s.call_tool("export_section",
-                                       {"device": "RouterA", "section": "system identity"}))
-            ib = txt(await s.call_tool("export_section",
-                                       {"device": "RouterB", "section": "system identity"}))
-            check("RouterA reports its own identity", "RouterA-NL" in ia, ia)
-            check("RouterB reports its own identity", "RouterB-DE" in ib, ib)
-            check("the two devices are genuinely different hosts",
-                  "RouterB-DE" not in ia and "RouterA-NL" not in ib)
+                macs_a, macs_b = macs(a), macs(b)
+                distinct = sorted(
+                    n for n in macs_a.keys() & macs_b.keys()
+                    if macs_a[n] != macs_b[n]
+                )
+                check("routers expose an interface with distinct MACs (fingerprint)",
+                      bool(distinct),
+                      f"A={macs_a} B={macs_b}")
+                fp = distinct[0] if distinct else None
+                parent_a = sorted(n for n in macs_a if n.startswith("ether"))[-1]
+                parent_b = sorted(n for n in macs_b if n.startswith("ether"))[-1]
 
-            # ── Selection rules ───────────────────────────────────────────
-            out = txt(await s.call_tool("list_interfaces", {}))
-            check("omitting device with >1 device errors and lists choices",
-                  "RouterA" in out and "RouterB" in out and "Error" in out, out)
+                # ── Write isolation: a VLAN per router, then cross-check ──
+                out = txt(await s.call_tool("create_vlan_interface", {
+                    "device": "RouterA", "name": "smoke-vlan-a", "vlan_id": 210,
+                    "interface": parent_a, "comment": "smoke test"}))
+                check("VLAN created on RouterA", "successfully" in out, out)
+                out = txt(await s.call_tool("create_vlan_interface", {
+                    "device": "RouterB", "name": "smoke-vlan-b", "vlan_id": 220,
+                    "interface": parent_b, "comment": "smoke test"}))
+                check("VLAN created on RouterB", "successfully" in out, out)
 
-            out = txt(await s.call_tool("list_interfaces", {"device": "Ghost"}))
-            check("unknown device errors and lists choices",
-                  "Unknown device" in out and "RouterA" in out, out)
+                va = txt(await s.call_tool("list_vlan_interfaces", {"device": "RouterA"}))
+                vb = txt(await s.call_tool("list_vlan_interfaces", {"device": "RouterB"}))
+                check("RouterA has only its own VLAN",
+                      "smoke-vlan-a" in va and "smoke-vlan-b" not in va, va)
+                check("RouterB has only its own VLAN",
+                      "smoke-vlan-b" in vb and "smoke-vlan-a" not in vb, vb)
 
-            out = txt(await s.call_tool("list_interfaces", {"device": "routera"}))
-            check("device matching is case-insensitive", "Failed to connect" not in out, out)
+                # ── Selection rules ───────────────────────────────────────
+                out = txt(await s.call_tool("list_interfaces", {}))
+                check("omitting device with >1 device errors and lists choices",
+                      "RouterA" in out and "RouterB" in out and "Error" in out, out)
 
-            # ── Session isolation ─────────────────────────────────────────
-            mac_a = ether2_mac(a)
-            mac_b = ether2_mac(b)
-            check("the routers have distinct ether2 MACs (usable as a fingerprint)",
-                  bool(mac_a) and bool(mac_b) and mac_a != mac_b,
-                  f"A={mac_a} B={mac_b}")
+                out = txt(await s.call_tool("list_interfaces", {"device": "Ghost"}))
+                check("unknown device errors and lists choices",
+                      "Unknown device" in out and "RouterA" in out, out)
 
-            # Fire interleaved calls at both routers at once.  These run in
-            # parallel threads sharing the inventory, so a pooled or shared
-            # SSH client would surface here as cross-talk between devices or
-            # as a session dropped out from under a running command.
-            targets = ["RouterA", "RouterB"] * 6
-            outs = [txt(o) for o in await asyncio.gather(
-                *[s.call_tool("list_interfaces", {"device": d}) for d in targets]
-            )]
-            got = [ether2_mac(o) for o in outs]
-            want = [mac_a if d == "RouterA" else mac_b for d in targets]
+                out = txt(await s.call_tool("list_interfaces", {"device": "routera"}))
+                check("device matching is case-insensitive",
+                      "Error" not in out[:20], out)
 
-            check(f"{len(targets)} concurrent calls each reached the right router",
-                  got == want, f"want {want[:4]}... got {got[:4]}...")
-            check("no concurrent call errored",
-                  not any("Error" in o for o in outs),
-                  next((o for o in outs if "Error" in o), ""))
+                # ── Concurrency: interleaved calls must not cross-talk ────
+                if fp:
+                    targets = ["RouterA", "RouterB"] * 6
+                    outs = [txt(o) for o in await asyncio.gather(
+                        *[s.call_tool("list_interfaces", {"device": d})
+                          for d in targets]
+                    )]
+                    got = [macs(o).get(fp) for o in outs]
+                    want = [macs_a[fp] if d == "RouterA" else macs_b[fp]
+                            for d in targets]
+                    check(f"{len(targets)} concurrent calls each reached the right router",
+                          got == want, f"want {want[:4]}... got {got[:4]}...")
+                    check("no concurrent call errored",
+                          not any("Error" in o for o in outs),
+                          next((o for o in outs if "Error" in o), ""))
 
-            # Connection churn must not exhaust the router's session limit.
-            serial = [txt(await s.call_tool("list_interfaces", {"device": "RouterA"}))
-                      for _ in range(10)]
-            check("10 back-to-back commands all succeed (no session exhaustion)",
-                  all(ether2_mac(o) == mac_a for o in serial),
-                  next((o for o in serial if ether2_mac(o) != mac_a), ""))
+                    serial = [txt(await s.call_tool(
+                        "list_interfaces", {"device": "RouterA"}))
+                        for _ in range(10)]
+                    check("10 back-to-back commands all succeed (no session exhaustion)",
+                          all(macs(o).get(fp) == macs_a[fp] for o in serial),
+                          next((o for o in serial if macs(o).get(fp) != macs_a[fp]), ""))
+
+                # ── Cleanup (also exercises remove + routing) ─────────────
+                out = txt(await s.call_tool("remove_vlan_interface",
+                                            {"device": "RouterA", "name": "smoke-vlan-a"}))
+                check("VLAN removed from RouterA", "successfully" in out, out)
+                out = txt(await s.call_tool("remove_vlan_interface",
+                                            {"device": "RouterB", "name": "smoke-vlan-b"}))
+                check("VLAN removed from RouterB", "successfully" in out, out)
+                va = txt(await s.call_tool("list_vlan_interfaces", {"device": "RouterA"}))
+                vb = txt(await s.call_tool("list_vlan_interfaces", {"device": "RouterB"}))
+                check("both routers back to baseline",
+                      "smoke-vlan" not in va and "smoke-vlan" not in vb)
 
     print()
     passed = sum(1 for _, ok in results if ok)

--- a/tests/smoke_multi_device.py
+++ b/tests/smoke_multi_device.py
@@ -11,6 +11,7 @@ lands on the device named by the `device` argument.
 import asyncio
 import json
 import os
+import re
 import sys
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -51,6 +52,16 @@ def env():
 
 def txt(res):
     return "\n".join(getattr(c, "text", "") for c in res.content)
+
+
+def ether2_mac(output):
+    """Pull ether2's MAC from a list_interfaces response.
+
+    Each container generates its own ether2 MAC, so the MAC in a response
+    identifies which router actually produced it.
+    """
+    m = re.search(r"ether2\s+\S+\s+\d+\s+([0-9A-Fa-f:]{17})", output)
+    return m.group(1) if m else ""
 
 
 async def main():
@@ -107,6 +118,37 @@ async def main():
 
             out = txt(await s.call_tool("list_interfaces", {"device": "routera"}))
             check("device matching is case-insensitive", "Failed to connect" not in out, out)
+
+            # ── Session isolation ─────────────────────────────────────────
+            mac_a = ether2_mac(a)
+            mac_b = ether2_mac(b)
+            check("the routers have distinct ether2 MACs (usable as a fingerprint)",
+                  bool(mac_a) and bool(mac_b) and mac_a != mac_b,
+                  f"A={mac_a} B={mac_b}")
+
+            # Fire interleaved calls at both routers at once.  These run in
+            # parallel threads sharing the inventory, so a pooled or shared
+            # SSH client would surface here as cross-talk between devices or
+            # as a session dropped out from under a running command.
+            targets = ["RouterA", "RouterB"] * 6
+            outs = [txt(o) for o in await asyncio.gather(
+                *[s.call_tool("list_interfaces", {"device": d}) for d in targets]
+            )]
+            got = [ether2_mac(o) for o in outs]
+            want = [mac_a if d == "RouterA" else mac_b for d in targets]
+
+            check(f"{len(targets)} concurrent calls each reached the right router",
+                  got == want, f"want {want[:4]}... got {got[:4]}...")
+            check("no concurrent call errored",
+                  not any("Error" in o for o in outs),
+                  next((o for o in outs if "Error" in o), ""))
+
+            # Connection churn must not exhaust the router's session limit.
+            serial = [txt(await s.call_tool("list_interfaces", {"device": "RouterA"}))
+                      for _ in range(10)]
+            check("10 back-to-back commands all succeed (no session exhaustion)",
+                  all(ether2_mac(o) == mac_a for o in serial),
+                  next((o for o in serial if ether2_mac(o) != mac_a), ""))
 
     print()
     passed = sum(1 for _, ok in results if ok)

--- a/tests/smoke_multi_device.py
+++ b/tests/smoke_multi_device.py
@@ -25,24 +25,30 @@ sys.path.insert(0, os.path.join(REPO, "src"))
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
-# Matches the compose file: routeros-a -> 2222, routeros-b -> 2223
+# Matches the compose file: routeros-a -> 2222, routeros-b -> 2223.
+#
+# No password is ever written to disk (CodeQL: clear-text storage). The
+# default lab password is empty, which is also DeviceConfig's default, so the
+# file simply omits the field. A non-empty ROUTEROS_PASS is delivered through
+# the inline MIKROTIK_INVENTORY environment variable instead of the file.
 PASSWORD = os.environ.get("ROUTEROS_PASS", "")
-INVENTORY_YAML = f"""\
-- title: RouterA
-  host: 127.0.0.1
-  port: 2222
-  username: admin
-  password: "{PASSWORD}"
-  tags: [lab, primary]
-  region: NL
-- title: RouterB
-  host: 127.0.0.1
-  port: 2223
-  username: admin
-  password: "{PASSWORD}"
-  tags: [lab, secondary]
-  region: DE
-"""
+
+DEVICES = [
+    {"title": "RouterA", "host": "127.0.0.1", "port": 2222, "username": "admin",
+     "tags": ["lab", "primary"], "region": "NL"},
+    {"title": "RouterB", "host": "127.0.0.1", "port": 2223, "username": "admin",
+     "tags": ["lab", "secondary"], "region": "DE"},
+]
+
+INVENTORY_YAML = "".join(
+    f"- title: {d['title']}\n"
+    f"  host: {d['host']}\n"
+    f"  port: {d['port']}\n"
+    f"  username: {d['username']}\n"
+    f"  tags: [{', '.join(d['tags'])}]\n"
+    f"  region: {d['region']}\n"
+    for d in DEVICES
+)
 
 results = []
 
@@ -62,6 +68,12 @@ def env(inventory_file):
         "MIKROTIK_MCP__TRANSPORT": "stdio",
         "PYTHONPATH": os.path.join(REPO, "src"),
     })
+    if PASSWORD:
+        # Inline inventory wins over the file, so a real password rides the
+        # environment (never the filesystem).
+        e["MIKROTIK_INVENTORY"] = json.dumps(
+            [{**d, "password": PASSWORD} for d in DEVICES]
+        )
     return e
 
 

--- a/tests/smoke_multi_device.py
+++ b/tests/smoke_multi_device.py
@@ -79,18 +79,22 @@ async def main():
                   "password" not in out.lower(), out)
 
             # ── Targeting ─────────────────────────────────────────────────
-            a = txt(await s.call_tool("get_system_identity", {"device": "RouterA"})) \
-                if "get_system_identity" in names else \
-                txt(await s.call_tool("list_interfaces", {"device": "RouterA"}))
+            a = txt(await s.call_tool("list_interfaces", {"device": "RouterA"}))
             check("command routed to RouterA", "Failed to connect" not in a and "Error" not in a[:20], a)
 
             b = txt(await s.call_tool("list_interfaces", {"device": "RouterB"}))
             check("command routed to RouterB", "Failed to connect" not in b and "Error" not in b[:20], b)
 
-            # The two routers must not return the same interface set by accident;
-            # a differing MAC address proves the calls hit different devices.
-            check("RouterA and RouterB return different device output", a != b,
-                  f"A[:60]={a[:60]!r} B[:60]={b[:60]!r}")
+            # Decisive proof: each router carries a distinct system identity, so
+            # exporting it shows which box actually executed the command.
+            ia = txt(await s.call_tool("export_section",
+                                       {"device": "RouterA", "section": "system identity"}))
+            ib = txt(await s.call_tool("export_section",
+                                       {"device": "RouterB", "section": "system identity"}))
+            check("RouterA reports its own identity", "RouterA-NL" in ia, ia)
+            check("RouterB reports its own identity", "RouterB-DE" in ib, ib)
+            check("the two devices are genuinely different hosts",
+                  "RouterB-DE" not in ia and "RouterA-NL" not in ib)
 
             # ── Selection rules ───────────────────────────────────────────
             out = txt(await s.call_tool("list_interfaces", {}))

--- a/tests/smoke_multi_device.py
+++ b/tests/smoke_multi_device.py
@@ -1,0 +1,116 @@
+"""Multi-device smoke test (issue #44).
+
+Drives the MCP server over the real stdio protocol against the two RouterOS
+containers from routeros-docker/docker-compose.yml and proves that a tool call
+lands on the device named by the `device` argument.
+
+    docker-compose -f routeros-docker/docker-compose.yml up -d
+    python tests/smoke_multi_device.py
+"""
+
+import asyncio
+import json
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(REPO, "src"))
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+# Matches the compose file: routeros-a -> 2222, routeros-b -> 2223
+INVENTORY = [
+    {"title": "RouterA", "host": "127.0.0.1", "port": 2222,
+     "username": "admin", "password": os.environ.get("ROUTEROS_PASS", ""),
+     "tags": ["lab", "primary"], "region": "NL"},
+    {"title": "RouterB", "host": "127.0.0.1", "port": 2223,
+     "username": "admin", "password": os.environ.get("ROUTEROS_PASS", ""),
+     "tags": ["lab", "secondary"], "region": "DE"},
+]
+
+results = []
+
+
+def check(label, ok, detail=""):
+    results.append((label, ok))
+    print(f"[{'PASS' if ok else 'FAIL'}] {label}")
+    if detail:
+        print("        " + str(detail).replace("\n", " ")[:160])
+
+
+def env():
+    e = dict(os.environ)
+    e.update({
+        "MIKROTIK_INVENTORY": json.dumps(INVENTORY),
+        "MIKROTIK_MCP__TRANSPORT": "stdio",
+        "PYTHONPATH": os.path.join(REPO, "src"),
+    })
+    return e
+
+
+def txt(res):
+    return "\n".join(getattr(c, "text", "") for c in res.content)
+
+
+async def main():
+    params = StdioServerParameters(
+        command=sys.executable, args=["-m", "mcp_mikrotik.server"], env=env(), cwd=REPO
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as s:
+            await s.initialize()
+
+            tools = (await s.list_tools()).tools
+            names = [t.name for t in tools]
+            check(f"server exposes {len(tools)} tools incl. list_devices",
+                  "list_devices" in names)
+
+            # every device-scoped tool advertises the device argument
+            sample = [t for t in tools if t.name == "list_interfaces"][0]
+            check("tools advertise a `device` argument",
+                  "device" in (sample.input_schema.get("properties") or {}))
+
+            # ── Tool D ────────────────────────────────────────────────────
+            out = txt(await s.call_tool("list_devices", {}))
+            check("list_devices shows both devices",
+                  "RouterA" in out and "RouterB" in out, out)
+            check("list_devices leaks no credentials",
+                  "password" not in out.lower(), out)
+
+            # ── Targeting ─────────────────────────────────────────────────
+            a = txt(await s.call_tool("get_system_identity", {"device": "RouterA"})) \
+                if "get_system_identity" in names else \
+                txt(await s.call_tool("list_interfaces", {"device": "RouterA"}))
+            check("command routed to RouterA", "Failed to connect" not in a and "Error" not in a[:20], a)
+
+            b = txt(await s.call_tool("list_interfaces", {"device": "RouterB"}))
+            check("command routed to RouterB", "Failed to connect" not in b and "Error" not in b[:20], b)
+
+            # The two routers must not return the same interface set by accident;
+            # a differing MAC address proves the calls hit different devices.
+            check("RouterA and RouterB return different device output", a != b,
+                  f"A[:60]={a[:60]!r} B[:60]={b[:60]!r}")
+
+            # ── Selection rules ───────────────────────────────────────────
+            out = txt(await s.call_tool("list_interfaces", {}))
+            check("omitting device with >1 device errors and lists choices",
+                  "RouterA" in out and "RouterB" in out and "Error" in out, out)
+
+            out = txt(await s.call_tool("list_interfaces", {"device": "Ghost"}))
+            check("unknown device errors and lists choices",
+                  "Unknown device" in out and "RouterA" in out, out)
+
+            out = txt(await s.call_tool("list_interfaces", {"device": "routera"}))
+            check("device matching is case-insensitive", "Failed to connect" not in out, out)
+
+    print()
+    passed = sum(1 for _, ok in results if ok)
+    print(f"RESULT: {passed}/{len(results)} smoke checks passed")
+    if passed != len(results):
+        print("FAILED:", [l for l, ok in results if not ok])
+    return 0 if passed == len(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -9,3 +9,37 @@ def test_health_check_returns_ok():
     assert resp.body == b"OK"
     assert resp.media_type == "text/plain"
 
+
+def test_device_guidance_lives_in_server_instructions_not_every_tool():
+    """The `device` argument is explained once, at initialize.
+
+    Repeating it in each tool description put the same sentence in front of
+    the model ~173 times, for no extra information.
+    """
+    from mcp_mikrotik.app import mcp
+
+    instructions = mcp.instructions or ""
+    assert "device" in instructions
+    assert "list_devices" in instructions
+
+    tools = asyncio.run(mcp.list_tools())
+    repeated = [
+        t.name for t in tools
+        if "title of the target device" in (t.description or "")
+        or "Device title from the inventory" in (t.description or "")
+    ]
+    assert repeated == [], f"device guidance duplicated into tool descriptions: {repeated}"
+
+
+def test_every_tool_still_accepts_a_device_argument():
+    """Dropping the prose must not drop the parameter."""
+    from mcp_mikrotik.app import mcp
+
+    tools = asyncio.run(mcp.list_tools())
+    missing = [
+        t.name for t in tools
+        if t.name != "list_devices"
+        and "device" not in (t.input_schema.get("properties") or {})
+    ]
+    assert missing == []
+

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -76,8 +76,12 @@ class FakeInventory:
 
 def _patch_inventory(monkeypatch, inv):
     from mcp_mikrotik import connector
+    from mcp_mikrotik import inventory as inv_mod
 
     monkeypatch.setattr(connector, "get_inventory", lambda: inv)
+    # The safe-mode manager resolves through the module-level inventory when
+    # the connector checks for an active session — keep both views consistent.
+    monkeypatch.setattr(inv_mod, "get_inventory", lambda: inv)
     return connector
 
 

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -1,6 +1,7 @@
 """Connector tests for the inventory-backed (multi-device) execution path."""
 
 import asyncio
+from contextlib import contextmanager
 
 import pytest
 
@@ -33,10 +34,17 @@ class DummyClient:
 
 
 class FakeInventory:
-    """Minimal inventory double: resolves titles and hands back clients."""
+    """Minimal inventory double: resolves titles and hands out connections.
+
+    Each device keeps one ``DummyClient`` so assertions can see the commands
+    that reached it, while ``opened``/``closed`` record the connection
+    lifecycle the connector drives.
+    """
 
     def __init__(self, clients: dict):
         self._clients = clients
+        self.opened: list = []
+        self.closed: list = []
         self._devices = {
             t.casefold(): DeviceConfig(title=t, host=f"10.0.0.{i + 1}")
             for i, t in enumerate(clients)
@@ -52,8 +60,18 @@ class FakeInventory:
             raise DeviceNotFoundError(f"Unknown device {title!r}.")
         return dev
 
-    def get_client(self, title=None):
-        return self._clients[self.resolve(title).title]
+    def connect(self, title=None):
+        client = self._clients[self.resolve(title).title]
+        self.opened.append(client)
+        return client
+
+    @contextmanager
+    def session(self, title=None):
+        client = self.connect(title)
+        try:
+            yield client
+        finally:
+            self.closed.append(client)
 
 
 def _patch_inventory(monkeypatch, inv):
@@ -87,6 +105,45 @@ def test_execute_sync_unknown_device_raises(monkeypatch):
     connector = _patch_inventory(monkeypatch, FakeInventory({"RouterA": DummyClient()}))
     with pytest.raises(DeviceNotFoundError):
         connector._execute_sync("/x", device="Nope")
+
+
+# ---------------------------------------------------------------------------
+# Connection lifecycle — one connection per command, never shared
+# ---------------------------------------------------------------------------
+
+def test_each_execution_opens_and_closes_its_own_connection(monkeypatch):
+    """Two commands must not ride on one shared client."""
+    inv = FakeInventory({"OnlyOne": DummyClient()})
+    connector = _patch_inventory(monkeypatch, inv)
+
+    connector._execute_sync("/one")
+    connector._execute_sync("/two")
+
+    assert len(inv.opened) == 2
+    assert len(inv.closed) == 2
+
+
+def test_connection_is_closed_when_the_command_fails(monkeypatch):
+    """A failing command must not leak an SSH session on the router."""
+    boom = DummyClient(raises=RuntimeError("boom"))
+    inv = FakeInventory({"OnlyOne": boom})
+    connector = _patch_inventory(monkeypatch, inv)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        connector._execute_sync("/bad")
+
+    assert inv.closed == [boom]
+
+
+def test_file_transfers_close_their_connection(monkeypatch):
+    inv = FakeInventory({"OnlyOne": DummyClient()})
+    connector = _patch_inventory(monkeypatch, inv)
+
+    connector.download_file_sync("backup_1.backup")
+    connector.upload_file_sync("restore.rsc", b"bytes")
+
+    assert len(inv.opened) == 2
+    assert len(inv.closed) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -1,165 +1,154 @@
+"""Connector tests for the inventory-backed (multi-device) execution path."""
+
 import asyncio
 
 import pytest
 
+from mcp_mikrotik.config import DeviceConfig
+from mcp_mikrotik.inventory import DeviceNotFoundError, Inventory
 
-def test_execute_sync_success(monkeypatch):
+
+class DummyClient:
+    """Stand-in for MikroTikSSHClient."""
+
+    def __init__(self, output="identity", raises=None):
+        self.output = output
+        self.raises = raises
+        self.commands = []
+        self.uploaded = None
+        self.downloaded = None
+
+    def execute_command(self, command: str) -> str:
+        self.commands.append(command)
+        if self.raises:
+            raise self.raises
+        return self.output
+
+    def download_file(self, filename: str) -> bytes:
+        self.downloaded = filename
+        return b"\x00binary"
+
+    def upload_file(self, filename: str, data: bytes) -> None:
+        self.uploaded = (filename, data)
+
+
+class FakeInventory:
+    """Minimal inventory double: resolves titles and hands back clients."""
+
+    def __init__(self, clients: dict):
+        self._clients = clients
+        self._devices = {
+            t.casefold(): DeviceConfig(title=t, host=f"10.0.0.{i + 1}")
+            for i, t in enumerate(clients)
+        }
+
+    def resolve(self, title=None):
+        if title is None:
+            if len(self._devices) == 1:
+                return next(iter(self._devices.values()))
+            raise DeviceNotFoundError("multiple devices; specify one")
+        dev = self._devices.get(str(title).casefold())
+        if dev is None:
+            raise DeviceNotFoundError(f"Unknown device {title!r}.")
+        return dev
+
+    def get_client(self, title=None):
+        return self._clients[self.resolve(title).title]
+
+
+def _patch_inventory(monkeypatch, inv):
     from mcp_mikrotik import connector
 
-    disconnected = {"called": 0}
-
-    class DummyClient:
-        def __init__(self, **kwargs):
-            self.kwargs = kwargs
-
-        def connect(self):
-            return True
-
-        def execute_command(self, command: str) -> str:
-            assert command == "/system identity print"
-            return "identity"
-
-        def disconnect(self):
-            disconnected["called"] += 1
-
-    monkeypatch.setattr(connector, "MikroTikSSHClient", lambda **kw: DummyClient(**kw))
-    result = connector._execute_sync("/system identity print")
-    assert result == "identity"
-    assert disconnected["called"] == 1
+    monkeypatch.setattr(connector, "get_inventory", lambda: inv)
+    return connector
 
 
-def test_execute_sync_connect_failure(monkeypatch):
-    from mcp_mikrotik import connector
+# ---------------------------------------------------------------------------
+# _execute_sync
+# ---------------------------------------------------------------------------
 
-    disconnected = {"called": 0}
+def test_execute_sync_uses_single_device_when_unspecified(monkeypatch):
+    client = DummyClient()
+    connector = _patch_inventory(monkeypatch, FakeInventory({"OnlyOne": client}))
 
-    class DummyClient:
-        def connect(self):
-            return False
-
-        def disconnect(self):
-            disconnected["called"] += 1
-
-    monkeypatch.setattr(connector, "MikroTikSSHClient", lambda **kw: DummyClient())
-    result = connector._execute_sync("/system identity print")
-    assert result.startswith("Error: Failed to connect")
-    assert disconnected["called"] == 1
+    assert connector._execute_sync("/system identity print") == "identity"
+    assert client.commands == ["/system identity print"]
 
 
-def test_execute_sync_exception(monkeypatch):
-    from mcp_mikrotik import connector
+def test_execute_sync_routes_to_named_device(monkeypatch):
+    a, b = DummyClient("from-A"), DummyClient("from-B")
+    connector = _patch_inventory(monkeypatch, FakeInventory({"RouterA": a, "RouterB": b}))
 
-    disconnected = {"called": 0}
-
-    class DummyClient:
-        def connect(self):
-            return True
-
-        def execute_command(self, command: str) -> str:
-            raise RuntimeError("boom")
-
-        def disconnect(self):
-            disconnected["called"] += 1
-
-    monkeypatch.setattr(connector, "MikroTikSSHClient", lambda **kw: DummyClient())
-    result = connector._execute_sync("/system identity print")
-    assert result.startswith("Error executing command: boom")
-    assert disconnected["called"] == 1
+    assert connector._execute_sync("/x", device="RouterB") == "from-B"
+    assert b.commands == ["/x"] and a.commands == []
 
 
-def test_download_file_sync_success(monkeypatch):
-    from mcp_mikrotik import connector
-
-    disconnected = {"called": 0}
-
-    class DummyClient:
-        def __init__(self, **kwargs):
-            self.kwargs = kwargs
-
-        def connect(self):
-            return True
-
-        def download_file(self, filename: str) -> bytes:
-            assert filename == "backup_1.backup"
-            return b"\x00binary"
-
-        def disconnect(self):
-            disconnected["called"] += 1
-
-    monkeypatch.setattr(connector, "MikroTikSSHClient", lambda **kw: DummyClient(**kw))
-    assert connector.download_file_sync("backup_1.backup") == b"\x00binary"
-    assert disconnected["called"] == 1
+def test_execute_sync_unknown_device_raises(monkeypatch):
+    connector = _patch_inventory(monkeypatch, FakeInventory({"RouterA": DummyClient()}))
+    with pytest.raises(DeviceNotFoundError):
+        connector._execute_sync("/x", device="Nope")
 
 
-def test_download_file_sync_connect_failure(monkeypatch):
-    from mcp_mikrotik import connector
+# ---------------------------------------------------------------------------
+# file transfer
+# ---------------------------------------------------------------------------
 
-    disconnected = {"called": 0}
+def test_download_file_sync_targets_device(monkeypatch):
+    a, b = DummyClient(), DummyClient()
+    connector = _patch_inventory(monkeypatch, FakeInventory({"RouterA": a, "RouterB": b}))
 
-    class DummyClient:
-        def connect(self):
-            return False
-
-        def disconnect(self):
-            disconnected["called"] += 1
-
-    monkeypatch.setattr(connector, "MikroTikSSHClient", lambda **kw: DummyClient())
-    with pytest.raises(ConnectionError):
-        connector.download_file_sync("x.backup")
-    assert disconnected["called"] == 1
+    assert connector.download_file_sync("backup_1.backup", device="RouterB") == b"\x00binary"
+    assert b.downloaded == "backup_1.backup"
+    assert a.downloaded is None
 
 
-def test_upload_file_sync_success(monkeypatch):
-    from mcp_mikrotik import connector
+def test_upload_file_sync_targets_device(monkeypatch):
+    a, b = DummyClient(), DummyClient()
+    connector = _patch_inventory(monkeypatch, FakeInventory({"RouterA": a, "RouterB": b}))
 
-    captured = {}
-    disconnected = {"called": 0}
-
-    class DummyClient:
-        def connect(self):
-            return True
-
-        def upload_file(self, filename: str, data: bytes) -> None:
-            captured["filename"] = filename
-            captured["data"] = data
-
-        def disconnect(self):
-            disconnected["called"] += 1
-
-    monkeypatch.setattr(connector, "MikroTikSSHClient", lambda **kw: DummyClient())
-    connector.upload_file_sync("restore.rsc", b"config-bytes")
-    assert captured == {"filename": "restore.rsc", "data": b"config-bytes"}
-    assert disconnected["called"] == 1
+    connector.upload_file_sync("restore.rsc", b"config-bytes", device="RouterA")
+    assert a.uploaded == ("restore.rsc", b"config-bytes")
+    assert b.uploaded is None
 
 
-def test_upload_file_sync_connect_failure(monkeypatch):
-    from mcp_mikrotik import connector
-
-    disconnected = {"called": 0}
-
-    class DummyClient:
-        def connect(self):
-            return False
-
-        def disconnect(self):
-            disconnected["called"] += 1
-
-    monkeypatch.setattr(connector, "MikroTikSSHClient", lambda **kw: DummyClient())
-    with pytest.raises(ConnectionError):
-        connector.upload_file_sync("x.rsc", b"data")
-    assert disconnected["called"] == 1
-
+# ---------------------------------------------------------------------------
+# execute_mikrotik_command
+# ---------------------------------------------------------------------------
 
 def test_execute_mikrotik_command_logs_error(ctx, monkeypatch):
-    from mcp_mikrotik import connector
+    connector = _patch_inventory(monkeypatch, FakeInventory({"OnlyOne": DummyClient()}))
 
     async def fake_to_thread(fn, *args, **kwargs):
         return fn(*args, **kwargs)
 
     monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
-    monkeypatch.setattr(connector, "_execute_sync", lambda cmd: "Error: nope")
+    monkeypatch.setattr(connector, "_execute_sync", lambda cmd, device=None: "Error: nope")
 
     result = asyncio.run(connector.execute_mikrotik_command("/bad", ctx))
     assert result == "Error: nope"
     assert ctx.error.await_count == 1
 
+
+def test_execute_mikrotik_command_unknown_device_is_reported(ctx, monkeypatch):
+    """A bad device must fail loudly and never execute somewhere else."""
+    client = DummyClient()
+    connector = _patch_inventory(monkeypatch, FakeInventory({"RouterA": client}))
+
+    result = asyncio.run(connector.execute_mikrotik_command("/x", ctx, device="Ghost"))
+    assert "Unknown device" in result
+    assert client.commands == []          # nothing ran anywhere
+    assert ctx.error.await_count == 1
+
+
+def test_execute_mikrotik_command_passes_resolved_device(ctx, monkeypatch):
+    a, b = DummyClient("A-out"), DummyClient("B-out")
+    connector = _patch_inventory(monkeypatch, FakeInventory({"RouterA": a, "RouterB": b}))
+
+    async def fake_to_thread(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    result = asyncio.run(connector.execute_mikrotik_command("/y", ctx, device="RouterB"))
+    assert result == "B-out"
+    assert b.commands == ["/y"] and a.commands == []

--- a/tests/unit/test_fleet.py
+++ b/tests/unit/test_fleet.py
@@ -1,0 +1,273 @@
+"""Unit tests for mcp_mikrotik.scope.fleet."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_mikrotik.config import DeviceConfig
+from mcp_mikrotik.inventory import DeviceInventory, reset_inventory
+import mcp_mikrotik.scope.fleet as fleet_module
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def ctx():
+    c = MagicMock()
+    c.info = AsyncMock()
+    c.error = AsyncMock()
+    return c
+
+
+def _sample_devices():
+    return [
+        DeviceConfig(name="mt-nl-1", host="1.1.1.1", tags=["nl", "eu", "core"]),
+        DeviceConfig(name="mt-usa-1", host="2.2.2.1", tags=["usa", "core"]),
+        DeviceConfig(name="mt-uae-1", host="3.3.3.1", tags=["uae"]),
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _reset_inventory():
+    reset_inventory()
+    yield
+    reset_inventory()
+
+
+# ---------------------------------------------------------------------------
+# list_devices
+# ---------------------------------------------------------------------------
+
+class TestListDevices:
+    def test_returns_json_with_devices(self, ctx, monkeypatch):
+        inv = DeviceInventory(_sample_devices())
+        monkeypatch.setattr(fleet_module, "get_inventory", lambda: inv)
+
+        result = asyncio.run(fleet_module.mikrotik_list_devices(ctx))
+
+        data = json.loads(result)
+        assert isinstance(data, list)
+        assert len(data) == 3
+        names = {d["name"] for d in data}
+        assert names == {"mt-nl-1", "mt-usa-1", "mt-uae-1"}
+
+    def test_device_summary_fields(self, ctx, monkeypatch):
+        inv = DeviceInventory(_sample_devices())
+        monkeypatch.setattr(fleet_module, "get_inventory", lambda: inv)
+
+        result = asyncio.run(fleet_module.mikrotik_list_devices(ctx))
+        data = json.loads(result)
+        entry = next(d for d in data if d["name"] == "mt-nl-1")
+
+        assert entry["host"] == "1.1.1.1"
+        assert entry["port"] == 22
+        assert "nl" in entry["tags"]
+
+    def test_empty_inventory_returns_help_text(self, ctx, monkeypatch):
+        inv = DeviceInventory([])
+        monkeypatch.setattr(fleet_module, "get_inventory", lambda: inv)
+
+        result = asyncio.run(fleet_module.mikrotik_list_devices(ctx))
+        assert "MIKROTIK_DEVICES" in result
+
+    def test_returns_str(self, ctx, monkeypatch):
+        inv = DeviceInventory(_sample_devices())
+        monkeypatch.setattr(fleet_module, "get_inventory", lambda: inv)
+        assert isinstance(asyncio.run(fleet_module.mikrotik_list_devices(ctx)), str)
+
+
+# ---------------------------------------------------------------------------
+# run_command_on_device
+# ---------------------------------------------------------------------------
+
+class TestRunCommandOnDevice:
+    def test_success(self, ctx, monkeypatch):
+        inv = DeviceInventory(_sample_devices())
+        monkeypatch.setattr(fleet_module, "get_inventory", lambda: inv)
+
+        async def fake_exec(device, command, ctx):
+            return "ether1  1.1.1.1/24  running"
+
+        monkeypatch.setattr(fleet_module, "execute_command_on_device", fake_exec)
+
+        result = asyncio.run(
+            fleet_module.mikrotik_run_command_on_device(ctx, "mt-nl-1", "/ip address print")
+        )
+        assert "mt-nl-1" in result
+        assert "ether1" in result
+
+    def test_device_not_found(self, ctx, monkeypatch):
+        inv = DeviceInventory(_sample_devices())
+        monkeypatch.setattr(fleet_module, "get_inventory", lambda: inv)
+
+        result = asyncio.run(
+            fleet_module.mikrotik_run_command_on_device(ctx, "ghost-router", "/ip address print")
+        )
+        assert "not found" in result.lower()
+        assert "ghost-router" in result
+
+    def test_device_not_found_lists_available(self, ctx, monkeypatch):
+        inv = DeviceInventory(_sample_devices())
+        monkeypatch.setattr(fleet_module, "get_inventory", lambda: inv)
+
+        result = asyncio.run(
+            fleet_module.mikrotik_run_command_on_device(ctx, "nope", "/ip address print")
+        )
+        assert "mt-nl-1" in result or "Available" in result
+
+    def test_returns_str(self, ctx, monkeypatch):
+        inv = DeviceInventory(_sample_devices())
+        monkeypatch.setattr(fleet_module, "get_inventory", lambda: inv)
+
+        async def fake_exec(device, command, ctx):
+            return "ok"
+
+        monkeypatch.setattr(fleet_module, "execute_command_on_device", fake_exec)
+
+        result = asyncio.run(
+            fleet_module.mikrotik_run_command_on_device(ctx, "mt-nl-1", "/system resource print")
+        )
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# run_command_on_tag
+# ---------------------------------------------------------------------------
+
+class TestRunCommandOnTag:
+    def test_parallel_execution(self, ctx, monkeypatch):
+        inv = DeviceInventory(_sample_devices())
+        monkeypatch.setattr(fleet_module, "get_inventory", lambda: inv)
+
+        async def fake_exec(device, command, ctx):
+            return f"output-from-{device.name}"
+
+        monkeypatch.setattr(fleet_module, "execute_command_on_device", fake_exec)
+
+        result = asyncio.run(
+            fleet_module.mikrotik_run_command_on_tag(ctx, "core", "/system resource print")
+        )
+        data = json.loads(result)
+        assert "mt-nl-1" in data
+        assert "mt-usa-1" in data
+        assert "output-from-mt-nl-1" in data["mt-nl-1"]
+
+    def test_tag_not_found(self, ctx, monkeypatch):
+        inv = DeviceInventory(_sample_devices())
+        monkeypatch.setattr(fleet_module, "get_inventory", lambda: inv)
+
+        result = asyncio.run(
+            fleet_module.mikrotik_run_command_on_tag(ctx, "nonexistent", "/ip address print")
+        )
+        assert "not found" in result.lower() or "No devices" in result
+
+    def test_exception_is_captured(self, ctx, monkeypatch):
+        inv = DeviceInventory(_sample_devices())
+        monkeypatch.setattr(fleet_module, "get_inventory", lambda: inv)
+
+        async def fail(device, command, ctx):
+            if device.name == "mt-usa-1":
+                raise ConnectionError("timeout")
+            return "ok"
+
+        monkeypatch.setattr(fleet_module, "execute_command_on_device", fail)
+
+        result = asyncio.run(
+            fleet_module.mikrotik_run_command_on_tag(ctx, "core", "/system resource print")
+        )
+        data = json.loads(result)
+        assert "Error" in data["mt-usa-1"]
+        assert data["mt-nl-1"] == "ok"
+
+    def test_returns_json_str(self, ctx, monkeypatch):
+        inv = DeviceInventory(_sample_devices())
+        monkeypatch.setattr(fleet_module, "get_inventory", lambda: inv)
+
+        async def fake_exec(device, command, ctx):
+            return "ok"
+
+        monkeypatch.setattr(fleet_module, "execute_command_on_device", fake_exec)
+
+        result = asyncio.run(
+            fleet_module.mikrotik_run_command_on_tag(ctx, "nl", "/ip address print")
+        )
+        assert isinstance(result, str)
+        json.loads(result)  # must be valid JSON
+
+
+# ---------------------------------------------------------------------------
+# run_command_on_all_devices
+# ---------------------------------------------------------------------------
+
+class TestRunCommandOnAllDevices:
+    def test_all_devices(self, ctx, monkeypatch):
+        inv = DeviceInventory(_sample_devices())
+        monkeypatch.setattr(fleet_module, "get_inventory", lambda: inv)
+
+        async def fake_exec(device, command, ctx):
+            return "ok"
+
+        monkeypatch.setattr(fleet_module, "execute_command_on_device", fake_exec)
+
+        result = asyncio.run(
+            fleet_module.mikrotik_run_command_on_all_devices(ctx, "/system resource print")
+        )
+        data = json.loads(result)
+        assert set(data.keys()) == {"mt-nl-1", "mt-usa-1", "mt-uae-1"}
+
+    def test_with_tag_filter(self, ctx, monkeypatch):
+        inv = DeviceInventory(_sample_devices())
+        monkeypatch.setattr(fleet_module, "get_inventory", lambda: inv)
+
+        async def fake_exec(device, command, ctx):
+            return "ok"
+
+        monkeypatch.setattr(fleet_module, "execute_command_on_device", fake_exec)
+
+        result = asyncio.run(
+            fleet_module.mikrotik_run_command_on_all_devices(
+                ctx, "/system resource print", tag_filter="eu"
+            )
+        )
+        data = json.loads(result)
+        assert set(data.keys()) == {"mt-nl-1"}
+
+    def test_empty_inventory(self, ctx, monkeypatch):
+        inv = DeviceInventory([])
+        monkeypatch.setattr(fleet_module, "get_inventory", lambda: inv)
+
+        result = asyncio.run(
+            fleet_module.mikrotik_run_command_on_all_devices(ctx, "/ip address print")
+        )
+        assert isinstance(result, str)
+        assert "No devices" in result
+
+    def test_tag_filter_no_match(self, ctx, monkeypatch):
+        inv = DeviceInventory(_sample_devices())
+        monkeypatch.setattr(fleet_module, "get_inventory", lambda: inv)
+
+        result = asyncio.run(
+            fleet_module.mikrotik_run_command_on_all_devices(
+                ctx, "/ip address print", tag_filter="unknown-tag"
+            )
+        )
+        assert "not found" in result.lower() or "No devices" in result
+
+    def test_returns_json_str(self, ctx, monkeypatch):
+        inv = DeviceInventory(_sample_devices())
+        monkeypatch.setattr(fleet_module, "get_inventory", lambda: inv)
+
+        async def fake_exec(device, command, ctx):
+            return "data"
+
+        monkeypatch.setattr(fleet_module, "execute_command_on_device", fake_exec)
+
+        result = asyncio.run(
+            fleet_module.mikrotik_run_command_on_all_devices(ctx, "/ip address print")
+        )
+        assert isinstance(result, str)
+        json.loads(result)  # must be valid JSON

--- a/tests/unit/test_inventory.py
+++ b/tests/unit/test_inventory.py
@@ -1,0 +1,124 @@
+"""Unit tests for mcp_mikrotik.inventory."""
+
+import pytest
+
+from mcp_mikrotik.config import DeviceConfig
+from mcp_mikrotik.inventory import DeviceInventory, get_inventory, reset_inventory
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_devices():
+    return [
+        DeviceConfig(name="mt-nl-1", host="1.1.1.1", tags=["nl", "eu", "core"]),
+        DeviceConfig(name="mt-nl-2", host="1.1.1.2", tags=["nl", "eu"]),
+        DeviceConfig(name="mt-usa-1", host="2.2.2.1", tags=["usa", "core"]),
+        DeviceConfig(name="mt-uae-1", host="3.3.3.1", tags=["uae"]),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# DeviceInventory
+# ---------------------------------------------------------------------------
+
+class TestDeviceInventory:
+    def test_count(self):
+        inv = DeviceInventory(_make_devices())
+        assert inv.count() == 4
+
+    def test_get_device_found(self):
+        inv = DeviceInventory(_make_devices())
+        device = inv.get_device("mt-nl-1")
+        assert device is not None
+        assert device.host == "1.1.1.1"
+
+    def test_get_device_not_found(self):
+        inv = DeviceInventory(_make_devices())
+        assert inv.get_device("nonexistent") is None
+
+    def test_get_devices_by_tag_single_match(self):
+        inv = DeviceInventory(_make_devices())
+        devices = inv.get_devices_by_tag("uae")
+        assert len(devices) == 1
+        assert devices[0].name == "mt-uae-1"
+
+    def test_get_devices_by_tag_multiple_matches(self):
+        inv = DeviceInventory(_make_devices())
+        devices = inv.get_devices_by_tag("nl")
+        names = {d.name for d in devices}
+        assert names == {"mt-nl-1", "mt-nl-2"}
+
+    def test_get_devices_by_tag_cross_region(self):
+        inv = DeviceInventory(_make_devices())
+        core_devices = inv.get_devices_by_tag("core")
+        names = {d.name for d in core_devices}
+        assert names == {"mt-nl-1", "mt-usa-1"}
+
+    def test_get_devices_by_tag_no_match(self):
+        inv = DeviceInventory(_make_devices())
+        assert inv.get_devices_by_tag("nonexistent-tag") == []
+
+    def test_get_all_devices_returns_all(self):
+        inv = DeviceInventory(_make_devices())
+        all_devices = inv.get_all_devices()
+        assert len(all_devices) == 4
+
+    def test_list_names(self):
+        inv = DeviceInventory(_make_devices())
+        names = set(inv.list_names())
+        assert names == {"mt-nl-1", "mt-nl-2", "mt-usa-1", "mt-uae-1"}
+
+    def test_empty_inventory(self):
+        inv = DeviceInventory([])
+        assert inv.count() == 0
+        assert inv.get_all_devices() == []
+        assert inv.get_device("any") is None
+        assert inv.get_devices_by_tag("any") == []
+
+    def test_device_defaults(self):
+        inv = DeviceInventory([DeviceConfig(name="basic", host="10.0.0.1")])
+        device = inv.get_device("basic")
+        assert device.username == "admin"
+        assert device.password == ""
+        assert device.port == 22
+        assert device.key_filename is None
+        assert device.tags == []
+
+
+# ---------------------------------------------------------------------------
+# Singleton helpers
+# ---------------------------------------------------------------------------
+
+class TestGetInventorySingleton:
+    def setup_method(self):
+        reset_inventory()
+
+    def teardown_method(self):
+        reset_inventory()
+
+    def test_returns_same_instance(self, monkeypatch):
+        monkeypatch.setattr(
+            "mcp_mikrotik.inventory.mikrotik_config",
+            type("cfg", (), {"devices": _make_devices()})(),
+        )
+        inv1 = get_inventory()
+        inv2 = get_inventory()
+        assert inv1 is inv2
+
+    def test_loads_from_config(self, monkeypatch):
+        monkeypatch.setattr(
+            "mcp_mikrotik.inventory.mikrotik_config",
+            type("cfg", (), {"devices": _make_devices()})(),
+        )
+        inv = get_inventory()
+        assert inv.count() == 4
+
+    def test_empty_config(self, monkeypatch):
+        monkeypatch.setattr(
+            "mcp_mikrotik.inventory.mikrotik_config",
+            type("cfg", (), {"devices": []})(),
+        )
+        inv = get_inventory()
+        assert inv.count() == 0

--- a/tests/unit/test_inventory.py
+++ b/tests/unit/test_inventory.py
@@ -249,6 +249,37 @@ def test_inventory_parses_yaml_flow_from_env(monkeypatch):
     assert cfg.inventory[0].region == "NL"
 
 
+def test_inventory_env_accepts_tab_whitespace_json(monkeypatch):
+    """PyYAML rejects tabs that JSON allows — the JSON-first parse must win.
+
+    A tab-indented inventory.json worked before the YAML migration; it must
+    keep working after it.
+    """
+    monkeypatch.setenv(
+        "MIKROTIK_INVENTORY",
+        '[\n\t{"title": "TitleA", "host": "10.0.0.1"},\n\t{"title":\t"TitleB", "host": "10.0.0.2"}\n]',
+    )
+    cfg = MikrotikConfig()
+    assert [d.title for d in cfg.inventory] == ["TitleA", "TitleB"]
+
+
+def test_inventory_file_accepts_tab_whitespace_json(monkeypatch, tmp_path):
+    import mcp_mikrotik.inventory as inv_mod
+    from mcp_mikrotik import config as cfg_mod
+
+    path = tmp_path / "inventory.json"
+    path.write_text(
+        '[\n\t{"title": "TitleA", "host": "10.0.0.1"}\n]', encoding="utf-8"
+    )
+    monkeypatch.delenv("MIKROTIK_INVENTORY", raising=False)
+    monkeypatch.setattr(
+        cfg_mod, "mikrotik_config", MikrotikConfig(inventory_file=str(path))
+    )
+
+    devices = inv_mod._load_devices()
+    assert [d.title for d in devices] == ["TitleA"]
+
+
 def test_invalid_inventory_yaml_is_rejected_without_echoing_it(monkeypatch):
     """The value holds credentials, so the error must not quote it back."""
     monkeypatch.setenv("MIKROTIK_INVENTORY", "[{title: A, password: hunter2, ]")

--- a/tests/unit/test_inventory.py
+++ b/tests/unit/test_inventory.py
@@ -1,0 +1,212 @@
+"""Tests for the multi-device Inventory (issue #44)."""
+
+import json
+
+import pytest
+
+from mcp_mikrotik.config import DeviceConfig, MikrotikConfig
+from mcp_mikrotik.inventory import DeviceNotFoundError, Inventory
+
+
+def _dev(title, host="10.0.0.1", **kw):
+    return DeviceConfig(title=title, host=host, **kw)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+def test_titles_and_len():
+    inv = Inventory([_dev("RouterA"), _dev("RouterB", "10.0.0.2")])
+    assert len(inv) == 2
+    assert inv.titles == ["RouterA", "RouterB"]
+
+
+def test_duplicate_titles_rejected():
+    with pytest.raises(ValueError, match="Duplicate device title"):
+        Inventory([_dev("Same"), _dev("Same", "10.0.0.2")])
+
+
+def test_duplicate_titles_are_case_insensitive():
+    with pytest.raises(ValueError, match="Duplicate device title"):
+        Inventory([_dev("RouterA"), _dev("routera", "10.0.0.2")])
+
+
+def test_blank_title_rejected():
+    with pytest.raises(ValueError):
+        DeviceConfig(title="   ", host="10.0.0.1")
+
+
+# ---------------------------------------------------------------------------
+# Resolution
+# ---------------------------------------------------------------------------
+
+def test_single_device_resolves_without_a_title():
+    inv = Inventory([_dev("OnlyOne")])
+    assert inv.resolve().title == "OnlyOne"
+    assert inv.resolve(None).title == "OnlyOne"
+    assert inv.resolve("").title == "OnlyOne"
+
+
+def test_multiple_devices_require_a_title():
+    inv = Inventory([_dev("RouterA"), _dev("RouterB", "10.0.0.2")])
+    with pytest.raises(DeviceNotFoundError) as exc:
+        inv.resolve()
+    # The error must list the choices so the caller can self-correct.
+    assert "RouterA" in str(exc.value) and "RouterB" in str(exc.value)
+
+
+def test_resolve_is_case_insensitive_and_trims():
+    inv = Inventory([_dev("RouterA"), _dev("RouterB", "10.0.0.2")])
+    assert inv.resolve("routera").title == "RouterA"
+    assert inv.resolve("  RouterB  ").title == "RouterB"
+
+
+def test_unknown_title_lists_available_devices():
+    inv = Inventory([_dev("RouterA"), _dev("RouterB", "10.0.0.2")])
+    with pytest.raises(DeviceNotFoundError) as exc:
+        inv.resolve("Ghost")
+    msg = str(exc.value)
+    assert "Ghost" in msg and "RouterA" in msg and "RouterB" in msg
+
+
+def test_empty_inventory_resolution_error():
+    with pytest.raises(DeviceNotFoundError, match="No MikroTik devices"):
+        Inventory([]).resolve()
+
+
+# ---------------------------------------------------------------------------
+# describe() — what the LLM sees
+# ---------------------------------------------------------------------------
+
+def test_describe_never_exposes_credentials():
+    inv = Inventory([
+        _dev("RouterA", username="admin", password="super-secret",
+             key_filename="/keys/id_ed25519", tags=["eu"], region="NL")
+    ])
+    described = inv.describe()
+    blob = json.dumps(described)
+    assert "super-secret" not in blob
+    assert "id_ed25519" not in blob
+    assert "password" not in blob and "key_filename" not in blob
+    assert described[0]["title"] == "RouterA"
+    assert described[0]["tags"] == ["eu"] and described[0]["region"] == "NL"
+
+
+# ---------------------------------------------------------------------------
+# Client handling
+# ---------------------------------------------------------------------------
+
+def test_get_client_is_cached_per_device(monkeypatch):
+    import mcp_mikrotik.inventory as inv_mod
+
+    built = []
+
+    class FakeSSH:
+        def __init__(self, **kw):
+            built.append(kw["host"])
+            self.client = object()
+
+        def connect(self):
+            return True
+
+        def disconnect(self):
+            pass
+
+    monkeypatch.setattr(inv_mod, "MikroTikSSHClient", FakeSSH)
+    monkeypatch.setattr(Inventory, "_is_alive", staticmethod(lambda c: True))
+
+    inv = Inventory([_dev("RouterA", "10.0.0.1"), _dev("RouterB", "10.0.0.2")])
+    c1 = inv.get_client("RouterA")
+    c2 = inv.get_client("RouterA")
+    c3 = inv.get_client("RouterB")
+
+    assert c1 is c2                 # reused
+    assert c3 is not c1             # per-device
+    assert built == ["10.0.0.1", "10.0.0.2"]
+
+
+def test_get_client_rebuilds_a_dead_connection(monkeypatch):
+    import mcp_mikrotik.inventory as inv_mod
+
+    built = []
+
+    class FakeSSH:
+        def __init__(self, **kw):
+            built.append(kw["host"])
+            self.client = object()
+
+        def connect(self):
+            return True
+
+        def disconnect(self):
+            pass
+
+    monkeypatch.setattr(inv_mod, "MikroTikSSHClient", FakeSSH)
+    monkeypatch.setattr(Inventory, "_is_alive", staticmethod(lambda c: False))
+
+    inv = Inventory([_dev("RouterA", "10.0.0.1")])
+    inv.get_client("RouterA")
+    inv.get_client("RouterA")
+    assert built == ["10.0.0.1", "10.0.0.1"]   # stale client replaced
+
+
+def test_get_client_raises_on_connect_failure(monkeypatch):
+    import mcp_mikrotik.inventory as inv_mod
+
+    class FailingSSH:
+        def __init__(self, **kw):
+            self.client = None
+
+        def connect(self):
+            return False
+
+        def disconnect(self):
+            pass
+
+    monkeypatch.setattr(inv_mod, "MikroTikSSHClient", FailingSSH)
+    inv = Inventory([_dev("RouterA", "10.0.0.1")])
+    with pytest.raises(ConnectionError, match="RouterA"):
+        inv.get_client("RouterA")
+
+
+# ---------------------------------------------------------------------------
+# Loading from configuration
+# ---------------------------------------------------------------------------
+
+def test_inventory_parses_json_from_env(monkeypatch):
+    payload = json.dumps([
+        {"title": "TitleA", "host": "127.0.0.1", "port": 2222,
+         "username": "admin", "password": "pw", "tags": ["t1"], "region": "NL"},
+        {"title": "TitleB", "host": "192.168.88.1"},
+    ])
+    monkeypatch.setenv("MIKROTIK_INVENTORY", payload)
+    cfg = MikrotikConfig()
+    assert [d.title for d in cfg.inventory] == ["TitleA", "TitleB"]
+    assert cfg.inventory[0].port == 2222
+    assert cfg.inventory[0].tags == ["t1"]
+    assert cfg.inventory[1].port == 22          # default
+
+
+def test_invalid_inventory_json_is_rejected(monkeypatch):
+    monkeypatch.setenv("MIKROTIK_INVENTORY", "{not json")
+    with pytest.raises(Exception):
+        MikrotikConfig()
+
+
+def test_falls_back_to_single_device_config(monkeypatch):
+    """No inventory configured -> synthesise one device from the flat settings."""
+    import mcp_mikrotik.inventory as inv_mod
+    from mcp_mikrotik import config as cfg_mod
+
+    monkeypatch.delenv("MIKROTIK_INVENTORY", raising=False)
+    monkeypatch.setattr(
+        cfg_mod, "mikrotik_config",
+        MikrotikConfig(host="192.168.88.1", username="u", password="p", port=2022),
+    )
+
+    devices = inv_mod._load_devices()
+    assert len(devices) == 1
+    assert devices[0].host == "192.168.88.1"
+    assert devices[0].port == 2022
+    assert devices[0].username == "u"

--- a/tests/unit/test_inventory.py
+++ b/tests/unit/test_inventory.py
@@ -1,5 +1,6 @@
 """Tests for the multi-device Inventory (issue #44)."""
 
+import copy
 import json
 
 import pytest
@@ -94,64 +95,88 @@ def test_describe_never_exposes_credentials():
 
 
 # ---------------------------------------------------------------------------
-# Client handling
+# Connections — never pooled, always closed
 # ---------------------------------------------------------------------------
 
-def test_get_client_is_cached_per_device(monkeypatch):
+def _recording_ssh(monkeypatch):
+    """Patch MikroTikSSHClient with a recorder. Returns (built, closed)."""
     import mcp_mikrotik.inventory as inv_mod
 
-    built = []
+    built, closed = [], []
 
     class FakeSSH:
         def __init__(self, **kw):
-            built.append(kw["host"])
+            self.host = kw["host"]
             self.client = object()
+            built.append(self)
 
         def connect(self):
             return True
 
         def disconnect(self):
-            pass
+            closed.append(self)
 
     monkeypatch.setattr(inv_mod, "MikroTikSSHClient", FakeSSH)
-    monkeypatch.setattr(Inventory, "_is_alive", staticmethod(lambda c: True))
+    return built, closed
 
+
+def test_each_call_opens_a_fresh_connection(monkeypatch):
+    """Clients are never pooled, so concurrent sessions cannot share one."""
+    built, _ = _recording_ssh(monkeypatch)
     inv = Inventory([_dev("RouterA", "10.0.0.1"), _dev("RouterB", "10.0.0.2")])
-    c1 = inv.get_client("RouterA")
-    c2 = inv.get_client("RouterA")
-    c3 = inv.get_client("RouterB")
 
-    assert c1 is c2                 # reused
-    assert c3 is not c1             # per-device
-    assert built == ["10.0.0.1", "10.0.0.2"]
+    a1 = inv.connect("RouterA")
+    a2 = inv.connect("RouterA")
+    b1 = inv.connect("RouterB")
+
+    # Two calls for the SAME device must still be two distinct connections.
+    assert a1 is not a2
+    assert b1 is not a1 and b1 is not a2
+    assert [c.host for c in built] == ["10.0.0.1", "10.0.0.1", "10.0.0.2"]
 
 
-def test_get_client_rebuilds_a_dead_connection(monkeypatch):
-    import mcp_mikrotik.inventory as inv_mod
+def test_inventory_holds_no_connection_state(monkeypatch):
+    """Opening connections must not mutate the inventory.
 
-    built = []
-
-    class FakeSSH:
-        def __init__(self, **kw):
-            built.append(kw["host"])
-            self.client = object()
-
-        def connect(self):
-            return True
-
-        def disconnect(self):
-            pass
-
-    monkeypatch.setattr(inv_mod, "MikroTikSSHClient", FakeSSH)
-    monkeypatch.setattr(Inventory, "_is_alive", staticmethod(lambda c: False))
-
+    Anything the inventory retained between calls would be state shared by
+    every session in the process — exactly what this design removes.
+    """
+    _recording_ssh(monkeypatch)
     inv = Inventory([_dev("RouterA", "10.0.0.1")])
-    inv.get_client("RouterA")
-    inv.get_client("RouterA")
-    assert built == ["10.0.0.1", "10.0.0.1"]   # stale client replaced
+
+    before = copy.deepcopy(vars(inv))
+    inv.connect("RouterA")
+    inv.connect("RouterA")
+    with inv.session("RouterA"):
+        pass
+
+    assert vars(inv) == before
 
 
-def test_get_client_raises_on_connect_failure(monkeypatch):
+def test_session_closes_the_connection(monkeypatch):
+    built, closed = _recording_ssh(monkeypatch)
+    inv = Inventory([_dev("RouterA", "10.0.0.1")])
+
+    with inv.session("RouterA") as client:
+        assert closed == []          # still open while the command runs
+
+    assert closed == [client]
+    assert built == [client]
+
+
+def test_session_closes_the_connection_on_error(monkeypatch):
+    """A failing command must not leak an SSH session on the router."""
+    built, closed = _recording_ssh(monkeypatch)
+    inv = Inventory([_dev("RouterA", "10.0.0.1")])
+
+    with pytest.raises(RuntimeError, match="command blew up"):
+        with inv.session("RouterA"):
+            raise RuntimeError("command blew up")
+
+    assert closed == built and len(closed) == 1
+
+
+def test_connect_raises_on_connect_failure(monkeypatch):
     import mcp_mikrotik.inventory as inv_mod
 
     class FailingSSH:
@@ -167,7 +192,28 @@ def test_get_client_raises_on_connect_failure(monkeypatch):
     monkeypatch.setattr(inv_mod, "MikroTikSSHClient", FailingSSH)
     inv = Inventory([_dev("RouterA", "10.0.0.1")])
     with pytest.raises(ConnectionError, match="RouterA"):
-        inv.get_client("RouterA")
+        inv.connect("RouterA")
+
+
+def test_session_propagates_connect_failure(monkeypatch):
+    """An unreachable device fails at the `with`, never yielding a client."""
+    import mcp_mikrotik.inventory as inv_mod
+
+    class FailingSSH:
+        def __init__(self, **kw):
+            self.client = None
+
+        def connect(self):
+            return False
+
+        def disconnect(self):
+            raise AssertionError("nothing was opened, so nothing may be closed")
+
+    monkeypatch.setattr(inv_mod, "MikroTikSSHClient", FailingSSH)
+    inv = Inventory([_dev("RouterA", "10.0.0.1")])
+    with pytest.raises(ConnectionError, match="RouterA"):
+        with inv.session("RouterA"):
+            raise AssertionError("body must not run")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_inventory.py
+++ b/tests/unit/test_inventory.py
@@ -221,6 +221,7 @@ def test_session_propagates_connect_failure(monkeypatch):
 # ---------------------------------------------------------------------------
 
 def test_inventory_parses_json_from_env(monkeypatch):
+    """JSON is a YAML subset, so the old inline JSON form keeps working."""
     payload = json.dumps([
         {"title": "TitleA", "host": "127.0.0.1", "port": 2222,
          "username": "admin", "password": "pw", "tags": ["t1"], "region": "NL"},
@@ -234,10 +235,120 @@ def test_inventory_parses_json_from_env(monkeypatch):
     assert cfg.inventory[1].port == 22          # default
 
 
-def test_invalid_inventory_json_is_rejected(monkeypatch):
-    monkeypatch.setenv("MIKROTIK_INVENTORY", "{not json")
-    with pytest.raises(Exception):
+def test_inventory_parses_yaml_flow_from_env(monkeypatch):
+    """YAML flow syntax needs no escaped quotes inside an MCP JSON config."""
+    monkeypatch.setenv(
+        "MIKROTIK_INVENTORY",
+        "[{title: TitleA, host: 127.0.0.1, port: 2222, region: NL, tags: [t1]},"
+        " {title: TitleB, host: 192.168.88.1}]",
+    )
+    cfg = MikrotikConfig()
+    assert [d.title for d in cfg.inventory] == ["TitleA", "TitleB"]
+    assert cfg.inventory[0].port == 2222
+    assert cfg.inventory[0].tags == ["t1"]
+    assert cfg.inventory[0].region == "NL"
+
+
+def test_invalid_inventory_yaml_is_rejected_without_echoing_it(monkeypatch):
+    """The value holds credentials, so the error must not quote it back."""
+    monkeypatch.setenv("MIKROTIK_INVENTORY", "[{title: A, password: hunter2, ]")
+    with pytest.raises(Exception) as exc:
         MikrotikConfig()
+    assert "hunter2" not in str(exc.value)
+
+
+def test_invalid_inventory_entry_error_hides_credentials(monkeypatch):
+    """A schema-invalid entry (e.g. 'hostname' typo) must not echo values."""
+    monkeypatch.setenv(
+        "MIKROTIK_INVENTORY",
+        '[{"title": "core-nl", "hostname": "10.0.0.1", "password": "FleetSecret9!"}]',
+    )
+    with pytest.raises(Exception) as exc:
+        MikrotikConfig()
+    msg = str(exc.value)
+    assert "FleetSecret9!" not in msg
+    assert "host" in msg                        # the offending field is named
+
+
+def test_inventory_file_accepts_yaml(monkeypatch, tmp_path):
+    import mcp_mikrotik.inventory as inv_mod
+    from mcp_mikrotik import config as cfg_mod
+
+    path = tmp_path / "inventory.yaml"
+    path.write_text(
+        "- title: TitleA\n"
+        "  host: 127.0.0.1\n"
+        "  port: 2222\n"
+        "  tags: [lab, primary]\n"
+        "  region: NL\n"
+        "- title: TitleB\n"
+        "  host: 192.168.88.1\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("MIKROTIK_INVENTORY", raising=False)
+    monkeypatch.setattr(
+        cfg_mod, "mikrotik_config", MikrotikConfig(inventory_file=str(path))
+    )
+
+    devices = inv_mod._load_devices()
+    assert [d.title for d in devices] == ["TitleA", "TitleB"]
+    assert devices[0].port == 2222
+    assert devices[0].tags == ["lab", "primary"]
+    assert devices[1].port == 22
+
+
+def test_inline_inventory_wins_over_file(monkeypatch, tmp_path):
+    import mcp_mikrotik.inventory as inv_mod
+    from mcp_mikrotik import config as cfg_mod
+
+    path = tmp_path / "inventory.yaml"
+    path.write_text("- title: FromFile\n  host: 10.0.0.9\n", encoding="utf-8")
+    monkeypatch.setenv("MIKROTIK_INVENTORY", "[{title: Inline, host: 10.0.0.1}]")
+    monkeypatch.setattr(
+        cfg_mod, "mikrotik_config", MikrotikConfig(inventory_file=str(path))
+    )
+
+    devices = inv_mod._load_devices()
+    assert [d.title for d in devices] == ["Inline"]
+
+
+def test_inventory_file_error_names_entry_without_credentials(monkeypatch, tmp_path):
+    import mcp_mikrotik.inventory as inv_mod
+    from mcp_mikrotik import config as cfg_mod
+
+    path = tmp_path / "inventory.yaml"
+    path.write_text(
+        "- title: core-nl\n"
+        "  hostname: 10.0.0.1\n"          # typo: should be 'host'
+        "  password: FleetSecret9!\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("MIKROTIK_INVENTORY", raising=False)
+    monkeypatch.setattr(
+        cfg_mod, "mikrotik_config", MikrotikConfig(inventory_file=str(path))
+    )
+
+    with pytest.raises(ValueError) as exc:
+        inv_mod._load_devices()
+    msg = str(exc.value)
+    assert "FleetSecret9!" not in msg
+    assert "core-nl" in msg and "host" in msg
+
+
+def test_inventory_file_rejects_non_list_shapes(monkeypatch, tmp_path):
+    import mcp_mikrotik.inventory as inv_mod
+    from mcp_mikrotik import config as cfg_mod
+
+    path = tmp_path / "inventory.yaml"
+    path.write_text("inventory:\n  title: NotAList\n  host: 10.0.0.1\n",
+                    encoding="utf-8")
+    monkeypatch.delenv("MIKROTIK_INVENTORY", raising=False)
+    monkeypatch.setattr(
+        cfg_mod, "mikrotik_config", MikrotikConfig(inventory_file=str(path))
+    )
+
+    with pytest.raises(ValueError, match="must be a list"):
+        inv_mod._load_devices()
 
 
 def test_falls_back_to_single_device_config(monkeypatch):

--- a/tests/unit/test_inventory.py
+++ b/tests/unit/test_inventory.py
@@ -366,6 +366,30 @@ def test_inventory_file_error_names_entry_without_credentials(monkeypatch, tmp_p
     assert "core-nl" in msg and "host" in msg
 
 
+def test_shipped_example_inventory_is_valid(monkeypatch):
+    """inventory.example.yml at the repo root must always match the schema."""
+    import pathlib
+
+    import mcp_mikrotik.inventory as inv_mod
+    from mcp_mikrotik import config as cfg_mod
+
+    example = pathlib.Path(__file__).resolve().parents[2] / "inventory.example.yml"
+    assert example.is_file(), "inventory.example.yml is missing from the repo root"
+
+    monkeypatch.delenv("MIKROTIK_INVENTORY", raising=False)
+    monkeypatch.setattr(
+        cfg_mod, "mikrotik_config", MikrotikConfig(inventory_file=str(example))
+    )
+
+    devices = inv_mod._load_devices()
+    assert [d.title for d in devices] == ["TitleA", "TitleB"]
+    assert devices[0].password == "change-me"
+    assert devices[1].key_filename == "/config/keys/id_ed25519"
+    # and the example is usable as-is: unique titles, resolvable
+    inv = Inventory(devices)
+    assert inv.resolve("titlea").title == "TitleA"
+
+
 def test_inventory_file_rejects_non_list_shapes(monkeypatch, tmp_path):
     import mcp_mikrotik.inventory as inv_mod
     from mcp_mikrotik import config as cfg_mod

--- a/tests/unit/test_safe_mode_manager.py
+++ b/tests/unit/test_safe_mode_manager.py
@@ -268,6 +268,44 @@ def test_execute_ignores_prompt_shaped_fragment_arriving_before_output(
     assert out == ""          # a clean add produces no output — and no junk
 
 
+def test_terminal_probe_split_across_chunks_is_still_answered(
+    monkeypatch, single_device_inventory
+):
+    """A 4-byte probe can straddle two network reads; the answer must not be lost.
+
+    The DA probe after each prompt is sent exactly once and gates the final
+    "> ", so a missed probe stalls the console until a timeout.
+    """
+    channel = ScriptedChannel(license_prompt=False, password_nag=False)
+    # Deliver the size probe split in the middle: "\x1b[6" ... "n"
+    channel._pending = channel.BANNER + "\x1b[6"
+    original_send = channel.send
+    state = {"tail_sent": False}
+
+    def recv(n):
+        out, channel._pending = channel._pending[:n], channel._pending[n:]
+        if not channel._pending and not state["tail_sent"]:
+            channel._pending = "n"          # the probe's last byte arrives late
+            state["tail_sent"] = True
+        return out.encode("utf-8")
+
+    def send(data):
+        if data == "\x1b[50;220R":
+            channel.sent.append(data)
+            channel._pending += "\r\n[admin@RouterA-NL] > "
+        else:
+            original_send(data)
+
+    channel.recv = recv
+    channel.send = send
+    mgr = _patched_manager(monkeypatch, channel)
+
+    result = mgr.enable()
+
+    assert "ENABLED" in result, result
+    assert channel.sent == ["\x1b[50;220R", "\x18"]
+
+
 def test_enable_accepts_ros721_success_message_without_safe_prompt(
     monkeypatch, single_device_inventory
 ):

--- a/tests/unit/test_safe_mode_manager.py
+++ b/tests/unit/test_safe_mode_manager.py
@@ -88,6 +88,56 @@ def _patched_manager(monkeypatch, channel):
     return SafeModeManager("RouterA")
 
 
+def test_get_safe_mode_manager_propagates_resolution_errors(monkeypatch):
+    """A typo'd or omitted device must error — not fabricate a fresh manager.
+
+    A phantom manager answers "safe mode is not active — nothing to commit"
+    while the real device still holds uncommitted changes that revert when its
+    session drops.
+    """
+    import mcp_mikrotik.inventory as inv_mod
+    from mcp_mikrotik.inventory import DeviceNotFoundError
+
+    def raising_resolve(title=None):
+        raise DeviceNotFoundError("Unknown device 'Ghost'. Available: RouterA.")
+
+    monkeypatch.setattr(
+        inv_mod, "get_inventory",
+        lambda: SimpleNamespace(resolve=raising_resolve),
+    )
+
+    with pytest.raises(DeviceNotFoundError):
+        safe_mode_mod.get_safe_mode_manager("Ghost")
+
+
+def test_safe_mode_tools_surface_resolution_errors(monkeypatch):
+    """status/commit/rollback report the error instead of 'not active'."""
+    import asyncio
+
+    from mcp_mikrotik.inventory import DeviceNotFoundError
+    from mcp_mikrotik.scope import safe_mode as scope_safe_mode
+    from unittest.mock import AsyncMock, MagicMock
+
+    def raising(device=None):
+        raise DeviceNotFoundError(
+            "Unknown device 'Ghost'. Available devices: RouterA, RouterB."
+        )
+
+    monkeypatch.setattr(scope_safe_mode, "get_safe_mode_manager", raising)
+    ctx = MagicMock()
+    ctx.info = AsyncMock()
+
+    for tool in (
+        scope_safe_mode.mikrotik_safe_mode_status,
+        scope_safe_mode.mikrotik_commit_safe_mode,
+        scope_safe_mode.mikrotik_rollback_safe_mode,
+        scope_safe_mode.mikrotik_enable_safe_mode,
+    ):
+        result = asyncio.run(tool(ctx, device="Ghost"))
+        assert result.startswith("Error:"), result
+        assert "RouterA" in result          # the choices are listed
+
+
 def test_enable_answers_license_and_password_dialogs(monkeypatch, single_device_inventory):
     channel = ScriptedChannel(license_prompt=True, password_nag=True)
     mgr = _patched_manager(monkeypatch, channel)

--- a/tests/unit/test_safe_mode_manager.py
+++ b/tests/unit/test_safe_mode_manager.py
@@ -1,0 +1,240 @@
+"""Tests for SafeModeManager's interactive login bring-up.
+
+A real RouterOS login is not just a prompt: fresh devices ask the software-
+license question, and RouterOS 7.21+ interposes a "new password>" step on
+every login while the admin password is empty.  enable() must answer both or
+it times out on exactly the routers the test environment ships.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import mcp_mikrotik.safe_mode as safe_mode_mod
+from mcp_mikrotik.config import DeviceConfig
+from mcp_mikrotik.safe_mode import _EOC, SafeModeManager
+
+
+class ScriptedChannel:
+    """Interactive-shell double that releases output in response to input."""
+
+    BANNER = "\r\n" * 5 + "  MMM      MMM       KKK\r\n  MikroTik RouterOS 7.21.4\r\n"
+
+    def __init__(self, license_prompt=True, password_nag=True):
+        self.sent = []
+        self._pending = self.BANNER
+        if license_prompt:
+            self._pending += "Do you want to see the software license? [Y/n]: "
+        elif password_nag:
+            self._pending += "Change your password (Ctrl-C to skip)\r\nnew password> "
+        else:
+            self._pending += "[admin@RouterA-NL] > "
+        self._password_nag = password_nag
+        self._license_prompt = license_prompt
+
+    def settimeout(self, _t):
+        pass
+
+    def recv_ready(self):
+        return bool(self._pending)
+
+    def recv(self, n):
+        out, self._pending = self._pending[:n], self._pending[n:]
+        return out.encode("utf-8")
+
+    def send(self, data):
+        self.sent.append(data)
+        if data == "n" and self._license_prompt:
+            self._license_prompt = False
+            if self._password_nag:
+                self._pending += "Change your password (Ctrl-C to skip)\r\nnew password> "
+            else:
+                self._pending += "\r\n[admin@RouterA-NL] > "
+        elif data == "\x03" and self._password_nag:
+            self._password_nag = False
+            self._pending += "\r\n[admin@RouterA-NL] > "
+        elif data == "\x18":
+            self._pending += "\r\n[admin@RouterA-NL] <SAFE> > "
+
+    def close(self):
+        pass
+
+
+class FakeSSH:
+    def __init__(self, channel):
+        self._channel = channel
+        self.client = SimpleNamespace(invoke_shell=lambda **kw: channel)
+
+    def connect(self):
+        return True
+
+    def disconnect(self):
+        pass
+
+
+@pytest.fixture()
+def single_device_inventory(monkeypatch):
+    import mcp_mikrotik.inventory as inv_mod
+
+    device = DeviceConfig(title="RouterA", host="10.0.0.1")
+    fake = SimpleNamespace(resolve=lambda title=None: device)
+    monkeypatch.setattr(inv_mod, "get_inventory", lambda: fake)
+    return device
+
+
+def _patched_manager(monkeypatch, channel):
+    monkeypatch.setattr(safe_mode_mod, "MikroTikSSHClient",
+                        lambda **kw: FakeSSH(channel))
+    return SafeModeManager("RouterA")
+
+
+def test_enable_answers_license_and_password_dialogs(monkeypatch, single_device_inventory):
+    channel = ScriptedChannel(license_prompt=True, password_nag=True)
+    mgr = _patched_manager(monkeypatch, channel)
+
+    result = mgr.enable()
+
+    assert "ENABLED" in result, result
+    assert mgr.is_active
+    # license declined, password step skipped, then Ctrl-X for safe mode
+    assert channel.sent == ["n", "\x03", "\x18"]
+
+
+def test_enable_skips_persistent_password_nag_alone(monkeypatch, single_device_inventory):
+    """The nag repeats on every login while the password is empty."""
+    channel = ScriptedChannel(license_prompt=False, password_nag=True)
+    mgr = _patched_manager(monkeypatch, channel)
+
+    result = mgr.enable()
+
+    assert "ENABLED" in result, result
+    assert channel.sent == ["\x03", "\x18"]
+
+
+def test_enable_with_plain_prompt_sends_nothing_extra(monkeypatch, single_device_inventory):
+    channel = ScriptedChannel(license_prompt=False, password_nag=False)
+    mgr = _patched_manager(monkeypatch, channel)
+
+    result = mgr.enable()
+
+    assert "ENABLED" in result, result
+    assert channel.sent == ["\x18"]
+
+
+def test_login_answers_terminal_size_probe(monkeypatch, single_device_inventory):
+    """The console measures the terminal and waits for the answer.
+
+    An unanswered probe leaves the console half-initialised and RouterOS
+    closes the channel when Ctrl-X asks for the safe-mode redraw.
+    """
+    channel = ScriptedChannel(license_prompt=False, password_nag=False)
+    channel._pending = channel.BANNER + "\x1b[9999B\x1b[6n"
+
+    original_send = channel.send
+
+    def send(data):
+        if data == "\x1b[50;220R":
+            channel.sent.append(data)
+            channel._pending += "\r\n[admin@RouterA-NL] > "
+        else:
+            original_send(data)
+
+    channel.send = send
+    mgr = _patched_manager(monkeypatch, channel)
+
+    result = mgr.enable()
+
+    assert "ENABLED" in result, result
+    assert channel.sent == ["\x1b[50;220R", "\x18"]
+
+
+def test_execute_returns_output_between_echo_and_sentinel(
+    monkeypatch, single_device_inventory
+):
+    """execute() must return the command's output — not echo, not prompt."""
+    channel = ScriptedChannel(license_prompt=False, password_nag=False)
+    original_send = channel.send
+
+    def send(data):
+        if data.startswith("/system identity print"):
+            channel.sent.append(data)
+            # colored echo on the prompt line, real output, bare sentinel,
+            # then a prompt fragment from a redraw — only the output survives
+            # typing echo, then the console's history reprint of the same
+            # line (without '>'), then output, sentinel, and redraw noise
+            channel._pending += (
+                f'\r\n[admin@RouterA-NL] <SAFE> > /system identity print; :put "{_EOC}"\r\n'
+                f'[admin@RouterA-NL] <SAFE> /system identity print; :put "{_EOC}"\r\n'
+                "  name: RouterA-NL\r\n"
+                f"{_EOC}\r\n"
+                "[admin@RouterA-NL] <SAFE>\r\n"
+                "[admin@RouterA-NL] <SAFE> > "
+            )
+        else:
+            original_send(data)
+
+    channel.send = send
+    mgr = _patched_manager(monkeypatch, channel)
+    assert "ENABLED" in mgr.enable()
+
+    out = mgr.execute("/system identity print")
+
+    assert out == "name: RouterA-NL"
+    assert channel.sent[-1] == f'/system identity print; :put "{_EOC}"\n'
+
+
+def test_execute_ignores_prompt_shaped_fragment_arriving_before_output(
+    monkeypatch, single_device_inventory
+):
+    """A redrawn prompt mid-stream must not end the read early."""
+    channel = ScriptedChannel(license_prompt=False, password_nag=False)
+    original_send = channel.send
+    state = {"phase": 0}
+
+    def send(data):
+        if data.startswith("/ip firewall filter add"):
+            channel.sent.append(data)
+            # first only prompt + echo arrive (the old failure mode)...
+            channel._pending += f"\r\n[admin@RouterA-NL] <SAFE> > {data.strip()}\r\n"
+            state["phase"] = 1
+        else:
+            original_send(data)
+
+    def recv(n):
+        out, channel._pending = channel._pending[:n], channel._pending[n:]
+        # ...and the sentinel only lands after the echo has fully drained
+        if not channel._pending and state["phase"] == 1:
+            channel._pending = f"{_EOC}\r\n[admin@RouterA-NL] <SAFE> > "
+            state["phase"] = 2
+        return out.encode("utf-8")
+
+    channel.send = send
+    channel.recv = recv
+    mgr = _patched_manager(monkeypatch, channel)
+    assert "ENABLED" in mgr.enable()
+
+    out = mgr.execute("/ip firewall filter add chain=forward action=drop")
+
+    assert out == ""          # a clean add produces no output — and no junk
+
+
+def test_enable_accepts_ros721_success_message_without_safe_prompt(
+    monkeypatch, single_device_inventory
+):
+    """RouterOS 7.21 confirms in prose; the <SAFE> prompt redraw may lag."""
+    channel = ScriptedChannel(license_prompt=False, password_nag=False)
+
+    def send(data):
+        channel.sent.append(data)
+        if data == "\x18":
+            channel._pending += (
+                "\r\nTaking Safe Mode session... Success!\r\n[admin@RouterA-NL] > "
+            )
+
+    channel.send = send
+    mgr = _patched_manager(monkeypatch, channel)
+
+    result = mgr.enable()
+
+    assert "ENABLED" in result, result
+    assert mgr.is_active

--- a/tests/unit/test_scope_ip_pool_expand.py
+++ b/tests/unit/test_scope_ip_pool_expand.py
@@ -10,7 +10,7 @@ def test_expand_ip_pool_hits_wrapper_bug(ctx, monkeypatch):
     """
     from mcp_mikrotik.scope import ip_pool as mod
 
-    async def fake_exec(command: str, _ctx):
+    async def fake_exec(command: str, _ctx, device=None):
         if "print detail" in command:
             return 'name="pool1" ranges=10.0.0.1-10.0.0.10'
         return ""

--- a/tests/unit/test_scope_ipv6_address.py
+++ b/tests/unit/test_scope_ipv6_address.py
@@ -111,7 +111,7 @@ def test_list_link_local_filter(ctx, monkeypatch):
 def test_list_empty_message(ctx, monkeypatch):
     from mcp_mikrotik.scope import ipv6_address as m
 
-    async def fake(cmd, _ctx):
+    async def fake(cmd, _ctx, device=None):
         return ""
 
     monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
@@ -129,7 +129,7 @@ def test_get_by_id_queries_id_first(ctx, monkeypatch):
 
     calls = []
 
-    async def fake(cmd, _ctx):
+    async def fake(cmd, _ctx, device=None):
         calls.append(cmd)
         return "address=2001:db8::1/64 interface=ether1"  # real entry data
 
@@ -145,7 +145,7 @@ def test_get_by_address_queries_address_first(ctx, monkeypatch):
 
     calls = []
 
-    async def fake(cmd, _ctx):
+    async def fake(cmd, _ctx, device=None):
         calls.append(cmd)
         return "address=2001:db8::1/64 interface=ether1"
 
@@ -162,7 +162,7 @@ def test_get_legend_only_is_treated_as_not_found(ctx, monkeypatch):
 
     legend = "Flags: X - disabled, I - invalid; D - dynamic; G - global, L - link-local"
 
-    async def fake(cmd, _ctx):
+    async def fake(cmd, _ctx, device=None):
         return legend  # non-empty, but no real "address=" row
 
     monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
@@ -173,13 +173,13 @@ def test_get_legend_only_is_treated_as_not_found(ctx, monkeypatch):
 def test_remove_by_id(ctx, monkeypatch):
     from mcp_mikrotik.scope import ipv6_address as m
 
-    async def fake(cmd, _ctx):
+    async def fake(cmd, _ctx, device=None):
         if "count-only" in cmd:
             return "1"      # found by id
         return ""           # remove succeeds
 
     seen = []
-    async def tracking(cmd, _ctx):
+    async def tracking(cmd, _ctx, device=None):
         seen.append(cmd)
         return await fake(cmd, _ctx)
 
@@ -192,7 +192,7 @@ def test_remove_by_id(ctx, monkeypatch):
 def test_remove_not_found(ctx, monkeypatch):
     from mcp_mikrotik.scope import ipv6_address as m
 
-    async def fake(cmd, _ctx):
+    async def fake(cmd, _ctx, device=None):
         return "0"  # count-only returns 0 for both id and address
 
     monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
@@ -210,7 +210,7 @@ def test_get_canonicalizes_noncanonical_address(ctx, monkeypatch):
 
     calls = []
 
-    async def fake(cmd, _ctx):
+    async def fake(cmd, _ctx, device=None):
         calls.append(cmd)
         return "address=2001:db8::1/64 interface=ether1"
 
@@ -227,7 +227,7 @@ def test_remove_by_address_path_canonicalized(ctx, monkeypatch):
 
     seen = []
 
-    async def fake(cmd, _ctx):
+    async def fake(cmd, _ctx, device=None):
         seen.append(cmd)
         if "count-only" in cmd:
             return "0" if ".id=" in cmd else "1"
@@ -250,7 +250,7 @@ def test_add_from_pool_confirms_via_interface(ctx, monkeypatch):
 
     seen = []
 
-    async def fake(cmd, _ctx):
+    async def fake(cmd, _ctx, device=None):
         seen.append(cmd)
         if cmd.startswith("/ipv6 address add"):
             return ""  # success
@@ -268,7 +268,7 @@ def test_add_from_pool_confirms_via_interface(ctx, monkeypatch):
 def test_add_failure_path(ctx, monkeypatch):
     from mcp_mikrotik.scope import ipv6_address as m
 
-    async def fake(cmd, _ctx):
+    async def fake(cmd, _ctx, device=None):
         return "failure: already have such address"
 
     monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
@@ -279,7 +279,7 @@ def test_add_failure_path(ctx, monkeypatch):
 def test_remove_failure_path(ctx, monkeypatch):
     from mcp_mikrotik.scope import ipv6_address as m
 
-    async def fake(cmd, _ctx):
+    async def fake(cmd, _ctx, device=None):
         if "count-only" in cmd:
             return "1"  # found by id
         return "failure: cannot remove"

--- a/tests/unit/test_scope_poe.py
+++ b/tests/unit/test_scope_poe.py
@@ -26,7 +26,7 @@ def test_get_poe_monitor_uses_once_flag(ctx, monkeypatch):
 def test_get_poe_monitor_returns_data(ctx, monkeypatch):
     from mcp_mikrotik.scope import poe
 
-    async def fake(cmd, _ctx):
+    async def fake(cmd, _ctx, device=None):
         return "name: ether9-ap\npoe-out-status: powered-on\npoe-out-power: 4.2W"
 
     monkeypatch.setattr(poe, "execute_mikrotik_command", fake, raising=True)
@@ -38,7 +38,7 @@ def test_get_poe_monitor_returns_data(ctx, monkeypatch):
 def test_get_poe_monitor_handles_empty(ctx, monkeypatch):
     from mcp_mikrotik.scope import poe
 
-    async def fake(cmd, _ctx):
+    async def fake(cmd, _ctx, device=None):
         return ""
 
     monkeypatch.setattr(poe, "execute_mikrotik_command", fake, raising=True)

--- a/tests/unit/test_server_main.py
+++ b/tests/unit/test_server_main.py
@@ -18,7 +18,11 @@ def test_server_main_runs_mcp_stdio(monkeypatch):
     cfg = types.SimpleNamespace(
         host="10.0.0.1",
         username="admin",
+        password="",
+        port=22,
         key_filename=None,
+        inventory=[],
+        inventory_file=None,
         mcp=types.SimpleNamespace(host="127.0.0.1", port=8123, transport="stdio",
                                   allowed_hosts="", allowed_origins=""),
     )
@@ -46,7 +50,11 @@ def test_server_main_passes_http_options_to_run(monkeypatch):
     cfg = types.SimpleNamespace(
         host="10.0.0.1",
         username="admin",
+        password="",
+        port=22,
         key_filename=None,
+        inventory=[],
+        inventory_file=None,
         mcp=types.SimpleNamespace(host="0.0.0.0", port=8123, transport="streamable-http",
                                   allowed_hosts="mcp.example.com", allowed_origins=""),
     )
@@ -76,7 +84,11 @@ def test_server_main_exits_on_exception(monkeypatch):
     cfg = types.SimpleNamespace(
         host="10.0.0.1",
         username="admin",
+        password="",
+        port=22,
         key_filename=None,
+        inventory=[],
+        inventory_file=None,
         mcp=types.SimpleNamespace(host="127.0.0.1", port=8123, transport="stdio"),
     )
 
@@ -226,7 +238,11 @@ def test_server_main_handles_keyboard_interrupt(monkeypatch):
     cfg = types.SimpleNamespace(
         host="10.0.0.1",
         username="admin",
+        password="",
+        port=22,
         key_filename=None,
+        inventory=[],
+        inventory_file=None,
         mcp=types.SimpleNamespace(host="127.0.0.1", port=8123, transport="stdio"),
     )
 

--- a/tests/unit/test_server_main.py
+++ b/tests/unit/test_server_main.py
@@ -105,6 +105,67 @@ def test_server_main_exits_on_exception(monkeypatch):
     assert exc.value.code == 1
 
 
+def test_server_main_exits_cleanly_on_bad_inventory_file(monkeypatch, tmp_path, caplog):
+    """A broken inventory stops the server at startup: exit 1, run() never called."""
+    import logging
+
+    from mcp_mikrotik import server
+
+    calls = {"run": 0}
+
+    class FakeMcp:
+        def run(self, transport: str, **kwargs):
+            calls["run"] += 1
+
+    bad = tmp_path / "inventory.yaml"
+    bad.write_text(
+        "- title: core-nl\n  hostname: 10.0.0.1\n  password: FleetSecret9!\n",
+        encoding="utf-8",
+    )
+    cfg = types.SimpleNamespace(
+        host="10.0.0.1", username="admin", password="", port=22,
+        key_filename=None, inventory=[], inventory_file=str(bad),
+        mcp=types.SimpleNamespace(host="127.0.0.1", port=8123, transport="stdio",
+                                  allowed_hosts="", allowed_origins=""),
+    )
+    monkeypatch.setattr(server, "MikrotikConfig", lambda _cli_parse_args=True: cfg)
+    monkeypatch.setattr(server, "mcp", FakeMcp())
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(SystemExit) as exc:
+            server.main()
+
+    assert exc.value.code == 1
+    assert calls["run"] == 0, "the server must not start with a broken inventory"
+    assert "Invalid MikroTik inventory" in caplog.text
+    assert "FleetSecret9!" not in caplog.text
+
+
+def test_server_main_exits_cleanly_on_bad_inline_inventory(monkeypatch, caplog):
+    """Config-level validation errors get the clean message, not a traceback."""
+    import logging
+
+    from pydantic import ValidationError
+
+    from mcp_mikrotik import server
+    from mcp_mikrotik.config import MikrotikConfig
+
+    def bad_config(_cli_parse_args=True):
+        # A schema-invalid inline inventory raises at config construction.
+        return MikrotikConfig(inventory='[{title: A, password: Hunter22}]')
+
+    monkeypatch.setattr(server, "MikrotikConfig", bad_config)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(SystemExit) as exc:
+            server.main()
+
+    assert exc.value.code == 1
+    assert "Invalid MikroTik configuration" in caplog.text
+    assert "host" in caplog.text            # the missing field is named
+    assert "Hunter22" not in caplog.text    # the credential is not
+
+
 def test_credential_warning_emitted_in_container_with_password(monkeypatch):
     """Warning fires when a plaintext password is set inside a container."""
     from mcp_mikrotik.server import _warn_if_plaintext_password_in_container

--- a/tests/unit/test_ssh_client.py
+++ b/tests/unit/test_ssh_client.py
@@ -149,6 +149,34 @@ def test_ssh_client_connect_and_execute(monkeypatch):
     assert state["closed"] == 1
 
 
+def test_failed_connect_closes_the_half_open_client(monkeypatch):
+    """A rejected login must not leave paramiko's transport running."""
+    from mcp_mikrotik.mikrotik_ssh_client import MikroTikSSHClient
+    import mcp_mikrotik.mikrotik_ssh_client as mod
+
+    state = {"closed": 0}
+
+    class RejectingSSH:
+        def set_missing_host_key_policy(self, _policy):
+            pass
+
+        def connect(self, **kwargs):
+            raise mod.paramiko.AuthenticationException("bad password")
+
+        def close(self):
+            state["closed"] += 1
+
+    monkeypatch.setattr(mod.paramiko, "SSHClient", lambda: RejectingSSH())
+
+    client = MikroTikSSHClient(host="h", username="u", password="wrong", key_filename=None)
+    assert client.connect() is False
+    assert state["closed"] == 1
+    # and the object reports itself as unusable rather than half-connected
+    assert client.client is None
+    with pytest.raises(Exception, match="Not connected"):
+        client.execute_command("/system identity print")
+
+
 def test_ssh_client_returns_stderr_when_no_stdout(monkeypatch):
     from mcp_mikrotik.mikrotik_ssh_client import MikroTikSSHClient
     import mcp_mikrotik.mikrotik_ssh_client as mod


### PR DESCRIPTION
Closes #44

> Reimplemented from scratch on top of current `master`, replacing the earlier fleet approach. The previous version added four generic tools that executed **raw command strings**; this one makes the **existing 173 structured tools** device-aware, so the model never hand-writes RouterOS syntax.

## Architecture

```
Tools ──device title──► Connector ──resolve──► Inventory ──► SSH client ──► device
                                                   ▲
                                       MIKROTIK_INVENTORY (JSON)
```

**`Inventory`** (`src/mcp_mikrotik/inventory.py`) owns the device definitions and one `MikroTikSSHClient` per device, keyed by a unique `title`. Clients are created **lazily on first use** and reused; a dropped session is rebuilt transparently, so one unreachable device can neither block start-up nor wedge the others.

## Configuration

The inventory is written in **YAML** (JSON is a YAML subset, so JSON inventories keep
working). Two sources, inline winning over the file:

**A YAML file (recommended):**

```yaml
- title: TitleA
  host: 192.168.88.1
  username: admin
  password: change-me
  region: NL
  tags: [branch]

- title: TitleB
  host: 192.168.89.1
  username: admin
  key_filename: /config/keys/id_ed25519
```

```json
{ "env": { "MIKROTIK_INVENTORY_FILE": "/config/inventory.yaml" } }
```

**Or inline, without a file** � env values are single strings, so a nested JSON object
cannot appear under `env`; YAML flow syntax gives the same structure with no escaped
quotes:

```json
{ "env": { "MIKROTIK_INVENTORY": "[{title: TitleA, host: 192.168.88.1, username: admin, password: change-me}]" } }
```

Device fields: `title` (unique), `host`, `port`, `username`, `password`, `key_filename`, `tags`, `region`.

A broken inventory (missing file, bad YAML, invalid entry) stops the server **at startup**
with one clear message. Validation errors never echo the inventory back � a malformed
entry is reported by position and field name only, so a typo cannot leak a password into
a log or a tool result.

**Docker:** mount the YAML file into the image's `/config` and point
`MIKROTIK_INVENTORY_FILE` at it:

```bash
docker run --rm -i   -v "$PWD/inventory.yaml:/config/inventory.yaml:ro"   -e MIKROTIK_INVENTORY_FILE=/config/inventory.yaml   ghcr.io/jeff-nasseri/mikrotik-mcp:latest
```

The entrypoint fails fast with an explicit message on the two classic mount traps: a file
unreadable by uid 1000, and a host file that did not exist so Docker created a directory
in its place.

## Selection rules

| Inventory | `device` argument | Behaviour |
|---|---|---|
| one device | omitted | that device is used |
| many | omitted | **error listing the available titles** |
| any | unknown title | **error listing the available titles** |
| any | valid title | routed to that device (case-insensitive) |

The connector resolves the target **before** executing, so a wrong or missing device fails loudly instead of silently running on another router.

## Tools

- **`list_devices`** — the LLM discovers the fleet (title, host, port, user, tags, region). **Credentials are never returned.**
- All **173** other tools gained an optional `device` argument.

## Safe mode is now per device

`safe_mode` was a module-level singleton bound to a single shell. With a fleet, enabling it on one router would have routed *every* device's commands into that router's session — a wrong-router write reported as success. It is now one manager per device.

## Two-router test environment

`routeros-docker/docker-compose.yml` now starts **two** RouterOS instances:

| Container | SSH |
|---|---|
| `routeros-a` | `127.0.0.1:2222` |
| `routeros-b` | `127.0.0.1:2223` |

## Connections are per command

`Inventory` originally pooled one `MikroTikSSHClient` per device. Because `get_inventory()`
is a module-level singleton, **every MCP session in the process shared one client per
device** � and therefore shared its fate: a disconnect, timeout or dropped transport in one
session broke a command another session was running. The stale-client rebuild path called
`disconnect()` on that shared object while another thread could be mid-command, and a single
inventory-wide lock was held across a full 10s SSH handshake, so one unreachable device
blocked every session from acquiring any client.

Pooling is removed. `Inventory.connect()` builds a new client per call and
`Inventory.session()` is a contextmanager that closes it in a `finally`, so a failing command
cannot leak a session on the router. The connector wraps every command and file transfer in
one. The `Inventory` now holds **no connection state at all**, which is what makes sharing
the instance safe.

Also fixed: a rejected login left paramiko's transport running while
`MikroTikSSHClient.connect()` swallowed the exception and returned `False`, leaking a thread
and a socket that paramiko's own strong reference kept alive. Pre-existing and unaffected by
the pooling removal, but per-command connections make that path routine.

The trade-off is one SSH handshake per command � tens of milliseconds on a LAN, more on a
distant or loaded device.

> Safe mode still holds one persistent shell per device, deliberately: RouterOS safe mode is
> a transaction on one device-side session. Routing a second session's write outside that
> shell would make it non-revertible while the operator believes the router is protected.

## Verification

**133 unit tests pass** (device routing, per-command connection lifecycle, YAML/JSON inventory parsing, credential-safe validation errors, safe-mode console bring-up and per-device resolution).

**`tests/smoke_multi_device.py` — 16/16 against both live containers**, including decisive proof that a call lands on the named device:

```
RouterA → # system id = cW+yPDdE1WK    /system identity set name=RouterA-NL
RouterB → # system id = p9Urq9Hc7+L    /system identity set name=RouterB-DE
```

Distinct system IDs confirm the two calls reached genuinely different routers.

Session isolation is proved under real parallelism: each container has its own `ether2` MAC,
so a response identifies the box that produced it.

```
[PASS] the routers have distinct ether2 MACs (usable as a fingerprint)
[PASS] 12 concurrent calls each reached the right router
[PASS] no concurrent call errored
[PASS] 10 back-to-back commands all succeed (no session exhaustion)
```
 Also verified: `list_devices` lists both and leaks no credentials; omitting `device` with two devices errors listing the choices; an unknown device errors listing the choices; matching is case-insensitive.

## Backwards compatibility

With no inventory configured, a single-device inventory is synthesised from the existing `MIKROTIK_HOST` / `MIKROTIK_USERNAME` / … settings and `device` may be omitted everywhere — existing single-device deployments, the Docker image and the registry entry keep working unchanged.

Docs: `docs/reference/inventory/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

