### PR TITLE
fix(versioning): use stable tags and bump next-version to 0.7.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -178,11 +178,12 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          # Tag uses semVer (3-part: v0.5.1) so GitVersion can parse it as a
-          # version source on the next run.  The PyPI package uses assemblySemVer
-          # (4-part: 0.5.1.0) which is a different value — both are exposed as
-          # separate outputs from the version job.
-          TAG="v${{ needs.version.outputs.semVer }}"
+          # Use majorMinorPatch (e.g. v0.7.0) — NOT semVer (e.g. v0.7.0-12).
+          # A stable tag is required so GitVersion treats it as a version source
+          # on the next run and correctly increments on the next feat:/fix: commit.
+          # Using a pre-release tag caused GitVersion to lock onto the same
+          # major.minor.patch indefinitely, regardless of commit type.
+          TAG="v${{ needs.version.outputs.majorMinorPatch }}"
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "Tag $TAG already exists — skipping."
           else
@@ -193,15 +194,15 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ needs.version.outputs.semVer }}
-          name: Release v${{ needs.version.outputs.semVer }}
+          tag_name: v${{ needs.version.outputs.majorMinorPatch }}
+          name: Release v${{ needs.version.outputs.majorMinorPatch }}
           body: |
-            ## Changes in v${{ needs.version.outputs.semVer }}
+            ## Changes in v${{ needs.version.outputs.majorMinorPatch }}
 
             This release was automatically created by GitHub Actions.
 
             **PyPI package version:** ${{ needs.version.outputs.version }}
-            **SemVer (git tag):** v${{ needs.version.outputs.semVer }}
+            **Git tag:** v${{ needs.version.outputs.majorMinorPatch }}
             **Commit:** ${{ github.sha }}
           draft: false
           prerelease: false

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -15,7 +15,7 @@
 #   +semver: breaking  (footer)        → Major bump  (EMERGENCY — major frozen at 0)
 
 mode: ContinuousDelivery
-next-version: 0.5.0
+next-version: 0.7.0
 
 # Parse every commit on HEAD→version-source; the highest matching rule wins.
 commit-message-incrementing: Enabled


### PR DESCRIPTION
## Root cause

Every master push was tagged with `semVer` output from GitVersion (e.g. `v0.6.0-12` — a **pre-release** tag). On the next CI run, GitVersion picked that pre-release tag as the version source and computed _"still heading towards 0.6.0"_ for every commit, regardless of whether it was a `feat:` or `fix:`. The minor version could never increment.

## Fixes

### 1. `GitVersion.yml` — raise `next-version` to `0.7.0`
Sets the version floor above all existing `v0.6.0-*` pre-release tags so this CI run immediately computes `0.7.0`.

### 2. `publish.yml` — tag with `majorMinorPatch` instead of `semVer`
| | Before | After |
|---|---|---|
| Tag created | `v0.6.0-12` (pre-release) | `v0.7.0` (stable) |
| Next run sees | "still 0.6.0 series" | proper version source |
| Next `feat:` bumps to | never | `0.8.0` ✓ |
| Next `fix:` bumps to | never | `0.7.1` ✓ |

## Expected result after merge
- GitVersion computes `0.7.0` (next-version floor wins over `v0.6.0-12`)
- PyPI publishes `0.7.0.0`
- CI tags the commit `v0.7.0` (stable)
- Future `feat:` → `0.8.0`, `fix:` → `0.7.1` — working correctly going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)