### PR TITLE
fix(ci): expose majorMinorPatch from version job outputs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,7 @@ jobs:
     outputs:
       version: ${{ steps.gitversion.outputs.assemblySemVer }}
       semVer: ${{ steps.gitversion.outputs.semVer }}
+      majorMinorPatch: ${{ steps.gitversion.outputs.majorMinorPatch }}
       should_publish: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}
     steps:
       - name: Checkout


### PR DESCRIPTION
## Root cause

PR #60 switched the git tag from `semVer` (`v0.7.0-2`) to `majorMinorPatch` (`v0.7.0`) so GitVersion gets a stable version source on every run. But `majorMinorPatch` was **never added to the `version` job `outputs:` block**.

GitHub Actions silently resolves undeclared downstream outputs to an empty string, so:

```bash
TAG="v${{ needs.version.outputs.majorMinorPatch }}"
# → TAG="v"  (empty string)
```

A bare `v` tag already exists in the repo, so every push to master failed:

```
! [rejected]  v -> v (already exists)
error: failed to push some refs
```

## Consequence of the bug

Because no stable `v0.7.0` tag was ever created:
- GitVersion had no stable version source → kept computing `0.7.0.0` on every run
- PyPI received a duplicate `0.7.0.0` upload → rejected (run [26402210638](https://github.com/jeff-nasseri/mikrotik-mcp/actions/runs/26402210638))
- The release pipeline failed on every merge

## Fix

Add one line to the `version` job `outputs:` block:

```yaml
majorMinorPatch: ${{ steps.gitversion.outputs.majorMinorPatch }}
```

## What happens after merging

| Run | GitVersion | PyPI | Git tag |
|-----|-----------|------|---------|
| This PR merges | `0.7.0.0` | skip-existing (already there) | **`v0.7.0` created** ✓ |
| Next `fix:` PR | `0.7.1.0` | published | `v0.7.1` created ✓ |
| Next `feat:` PR | `0.8.0.0` | published | `v0.8.0` created ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)