### PR TITLE
docs: add mikrotik-mcp.com website link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/jeff-nasseri-mikrotik-mcp-badge.png)](https://mseep.ai/app/jeff-nasseri-mikrotik-mcp)
 
+[![Website](https://img.shields.io/badge/website-mikrotik--mcp.com-007ACC?style=flat-square&logo=googlechrome&logoColor=white)](https://www.mikrotik-mcp.com/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/jeff-nasseri/mikrotik-mcp/publish.yml?branch=master&label=build&style=flat-square&color=%23007ACC)](https://github.com/jeff-nasseri/mikrotik-mcp/actions/workflows/publish.yml)
 [![Tests](https://img.shields.io/github/actions/workflow/status/jeff-nasseri/mikrotik-mcp/publish.yml?branch=master&label=tests&style=flat-square&color=%2300C853)](https://github.com/jeff-nasseri/mikrotik-mcp/actions/workflows/publish.yml)
 [![MIT License](https://img.shields.io/github/license/jeff-nasseri/mikrotik-mcp?style=flat-square&color=%23FF6B35)](https://github.com/jeff-nasseri/mikrotik-mcp/blob/master/LICENSE)
@@ -27,6 +28,8 @@ https://github.com/user-attachments/assets/e0301ff2-8144-4503-83d0-48589d95027d
 ## Documentation
 
 📚 **[Full Documentation](docs/README.md)** - Complete guides, API reference, and examples
+
+> 🌐 **Prefer to read online?** The same documentation is also published at **[www.mikrotik-mcp.com](https://www.mikrotik-mcp.com/)** ([docs](https://www.mikrotik-mcp.com/docs/)) — an optional, web-friendly way to explore the project while reviewing the repo.
 
 ### Quick Links
 


### PR DESCRIPTION
## Summary

The project now has a live website at **https://www.mikrotik-mcp.com/**. This PR surfaces it in the root README:

- **Website badge** — added to the badge cluster, styled to match the existing shields.io `flat-square` badges and the brand blue (`#007ACC`).
- **Optional online docs note** — a short callout in the `## Documentation` section pointing reviewers to the hosted docs at https://www.mikrotik-mcp.com/docs/ as a web-friendly alternative to the in-repo markdown. Framed as optional, so the in-repo docs remain the source of truth.

Docs-only change — no code touched.

## Test plan

- [ ] Badge renders and links to https://www.mikrotik-mcp.com/
- [ ] Documentation callout renders as a blockquote and both links resolve (site root + `/docs/`)
- [ ] Existing badges and Quick Links are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)