### PR TITLE
docs: fix incorrect clone URL and directory in install steps

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -23,8 +23,8 @@ The client fetches the server metadata from the registry, installs `mcp-server-m
 
 ```bash
 # Clone the repository
-git clone https://github.com/jeff-nasseri/mikrotik-mcp/tree/master
-cd mcp-mikrotik
+git clone https://github.com/jeff-nasseri/mikrotik-mcp.git
+cd mikrotik-mcp
 
 # Create virtual environment
 python -m venv .venv


### PR DESCRIPTION
Closes #79

## Problem

The **Manual Installation** quick-start in `docs/getting-started/installation.md` had two mistakes in the clone steps:

1. **Non-clonable URL** — `https://github.com/jeff-nasseri/mikrotik-mcp/tree/master` is a GitHub *web* URL (the `/tree/master` path), not something `git clone` can use.
2. **Wrong directory** — `cd mcp-mikrotik` doesn't match the cloned folder. Cloning `mikrotik-mcp` creates a `mikrotik-mcp/` directory.

## Fix

```diff
-git clone https://github.com/jeff-nasseri/mikrotik-mcp/tree/master
-cd mcp-mikrotik
+git clone https://github.com/jeff-nasseri/mikrotik-mcp.git
+cd mikrotik-mcp
```

This now matches the correct (already-working) clone steps used in the **Docker Installation** section further down the same page.

> `docs:` commit — CI runs but no version bump / PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)