### PR TITLE
fix(package): expose __version__ via importlib.metadata

### DIFF
--- a/src/mcp_mikrotik/__init__.py
+++ b/src/mcp_mikrotik/__init__.py
@@ -1,0 +1,6 @@
+try:
+    from importlib.metadata import version, PackageNotFoundError
+
+    __version__ = version("mcp-server-mikrotik")
+except PackageNotFoundError:
+    __version__ = "0.0.0"  # fallback when running from source without install


### PR DESCRIPTION
## What & Why

Packages should expose a `__version__` attribute so callers and tooling can check the running version at runtime:

```python
from mcp_mikrotik import __version__
print(__version__)  # "0.7.1.0"
```

Uses `importlib.metadata` (stdlib since Python 3.8, no extra dependency) with a `"0.0.0"` fallback for running from source without installation.

## Version bump expected

This PR uses a `fix:` commit prefix → patch bump: **`0.7.0` → `0.7.1`**

| Before | After |
|--------|-------|
| `v0.7.0` | `v0.7.1` |
| PyPI `0.7.0.0` | PyPI `0.7.1.0` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)