### PR TITLE
docs: add MCP registry install method to installation guide

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,5 +1,19 @@
 # Installation
 
+## MCP Registry (Recommended)
+
+MikroTik MCP is listed on the [MCP Registry](https://registry.modelcontextprotocol.io) — a community-driven catalog of MCP servers. Registry-aware clients (Claude Desktop, VS Code, Cursor) can install it in one command without manual config file editing.
+
+```bash
+claude mcp add io.github.jeff-nasseri/mikrotik-mcp
+```
+
+The client fetches the server metadata from the registry, installs `mcp-server-mikrotik` from PyPI, and prompts you for the required environment variables (`MIKROTIK_HOST`, `MIKROTIK_USERNAME`, `MIKROTIK_PASSWORD`).
+
+> **PyPI install only:** If your client does not support registry-based install, use one of the manual methods below.
+
+---
+
 ## Prerequisites
 - Python 3.8+
 - MikroTik RouterOS device with API access enabled


### PR DESCRIPTION
## Summary

- Adds a new **MCP Registry (Recommended)** section at the top of the installation page
- Documents `claude mcp add io.github.jeff-nasseri/mikrotik-mcp` as the easiest install path
- Brief note on what the registry does and which clients support it
- Existing manual and Docker install sections are unchanged, kept below for clients that don't support registry-based install

## Preview

```
## MCP Registry (Recommended)

MikroTik MCP is listed on the MCP Registry — a community-driven catalog of MCP servers.
Registry-aware clients (Claude Desktop, VS Code, Cursor) can install it in one command:

    claude mcp add io.github.jeff-nasseri/mikrotik-mcp
```

> This is a `docs:` commit — no version bump, no PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)