### PR TITLE
feat: automate MCP registry publish in CI pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -163,6 +163,39 @@ jobs:
           print-hash: true
           skip-existing: true
 
+  publish-mcp-registry:
+    runs-on: ubuntu-latest
+    needs: [version, publish]
+    # Only run when PyPI publish actually succeeded (not skipped or failed).
+    if: needs.version.outputs.should_publish == 'true' && needs.publish.result == 'success'
+    permissions:
+      id-token: write   # required for GitHub OIDC authentication
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download mcp-publisher
+        run: |
+          curl -fsSL -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz"
+          tar xf mcp-publisher.tar.gz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Update server.json version
+        run: |
+          VERSION="${{ needs.version.outputs.version }}"
+          # Update both the top-level "version" and the package-level "version" fields.
+          sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/g" server.json
+          echo "server.json version set to $VERSION"
+          cat server.json
+
+      - name: Authenticate with MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish
+
   create-release:
     runs-on: ubuntu-latest
     needs: [version, build, publish]


### PR DESCRIPTION
## Summary

- Adds a `publish-mcp-registry` job to the existing `publish.yml` pipeline
- Runs automatically after every successful PyPI publish (master push)
- Uses **GitHub OIDC** (`mcp-publisher login github-oidc`) — no secrets or personal tokens required
- Dynamically patches `server.json` version to match the built PyPI version before publishing

## How it works

```
version → build → test → publish (PyPI) → publish-mcp-registry
                                         ↓
                       registry.modelcontextprotocol.io
```

1. Downloads the `mcp-publisher` Go binary from GitHub Releases
2. Updates `server.json` with the current build version
3. Authenticates via GitHub OIDC (namespace `io.github.jeff-nasseri` is verified against the repo owner)
4. Publishes to the MCP registry

## Test plan
- [ ] Merge this PR → CI should run the new `publish-mcp-registry` job
- [ ] Check job logs confirm `✓ Successfully published`
- [ ] Verify at `https://registry.modelcontextprotocol.io/v0.1/servers/io.github.jeff-nasseri%2Fmikrotik-mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)