### PR TITLE
feat(interfaces): add list/get/enable/disable for all interface types

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -4,6 +4,7 @@ Complete reference documentation for all MikroTik MCP tools.
 
 ## Available Tool Categories
 
+- **[Interfaces](interfaces/README.md)** - All Interface Management (ethernet, bridge, PPPoE, SFP, LTE …)
 - **[VLAN](vlan/README.md)** - VLAN Interface Management
 - **[IP Address](ip-address/README.md)** - IP Address Management
 - **[DHCP](dhcp/README.md)** - DHCP Server Management

--- a/docs/reference/interfaces/README.md
+++ b/docs/reference/interfaces/README.md
@@ -1,0 +1,62 @@
+# Interface Management
+
+Tools for listing and managing **all** interfaces on a MikroTik device — ethernet, bridge, WireGuard, PPPoE, VLAN, WiFi, SFP, LTE, loopback, and any other type. This is the equivalent of `/interface print` in RouterOS.
+
+> For type-specific management (create, remove, update) use the dedicated tool categories:
+> [VLAN](../vlan/README.md) · [WireGuard](../wireguard/README.md) · [Wireless](../../integrations/README.md)
+
+## `list_interfaces`
+
+Lists all interfaces on the device, with optional filtering.
+
+- Parameters:
+  - `type_filter` (optional): Filter by interface type — `"ether"`, `"bridge"`, `"vlan"`, `"wg"`, `"pppoe-out"`, `"wifi"`, `"lte"`, `"loopback"`, etc.
+  - `name_filter` (optional): Partial name match e.g. `"ether"` matches `ether1`, `ether2` …
+  - `running_only` (optional): Return only currently running interfaces
+  - `disabled_only` (optional): Return only disabled interfaces
+
+- Examples:
+  ```
+  list_interfaces()                              # all interfaces
+  list_interfaces(type_filter="ether")           # ethernet ports only
+  list_interfaces(type_filter="bridge")          # bridge interfaces only
+  list_interfaces(running_only=True)             # only interfaces that are up
+  list_interfaces(name_filter="ether")           # any interface whose name contains "ether"
+  ```
+
+## `get_interface`
+
+Gets detailed information about a single interface by exact name.
+
+- Parameters:
+  - `name` (required): Exact interface name e.g. `"ether1"`, `"bridge"`, `"pppoe-out1"`, `"wg0"`
+
+- Example:
+  ```
+  get_interface(name="ether1-wan")
+  get_interface(name="pppoe-out1")
+  ```
+
+## `enable_interface`
+
+Enables a disabled interface.
+
+- Parameters:
+  - `name` (required): Exact interface name
+
+- Example:
+  ```
+  enable_interface(name="ether4")
+  ```
+
+## `disable_interface`
+
+Disables an interface (takes it down without removing it).
+
+- Parameters:
+  - `name` (required): Exact interface name
+
+- Example:
+  ```
+  disable_interface(name="ether4")
+  ```

--- a/src/mcp_mikrotik/app.py
+++ b/src/mcp_mikrotik/app.py
@@ -47,5 +47,5 @@ async def health_check(request: Request) -> Response:
 # Import scope modules to trigger @mcp.tool() registration
 from mcp_mikrotik.scope import (  # noqa: F401, E402
     backup, dhcp, dns, firewall_filter, firewall_nat,
-    ip_address, ip_pool, logs, queue, safe_mode, routes, users, vlan, wireless, wireguard,
+    interfaces, ip_address, ip_pool, logs, queue, safe_mode, routes, users, vlan, wireless, wireguard,
 )

--- a/src/mcp_mikrotik/scope/interfaces.py
+++ b/src/mcp_mikrotik/scope/interfaces.py
@@ -1,0 +1,116 @@
+from typing import Literal, Optional
+from ..connector import execute_mikrotik_command
+from mcp.server.fastmcp import Context
+from ..app import mcp, READ, WRITE_IDEMPOTENT, annotate
+
+
+@mcp.tool(name="list_interfaces", annotations=annotate(READ, "List Interfaces"))
+async def mikrotik_list_interfaces(
+    ctx: Context,
+    type_filter: Optional[Literal[
+        "ether", "wg", "bridge", "vlan", "pppoe-out", "pppoe-server",
+        "wifi", "wireless", "lte", "loopback", "sfp", "sfp-sfpplus"
+    ]] = None,
+    name_filter: Optional[str] = None,
+    running_only: bool = False,
+    disabled_only: bool = False,
+) -> str:
+    """Lists all interfaces on the MikroTik device (ethernet, bridge, WireGuard,
+    PPPoE, VLAN, WiFi, SFP, LTE, loopback, and any other type).
+
+    Notes:
+        type_filter: RouterOS interface type e.g. "ether", "bridge", "vlan",
+            "wg", "pppoe-out", "wifi", "lte", "loopback"
+        name_filter: partial name match e.g. "ether" matches ether1, ether2 …
+    """
+    await ctx.info("Listing all interfaces")
+
+    cmd = "/interface print"
+
+    filters = []
+    if type_filter:
+        filters.append(f'type="{type_filter}"')
+    if name_filter:
+        filters.append(f'name~"{name_filter}"')
+    if running_only:
+        filters.append("running=yes")
+    if disabled_only:
+        filters.append("disabled=yes")
+
+    if filters:
+        cmd += " where " + " ".join(filters)
+
+    result = await execute_mikrotik_command(cmd, ctx)
+
+    if not result or result.strip() == "":
+        return "No interfaces found matching the criteria."
+
+    return f"INTERFACES:\n\n{result}"
+
+
+@mcp.tool(name="get_interface", annotations=annotate(READ, "Get Interface"))
+async def mikrotik_get_interface(ctx: Context, name: str) -> str:
+    """Gets detailed information about a specific interface by name.
+
+    Notes:
+        name: exact interface name e.g. "ether1", "bridge", "pppoe-out1", "wg0"
+    """
+    await ctx.info(f"Getting interface details: name={name}")
+
+    cmd = f'/interface print detail where name="{name}"'
+    result = await execute_mikrotik_command(cmd, ctx)
+
+    if not result or result.strip() == "":
+        return f"Interface '{name}' not found."
+
+    return f"INTERFACE DETAILS:\n\n{result}"
+
+
+@mcp.tool(name="enable_interface", annotations=annotate(WRITE_IDEMPOTENT, "Enable Interface"))
+async def mikrotik_enable_interface(ctx: Context, name: str) -> str:
+    """Enables an interface on the MikroTik device.
+
+    Notes:
+        name: exact interface name e.g. "ether1", "bridge", "pppoe-out1"
+    """
+    await ctx.info(f"Enabling interface: name={name}")
+
+    cmd = f'/interface enable [find name="{name}"]'
+    result = await execute_mikrotik_command(cmd, ctx)
+
+    if "failure:" in result.lower() or "error" in result.lower():
+        return f"Failed to enable interface '{name}': {result}"
+
+    # Verify the change
+    check_cmd = f'/interface print detail where name="{name}"'
+    details = await execute_mikrotik_command(check_cmd, ctx)
+
+    if not details.strip():
+        return f"Interface '{name}' not found."
+
+    return f"Interface '{name}' enabled successfully:\n\n{details}"
+
+
+@mcp.tool(name="disable_interface", annotations=annotate(WRITE_IDEMPOTENT, "Disable Interface"))
+async def mikrotik_disable_interface(ctx: Context, name: str) -> str:
+    """Disables an interface on the MikroTik device.
+
+    Notes:
+        name: exact interface name e.g. "ether1", "bridge", "pppoe-out1"
+    """
+    await ctx.info(f"Disabling interface: name={name}")
+
+    cmd = f'/interface disable [find name="{name}"]'
+    result = await execute_mikrotik_command(cmd, ctx)
+
+    if "failure:" in result.lower() or "error" in result.lower():
+        return f"Failed to disable interface '{name}': {result}"
+
+    # Verify the change
+    check_cmd = f'/interface print detail where name="{name}"'
+    details = await execute_mikrotik_command(check_cmd, ctx)
+
+    if not details.strip():
+        return f"Interface '{name}' not found."
+
+    return f"Interface '{name}' disabled successfully:\n\n{details}"


### PR DESCRIPTION
Closes #66

## Problem

MikroTik MCP had no way to list physical/logical interfaces (ethernet, bridge, PPPoE, SFP, LTE, loopback). The existing tools only covered typed subpaths (`/interface vlan print`, `/interface wireguard print`, `/interface wireless print`), leaving the most common interfaces completely inaccessible.

## Solution

New `interfaces.py` scope backed by RouterOS `/interface print` — the master interface list covering **all** types:

| Tool | RouterOS command |
|---|---|
| `list_interfaces` | `/interface print [where ...]` |
| `get_interface` | `/interface print detail where name=X` |
| `enable_interface` | `/interface enable [find name=X]` |
| `disable_interface` | `/interface disable [find name=X]` |

`list_interfaces` supports four optional filters: `type_filter`, `name_filter`, `running_only`, `disabled_only`.

## Docs

- Added `docs/reference/interfaces/README.md`
- Added **Interfaces** entry to `docs/reference/README.md`

## Test plan
- [ ] All 45 unit tests pass ✅
- [ ] `list_interfaces()` returns all interface types including ethernet
- [ ] `list_interfaces(type_filter="ether")` returns only ethernet ports
- [ ] `list_interfaces(running_only=True)` returns only running interfaces
- [ ] `get_interface(name="ether1")` returns detail for a single interface
- [ ] `enable_interface` / `disable_interface` toggle correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)