### PR TITLE
feat(security): command-injection protection + per-field input allowlists

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,11 +42,18 @@ MikroTik MCP uses SSH to connect to RouterOS devices. Be aware of the following:
   - Consider using SSH key-based authentication instead of passwords
   - Use SSH keys with passphrases for additional security
 
-### 2. Command Injection Risks
+### 2. Command Injection & Input Validation
 
 - The server executes SSH commands on MikroTik devices based on tool inputs
-- Always validate and sanitize inputs before passing them to MikroTik commands
-- Avoid constructing commands using unsanitized user input
+- **Built-in protection (zero dependencies, always active):** two layers block
+  injection without any configuration:
+  1. **Structural check** — rejects `;`, backtick, `{}`, and newlines from
+     the final command string, blocking the canonical breakout payloads
+  2. **Per-field allowlist** — each user-supplied string is validated against
+     a tight character allowlist matched to its RouterOS field type (interface
+     names, IPs, bandwidth strings, comments, …) before the command is built
+- See [docs/security/input-validation.md](docs/security/input-validation.md)
+  for the full field-type reference
 - Be cautious when using this server in environments where untrusted users have access
 
 ### 3. Access Control

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,10 @@ Complete tool documentation organized by category:
 
 - **[Usage Examples](examples/usage-examples.md)** - Complete mcp-cli usage examples
 
+## Security
+
+- **[Input Validation](security/input-validation.md)** - Command injection prevention and per-field allowlists
+
 ## Contributing
 
 - **[Contributing Guide](contributing.md)** - Learn how to contribute

--- a/docs/security/input-validation.md
+++ b/docs/security/input-validation.md
@@ -1,0 +1,83 @@
+# Input Validation & Command Injection Protection
+
+MikroTik MCP implements two zero-dependency layers of protection against
+injection attacks (issue [#53](https://github.com/jeff-nasseri/mikrotik-mcp/issues/53)).
+
+---
+
+## Layer 1 — Structural command-injection check
+
+Every assembled RouterOS command is validated by `check_command_safety()`
+immediately before it is sent over SSH. Characters that **never appear in a
+legitimate command** but are the classic building blocks of injection are rejected:
+
+| Blocked | Reason |
+|---------|--------|
+| `;` | command separator — `name="x" ; /system reboot` |
+| `` ` `` | backtick sub-command |
+| `{` `}` | script block delimiters |
+| `\n` `\r` | line break — splits one command into two |
+
+`[` and `]` are intentionally **allowed** — the RouterOS `[find ...]`
+sub-selector uses them legitimately.
+
+This layer blocks the exact payload from issue #53 — `foo"] ; /system reboot;`
+— by default, with no configuration required.
+
+---
+
+## Layer 2 — Per-field allowlist
+
+Each user-supplied string parameter is validated against a tight character
+allowlist matched to its RouterOS field type **before** the command is
+constructed. Rather than blocking a known-bad set, only a known-good set of
+characters is accepted — harder to bypass and gives clear error messages.
+
+### Field types
+
+| Field type | Accepted values | Example |
+|---|---|---|
+| `INTERFACE_NAME` | letters, digits, `.` `-` `_` (max 47) | `ether1-wan` |
+| `IP_ADDRESS` | dotted-decimal IPv4 | `192.168.1.1` |
+| `IP_CIDR` | IPv4 with optional `/prefix` | `192.168.1.0/24` |
+| `IP_RANGE` | `x.x.x.x-x.x.x.x` | `192.168.1.1-192.168.1.100` |
+| `IP_RANGES` | comma-separated ranges/CIDRs | `10.0.0.1-10.0.0.50,10.0.0.100-10.0.0.120` |
+| `HOSTNAME` | letters, digits, `.` `-` `_` (max 253) | `vpn.example.com` |
+| `MAC_ADDRESS` | `AA:BB:CC:DD:EE:FF` | `00:1A:2B:3C:4D:5E` |
+| `BANDWIDTH` | digits + `K`/`M`/`G`, optional `/down` | `10M/5M` |
+| `DURATION` | digits + `w`/`d`/`h`/`m`/`s` | `1h30m` |
+| `COMMENT` | printable ASCII (max 255 chars) | `office uplink` |
+| `ROUTEROS_ID` | optional `*` + digits | `*3` or `42` |
+| `PORT_SPEC` | single, range, or comma list | `80-443` |
+| `USERNAME` | letters, digits, `.` `-` `_` | `mcp-user` |
+| `WG_KEY` | 44-char base64 WireGuard key | `AAAA…=` |
+| `ADDRESS_LIST` | letters, digits, space, `.` `-` `_` | `my-blocked-list` |
+| `ROUTING_MARK` | letters, digits, `.` `-` `_` | `main` |
+| `LOG_PREFIX` | letters, digits, space, `:` `.` `-` | `fw-drop` |
+
+### How it works
+
+In each scope module, user-supplied string parameters are validated at the
+start of each tool function:
+
+```python
+from ..security import V, validate_field
+
+async def mikrotik_create_vlan_interface(ctx, name, vlan_id, interface, comment=None, ...):
+    validate_field(name,      V.INTERFACE_NAME, "name")
+    validate_field(interface, V.INTERFACE_NAME, "interface")
+    validate_field(comment,   V.COMMENT,        "comment")
+    # ... build command
+```
+
+`validate_field` is a no-op for `None` and empty strings (optional fields).
+It raises `SecurityError` (a `ValueError` subclass) when the value falls
+outside the allowed character set.
+
+---
+
+## No external dependencies
+
+Both layers are implemented in pure Python using only the standard `re`
+module. There is no ML model, no download, and no runtime overhead beyond a
+regex match per validated field.

--- a/src/mcp_mikrotik/connector.py
+++ b/src/mcp_mikrotik/connector.py
@@ -5,6 +5,7 @@ from mcp.server.fastmcp import Context
 
 from . import config
 from .mikrotik_ssh_client import MikroTikSSHClient
+from .security import SecurityError, check_command_safety
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +42,20 @@ async def execute_mikrotik_command(command: str, ctx: Context) -> str:
 
     When Safe Mode is active the command is routed through the persistent
     interactive shell session so it runs inside the safe-mode context.
+
+    The structural command-injection check (Layer 1) runs here immediately
+    before the command is sent to the device — blocking ; ` { } newlines.
+    Per-field allowlist validation (Layer 2) happens earlier in each scope
+    module via validate_field().
     """
+    try:
+        check_command_safety(command)
+    except SecurityError as exc:
+        msg = f"Security violation — command blocked: {exc}"
+        logger.warning(msg)
+        await ctx.error(msg)
+        return msg
+
     from .safe_mode import get_safe_mode_manager
 
     safe_mgr = get_safe_mode_manager()

--- a/src/mcp_mikrotik/scope/dhcp.py
+++ b/src/mcp_mikrotik/scope/dhcp.py
@@ -4,6 +4,7 @@ from mcp.server.fastmcp import Context
 
 from ..app import mcp, READ, WRITE, DESTRUCTIVE, annotate
 from ..connector import execute_mikrotik_command
+from ..security import SecurityError, V, validate_field
 
 
 @mcp.tool(name="create_dhcp_server", annotations=annotate(WRITE, "Create DHCP Server"))
@@ -23,6 +24,10 @@ async def mikrotik_create_dhcp_server(
     Notes:
         lease_time: duration e.g. "1d", "12h", "30m", "1h30m"
     """
+    validate_field(name, V.INTERFACE_NAME, "name")
+    validate_field(interface, V.INTERFACE_NAME, "interface")
+    validate_field(lease_time, V.DURATION, "lease_time")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Creating DHCP server: name={name}, interface={interface}")
 
     # Build the command
@@ -64,6 +69,8 @@ async def mikrotik_list_dhcp_servers(
     invalid_only: bool = False
 ) -> str:
     """Lists DHCP servers on the MikroTik device."""
+    validate_field(name_filter, V.INTERFACE_NAME, "name_filter")
+    validate_field(interface_filter, V.INTERFACE_NAME, "interface_filter")
     await ctx.info(f"Listing DHCP servers with filters: name={name_filter}, interface={interface_filter}")
 
     # Build the command
@@ -93,6 +100,7 @@ async def mikrotik_list_dhcp_servers(
 @mcp.tool(name="get_dhcp_server", annotations=annotate(READ, "Get DHCP Server"))
 async def mikrotik_get_dhcp_server(ctx: Context, name: str) -> str:
     """Gets detailed information about a specific DHCP server."""
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Getting DHCP server details: name={name}")
 
     cmd = f'/ip dhcp-server print detail where name="{name}"'
@@ -117,6 +125,9 @@ async def mikrotik_create_dhcp_network(
     comment: Optional[str] = None
 ) -> str:
     """Creates a DHCP network configuration (gateway, DNS, domain, etc.) on the MikroTik device."""
+    validate_field(network, V.IP_CIDR, "network")
+    validate_field(gateway, V.IP_CIDR, "gateway")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Creating DHCP network: network={network}, gateway={gateway}")
 
     # Build the command
@@ -169,6 +180,9 @@ async def mikrotik_create_dhcp_pool(
         ranges: hyphen-separated range(s) e.g. "192.168.1.1-192.168.1.100"
             Multiple ranges comma-separated: "10.0.0.1-10.0.0.50,10.0.0.100-10.0.0.120"
     """
+    validate_field(name, V.INTERFACE_NAME, "name")
+    validate_field(ranges, V.IP_RANGES, "ranges")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Creating DHCP pool: name={name}, ranges={ranges}")
 
     # Build the command
@@ -195,6 +209,7 @@ async def mikrotik_create_dhcp_pool(
 @mcp.tool(name="remove_dhcp_server", annotations=annotate(DESTRUCTIVE, "Remove DHCP Server"))
 async def mikrotik_remove_dhcp_server(ctx: Context, name: str) -> str:
     """Removes a DHCP server from the MikroTik device."""
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Removing DHCP server: name={name}")
 
     # First check if the server exists

--- a/src/mcp_mikrotik/scope/dns.py
+++ b/src/mcp_mikrotik/scope/dns.py
@@ -4,6 +4,7 @@ from mcp.server.fastmcp import Context
 
 from ..connector import execute_mikrotik_command
 from ..app import mcp, READ, WRITE, WRITE_IDEMPOTENT, DESTRUCTIVE, annotate
+from ..security import SecurityError, V, validate_field
 
 @mcp.tool(name="set_dns_servers", annotations=annotate(WRITE, "Set DNS Servers"))
 async def mikrotik_set_dns_servers(
@@ -19,6 +20,9 @@ async def mikrotik_set_dns_servers(
     verify_doh_cert: bool = True
 ) -> str:
     """Sets DNS server configuration."""
+    for s in servers:
+        validate_field(s, V.HOSTNAME, "servers")
+    validate_field(doh_server, V.HOSTNAME, "doh_server")
     await ctx.info(f"Setting DNS servers: {', '.join(servers)}")
 
     cmd = "/ip dns set servers=" + ",".join(servers)
@@ -85,6 +89,11 @@ async def mikrotik_add_dns_static(
     regexp: Optional[str] = None
 ) -> str:
     """Adds a static DNS entry."""
+    validate_field(name, V.HOSTNAME, "name")
+    validate_field(address, V.IP_CIDR, "address")
+    validate_field(cname, V.HOSTNAME, "cname")
+    validate_field(srv_target, V.HOSTNAME, "srv_target")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Adding static DNS entry: name={name}")
 
     cmd = f'/ip dns static add name="{name}"'
@@ -150,6 +159,8 @@ async def mikrotik_list_dns_static(
     regexp_only: bool = False
 ) -> str:
     """Lists static DNS entries."""
+    validate_field(name_filter, V.HOSTNAME, "name_filter")
+    validate_field(address_filter, V.IP_CIDR, "address_filter")
     await ctx.info(f"Listing static DNS entries with filters: name={name_filter}")
 
     cmd = "/ip dns static print"
@@ -179,6 +190,7 @@ async def mikrotik_list_dns_static(
 @mcp.tool(name="get_dns_static", annotations=annotate(READ, "Get DNS Static Entry"))
 async def mikrotik_get_dns_static(ctx: Context, entry_id: str) -> str:
     """Gets details of a specific static DNS entry."""
+    validate_field(entry_id, V.ROUTEROS_ID, "entry_id")
     await ctx.info(f"Getting static DNS entry details: entry_id={entry_id}")
 
     cmd = f"/ip dns static print detail where .id={entry_id}"
@@ -209,6 +221,15 @@ async def mikrotik_update_dns_static(
     regexp: Optional[str] = None
 ) -> str:
     """Updates a static DNS entry."""
+    validate_field(entry_id, V.ROUTEROS_ID, "entry_id")
+    validate_field(name, V.HOSTNAME, "name")
+    if address:
+        validate_field(address, V.IP_CIDR, "address")
+    if cname:
+        validate_field(cname, V.HOSTNAME, "cname")
+    if srv_target:
+        validate_field(srv_target, V.HOSTNAME, "srv_target")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Updating static DNS entry: entry_id={entry_id}")
 
     cmd = f"/ip dns static set {entry_id}"
@@ -282,6 +303,7 @@ async def mikrotik_update_dns_static(
 @mcp.tool(name="remove_dns_static", annotations=annotate(DESTRUCTIVE, "Remove DNS Static Entry"))
 async def mikrotik_remove_dns_static(ctx: Context, entry_id: str) -> str:
     """Removes a static DNS entry."""
+    validate_field(entry_id, V.ROUTEROS_ID, "entry_id")
     await ctx.info(f"Removing static DNS entry: entry_id={entry_id}")
 
     check_cmd = f"/ip dns static print count-only where .id={entry_id}"
@@ -377,6 +399,8 @@ async def mikrotik_test_dns_query(
     type: str = "A"
 ) -> str:
     """Tests a DNS query."""
+    validate_field(name, V.HOSTNAME, "name")
+    validate_field(server, V.HOSTNAME, "server")
     await ctx.info(f"Testing DNS query: name={name}, type={type}")
 
     cmd = f"/resolve {name}"

--- a/src/mcp_mikrotik/scope/firewall_filter.py
+++ b/src/mcp_mikrotik/scope/firewall_filter.py
@@ -2,6 +2,7 @@ from typing import Literal, Optional, List
 from mcp.server.fastmcp import Context
 from ..app import mcp, READ, WRITE, WRITE_IDEMPOTENT, DESTRUCTIVE, DANGEROUS, annotate
 from ..connector import execute_mikrotik_command
+from ..security import SecurityError, V, validate_field
 
 @mcp.tool(name="create_filter_rule", annotations=annotate(WRITE, "Create Firewall Filter Rule"))
 async def mikrotik_create_filter_rule(
@@ -35,6 +36,16 @@ async def mikrotik_create_filter_rule(
         tcp_flags: RouterOS flag expression e.g. "syn,!ack"
         place_before: rule number or ID (*N) to insert before e.g. "0" or "*3"
     """
+    validate_field(src_address, V.IP_CIDR, "src_address")
+    validate_field(dst_address, V.IP_CIDR, "dst_address")
+    validate_field(src_port, V.PORT_SPEC, "src_port")
+    validate_field(dst_port, V.PORT_SPEC, "dst_port")
+    validate_field(in_interface, V.INTERFACE_NAME, "in_interface")
+    validate_field(out_interface, V.INTERFACE_NAME, "out_interface")
+    validate_field(src_address_list, V.ADDRESS_LIST, "src_address_list")
+    validate_field(dst_address_list, V.ADDRESS_LIST, "dst_address_list")
+    validate_field(comment, V.COMMENT, "comment")
+    validate_field(log_prefix, V.LOG_PREFIX, "log_prefix")
     await ctx.info(f"Creating firewall filter rule: chain={chain}, action={action}")
 
     # Build the command
@@ -139,6 +150,9 @@ async def mikrotik_list_filter_rules(
     dynamic_only: bool = False
 ) -> str:
     """Lists firewall filter rules on the MikroTik device."""
+    validate_field(src_address_filter, V.IP_CIDR, "src_address_filter")
+    validate_field(dst_address_filter, V.IP_CIDR, "dst_address_filter")
+    validate_field(interface_filter, V.INTERFACE_NAME, "interface_filter")
     await ctx.info(f"Listing firewall filter rules with filters: chain={chain_filter}, action={action_filter}")
 
     # Build the command
@@ -183,6 +197,7 @@ async def mikrotik_get_filter_rule(ctx: Context, rule_id: str) -> str:
     Notes:
         rule_id: use the ID from list output e.g. "*1" or "0"
     """
+    validate_field(rule_id, V.ROUTEROS_ID, "rule_id")
     await ctx.info(f"Getting firewall filter rule details: rule_id={rule_id}")
 
     cmd = f"/ip firewall filter print detail where .id={rule_id}"
@@ -226,6 +241,26 @@ async def mikrotik_update_filter_rule(
         tcp_flags: RouterOS flag expression e.g. "syn,!ack"
         Pass "" to clear an optional field (e.g. src_address="").
     """
+    validate_field(rule_id, V.ROUTEROS_ID, "rule_id")
+    if src_address:
+        validate_field(src_address, V.IP_CIDR, "src_address")
+    if dst_address:
+        validate_field(dst_address, V.IP_CIDR, "dst_address")
+    if src_port:
+        validate_field(src_port, V.PORT_SPEC, "src_port")
+    if dst_port:
+        validate_field(dst_port, V.PORT_SPEC, "dst_port")
+    if in_interface:
+        validate_field(in_interface, V.INTERFACE_NAME, "in_interface")
+    if out_interface:
+        validate_field(out_interface, V.INTERFACE_NAME, "out_interface")
+    if src_address_list:
+        validate_field(src_address_list, V.ADDRESS_LIST, "src_address_list")
+    if dst_address_list:
+        validate_field(dst_address_list, V.ADDRESS_LIST, "dst_address_list")
+    validate_field(comment, V.COMMENT, "comment")
+    if log_prefix:
+        validate_field(log_prefix, V.LOG_PREFIX, "log_prefix")
     await ctx.info(f"Updating firewall filter rule: rule_id={rule_id}")
 
     # Build the command
@@ -335,6 +370,7 @@ async def mikrotik_remove_filter_rule(ctx: Context, rule_id: str) -> str:
     Notes:
         rule_id: use the ID from list output e.g. "*1" or "0"
     """
+    validate_field(rule_id, V.ROUTEROS_ID, "rule_id")
     await ctx.info(f"Removing firewall filter rule: rule_id={rule_id}")
 
     # First check if the rule exists
@@ -361,6 +397,7 @@ async def mikrotik_move_filter_rule(ctx: Context, rule_id: str, destination: int
         rule_id: use the ID from list output e.g. "*1" or "0"
         destination: 0-based target position index
     """
+    validate_field(rule_id, V.ROUTEROS_ID, "rule_id")
     await ctx.info(f"Moving firewall filter rule: rule_id={rule_id} to position {destination}")
 
     # Check if the rule exists

--- a/src/mcp_mikrotik/scope/firewall_nat.py
+++ b/src/mcp_mikrotik/scope/firewall_nat.py
@@ -2,6 +2,7 @@ from typing import Literal, Optional
 from mcp.server.fastmcp import Context
 from ..connector import execute_mikrotik_command
 from ..app import mcp, READ, WRITE, WRITE_IDEMPOTENT, DESTRUCTIVE, annotate
+from ..security import SecurityError, V, validate_field
 
 @mcp.tool(name="create_nat_rule", annotations=annotate(WRITE, "Create NAT Rule"))
 async def mikrotik_create_nat_rule(
@@ -30,6 +31,14 @@ async def mikrotik_create_nat_rule(
         to_ports: single port or range e.g. "8080" or "8080-8090"
         place_before: rule number or ID (*N) to insert before e.g. "0" or "*3"
     """
+    validate_field(src_address, V.IP_CIDR, "src_address")
+    validate_field(dst_address, V.IP_CIDR, "dst_address")
+    validate_field(src_port, V.PORT_SPEC, "src_port")
+    validate_field(dst_port, V.PORT_SPEC, "dst_port")
+    validate_field(in_interface, V.INTERFACE_NAME, "in_interface")
+    validate_field(out_interface, V.INTERFACE_NAME, "out_interface")
+    validate_field(comment, V.COMMENT, "comment")
+    validate_field(log_prefix, V.LOG_PREFIX, "log_prefix")
     await ctx.info(f"Creating NAT rule: chain={chain}, action={action}")
 
     # Validate action based on chain
@@ -130,6 +139,9 @@ async def mikrotik_list_nat_rules(
     invalid_only: bool = False
 ) -> str:
     """Lists NAT rules on the MikroTik device."""
+    validate_field(src_address_filter, V.IP_CIDR, "src_address_filter")
+    validate_field(dst_address_filter, V.IP_CIDR, "dst_address_filter")
+    validate_field(interface_filter, V.INTERFACE_NAME, "interface_filter")
     await ctx.info(f"Listing NAT rules with filters: chain={chain_filter}, action={action_filter}")
 
     # Build the command
@@ -172,6 +184,7 @@ async def mikrotik_get_nat_rule(ctx: Context, rule_id: str) -> str:
     Notes:
         rule_id: use the ID from list output e.g. "*1" or "0"
     """
+    validate_field(rule_id, V.ROUTEROS_ID, "rule_id")
     await ctx.info(f"Getting NAT rule details: rule_id={rule_id}")
 
     cmd = f"/ip firewall nat print detail where .id={rule_id}"
@@ -210,6 +223,22 @@ async def mikrotik_update_nat_rule(
         to_ports: single port or range e.g. "8080" or "8080-8090"
         Pass "" to clear an optional field.
     """
+    validate_field(rule_id, V.ROUTEROS_ID, "rule_id")
+    if src_address:
+        validate_field(src_address, V.IP_CIDR, "src_address")
+    if dst_address:
+        validate_field(dst_address, V.IP_CIDR, "dst_address")
+    if src_port:
+        validate_field(src_port, V.PORT_SPEC, "src_port")
+    if dst_port:
+        validate_field(dst_port, V.PORT_SPEC, "dst_port")
+    if in_interface:
+        validate_field(in_interface, V.INTERFACE_NAME, "in_interface")
+    if out_interface:
+        validate_field(out_interface, V.INTERFACE_NAME, "out_interface")
+    validate_field(comment, V.COMMENT, "comment")
+    if log_prefix:
+        validate_field(log_prefix, V.LOG_PREFIX, "log_prefix")
     await ctx.info(f"Updating NAT rule: rule_id={rule_id}")
 
     # Build the command
@@ -299,6 +328,7 @@ async def mikrotik_remove_nat_rule(ctx: Context, rule_id: str) -> str:
     Notes:
         rule_id: use the ID from list output e.g. "*1" or "0"
     """
+    validate_field(rule_id, V.ROUTEROS_ID, "rule_id")
     await ctx.info(f"Removing NAT rule: rule_id={rule_id}")
 
     # First check if the rule exists
@@ -325,6 +355,7 @@ async def mikrotik_move_nat_rule(ctx: Context, rule_id: str, destination: int) -
         rule_id: use the ID from list output e.g. "*1" or "0"
         destination: 0-based target position index
     """
+    validate_field(rule_id, V.ROUTEROS_ID, "rule_id")
     await ctx.info(f"Moving NAT rule: rule_id={rule_id} to position {destination}")
 
     # Check if the rule exists

--- a/src/mcp_mikrotik/scope/interfaces.py
+++ b/src/mcp_mikrotik/scope/interfaces.py
@@ -2,6 +2,7 @@ from typing import Literal, Optional
 from ..connector import execute_mikrotik_command
 from mcp.server.fastmcp import Context
 from ..app import mcp, READ, WRITE_IDEMPOTENT, annotate
+from ..security import SecurityError, V, validate_field
 
 
 @mcp.tool(name="list_interfaces", annotations=annotate(READ, "List Interfaces"))
@@ -23,6 +24,7 @@ async def mikrotik_list_interfaces(
             "wg", "pppoe-out", "wifi", "lte", "loopback"
         name_filter: partial name match e.g. "ether" matches ether1, ether2 …
     """
+    validate_field(name_filter, V.INTERFACE_NAME, "name_filter")
     await ctx.info("Listing all interfaces")
 
     cmd = "/interface print"
@@ -55,6 +57,7 @@ async def mikrotik_get_interface(ctx: Context, name: str) -> str:
     Notes:
         name: exact interface name e.g. "ether1", "bridge", "pppoe-out1", "wg0"
     """
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Getting interface details: name={name}")
 
     cmd = f'/interface print detail where name="{name}"'
@@ -73,6 +76,7 @@ async def mikrotik_enable_interface(ctx: Context, name: str) -> str:
     Notes:
         name: exact interface name e.g. "ether1", "bridge", "pppoe-out1"
     """
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Enabling interface: name={name}")
 
     cmd = f'/interface enable [find name="{name}"]'
@@ -98,6 +102,7 @@ async def mikrotik_disable_interface(ctx: Context, name: str) -> str:
     Notes:
         name: exact interface name e.g. "ether1", "bridge", "pppoe-out1"
     """
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Disabling interface: name={name}")
 
     cmd = f'/interface disable [find name="{name}"]'

--- a/src/mcp_mikrotik/scope/ip_address.py
+++ b/src/mcp_mikrotik/scope/ip_address.py
@@ -3,6 +3,7 @@ from typing import Optional
 from ..connector import execute_mikrotik_command
 from mcp.server.fastmcp import Context
 from ..app import mcp, READ, WRITE, DESTRUCTIVE, annotate
+from ..security import SecurityError, V, validate_field
 
 @mcp.tool(name="add_ip_address", annotations=annotate(WRITE, "Add IP Address"))
 async def mikrotik_add_ip_address(
@@ -15,6 +16,10 @@ async def mikrotik_add_ip_address(
     disabled: bool = False
 ) -> str:
     """Adds an IP address to an interface on the MikroTik device."""
+    validate_field(address, V.IP_CIDR, "address")
+    validate_field(interface, V.INTERFACE_NAME, "interface")
+    validate_field(network, V.IP_CIDR, "network")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Adding IP address: address={address}, interface={interface}")
 
     # Build the command
@@ -54,6 +59,9 @@ async def mikrotik_list_ip_addresses(
     dynamic_only: bool = False
 ) -> str:
     """Lists IP addresses on the MikroTik device."""
+    validate_field(interface_filter, V.INTERFACE_NAME, "interface_filter")
+    validate_field(address_filter, V.IP_CIDR, "address_filter")
+    validate_field(network_filter, V.IP_CIDR, "network_filter")
     await ctx.info(f"Listing IP addresses with filters: interface={interface_filter}, address={address_filter}")
 
     # Build the command
@@ -85,6 +93,7 @@ async def mikrotik_list_ip_addresses(
 @mcp.tool(name="get_ip_address", annotations=annotate(READ, "Get IP Address"))
 async def mikrotik_get_ip_address(ctx: Context, address_id: str) -> str:
     """Gets detailed information about a specific IP address by ID or address value."""
+    validate_field(address_id, V.COMMENT, "address_id")
     await ctx.info(f"Getting IP address details: address_id={address_id}")
 
     # Try to find by ID first, then by address
@@ -104,6 +113,7 @@ async def mikrotik_get_ip_address(ctx: Context, address_id: str) -> str:
 @mcp.tool(name="remove_ip_address", annotations=annotate(DESTRUCTIVE, "Remove IP Address"))
 async def mikrotik_remove_ip_address(ctx: Context, address_id: str) -> str:
     """Removes an IP address from the MikroTik device by ID or address value."""
+    validate_field(address_id, V.COMMENT, "address_id")
     await ctx.info(f"Removing IP address: address_id={address_id}")
 
     # Try to find by ID first

--- a/src/mcp_mikrotik/scope/ip_pool.py
+++ b/src/mcp_mikrotik/scope/ip_pool.py
@@ -4,6 +4,7 @@ from mcp.server.fastmcp import Context
 
 from ..connector import execute_mikrotik_command
 from ..app import mcp, READ, WRITE, WRITE_IDEMPOTENT, DESTRUCTIVE, annotate
+from ..security import SecurityError, V, validate_field
 
 @mcp.tool(name="create_ip_pool", annotations=annotate(WRITE, "Add IP Pool"))
 async def mikrotik_create_ip_pool(
@@ -19,6 +20,9 @@ async def mikrotik_create_ip_pool(
         ranges: hyphen-separated range(s) e.g. "192.168.1.1-192.168.1.100"
             Multiple ranges comma-separated: "10.0.0.1-10.0.0.50,10.0.0.100-10.0.0.120"
     """
+    validate_field(name, V.INTERFACE_NAME, "name")
+    validate_field(ranges, V.IP_RANGES, "ranges")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Creating IP pool: name={name}, ranges={ranges}")
 
     # Build the command
@@ -66,6 +70,7 @@ async def mikrotik_list_ip_pools(
     include_used: bool = False
 ) -> str:
     """Lists IP pools on the MikroTik device."""
+    validate_field(name_filter, V.INTERFACE_NAME, "name_filter")
     await ctx.info(f"Listing IP pools with filters: name={name_filter}, ranges={ranges_filter}")
 
     # Build the command
@@ -116,6 +121,7 @@ async def mikrotik_list_ip_pools(
 @mcp.tool(name="get_ip_pool", annotations=annotate(READ, "Get IP Pool"))
 async def mikrotik_get_ip_pool(ctx: Context, name: str) -> str:
     """Gets detailed information about a specific IP pool including used address count."""
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Getting IP pool details: name={name}")
 
     cmd = f'/ip pool print detail where name="{name}"'
@@ -149,6 +155,10 @@ async def mikrotik_update_ip_pool(
             Multiple ranges comma-separated: "10.0.0.1-10.0.0.50,10.0.0.100-10.0.0.120"
         Pass "" for next_pool to clear it.
     """
+    validate_field(name, V.INTERFACE_NAME, "name")
+    validate_field(new_name, V.INTERFACE_NAME, "new_name")
+    validate_field(ranges, V.IP_RANGES, "ranges")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Updating IP pool: name={name}")
 
     # Build the command
@@ -189,6 +199,7 @@ async def mikrotik_update_ip_pool(
 @mcp.tool(name="remove_ip_pool", annotations=annotate(DESTRUCTIVE, "Remove IP Pool"))
 async def mikrotik_remove_ip_pool(ctx: Context, name: str) -> str:
     """Removes an IP pool from the MikroTik device (fails if pool is in use)."""
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Removing IP pool: name={name}")
 
     # First check if the pool exists
@@ -230,6 +241,8 @@ async def mikrotik_list_ip_pool_used(
     info_filter: Optional[str] = None
 ) -> str:
     """Lists currently used (allocated) addresses from IP pools."""
+    validate_field(pool_name, V.INTERFACE_NAME, "pool_name")
+    validate_field(address_filter, V.IP_CIDR, "address_filter")
     await ctx.info(f"Listing used IP pool addresses: pool={pool_name}, address={address_filter}")
 
     cmd = "/ip pool used print"
@@ -263,6 +276,8 @@ async def mikrotik_expand_ip_pool(ctx: Context, name: str, additional_ranges: st
         additional_ranges: hyphen-separated range(s) e.g. "192.168.1.101-192.168.1.150"
             Multiple ranges comma-separated: "10.0.0.51-10.0.0.60,10.0.0.70-10.0.0.80"
     """
+    validate_field(name, V.INTERFACE_NAME, "name")
+    validate_field(additional_ranges, V.IP_RANGES, "additional_ranges")
     await ctx.info(f"Expanding IP pool: name={name}, additional_ranges={additional_ranges}")
 
     # Get current ranges

--- a/src/mcp_mikrotik/scope/queue.py
+++ b/src/mcp_mikrotik/scope/queue.py
@@ -2,6 +2,7 @@ from typing import Literal, Optional
 from mcp.server.fastmcp import Context
 from ..app import mcp, READ, WRITE, WRITE_IDEMPOTENT, DESTRUCTIVE, annotate
 from ..connector import execute_mikrotik_command
+from ..security import SecurityError, V, validate_field
 
 
 # ───────────────────────────────────────────────
@@ -49,6 +50,7 @@ async def mikrotik_create_queue_type(
         cake_rtt: round-trip time e.g. "50ms", "100ms"
         fq_codel_target / fq_codel_interval: time e.g. "5ms", "100ms"
     """
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Creating queue type: name={name}, kind={kind}")
 
     cmd = f"/queue type add name={name} kind={kind}"
@@ -143,6 +145,7 @@ async def mikrotik_list_queue_types(
     kind_filter: Optional[str] = None,
 ) -> str:
     """Lists queue types on the MikroTik device."""
+    validate_field(name_filter, V.INTERFACE_NAME, "name_filter")
     await ctx.info("Listing queue types")
 
     cmd = "/queue type print"
@@ -164,6 +167,7 @@ async def mikrotik_list_queue_types(
 @mcp.tool(name="get_queue_type", annotations=annotate(READ, "Get Queue Type"))
 async def mikrotik_get_queue_type(ctx: Context, name: str) -> str:
     """Gets detailed information about a specific queue type."""
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Getting queue type details: name={name}")
 
     cmd = f'/queue type print detail where name="{name}"'
@@ -192,6 +196,8 @@ async def mikrotik_update_queue_type(
     pcq_classifier: Optional[str] = None,
 ) -> str:
     """Updates an existing queue type's discipline-specific settings."""
+    validate_field(name, V.INTERFACE_NAME, "name")
+    validate_field(new_name, V.INTERFACE_NAME, "new_name")
     await ctx.info(f"Updating queue type: name={name}")
 
     cmd = f'/queue type set [find name="{name}"]'
@@ -242,6 +248,7 @@ async def mikrotik_update_queue_type(
 @mcp.tool(name="remove_queue_type", annotations=annotate(DESTRUCTIVE, "Remove Queue Type"))
 async def mikrotik_remove_queue_type(ctx: Context, name: str) -> str:
     """Removes a queue type from the MikroTik device."""
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Removing queue type: name={name}")
 
     cmd = f'/queue type remove [find name="{name}"]'
@@ -281,6 +288,14 @@ async def mikrotik_create_queue_tree(
         parent: interface name e.g. "ether1" or parent queue name
         priority: 1 (highest) – 8 (lowest)
     """
+    validate_field(name, V.INTERFACE_NAME, "name")
+    validate_field(parent, V.INTERFACE_NAME, "parent")
+    validate_field(max_limit, V.BANDWIDTH, "max_limit")
+    validate_field(limit_at, V.BANDWIDTH, "limit_at")
+    validate_field(burst_limit, V.BANDWIDTH, "burst_limit")
+    validate_field(burst_threshold, V.BANDWIDTH, "burst_threshold")
+    validate_field(burst_time, V.DURATION, "burst_time")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Creating queue tree: name={name}, parent={parent}")
 
     cmd = f"/queue tree add name={name} parent={parent}"
@@ -337,6 +352,8 @@ async def mikrotik_list_queue_trees(
     invalid_only: bool = False,
 ) -> str:
     """Lists queue trees on the MikroTik device."""
+    validate_field(name_filter, V.INTERFACE_NAME, "name_filter")
+    validate_field(parent_filter, V.INTERFACE_NAME, "parent_filter")
     await ctx.info("Listing queue trees")
 
     cmd = "/queue tree print"
@@ -362,6 +379,7 @@ async def mikrotik_list_queue_trees(
 @mcp.tool(name="get_queue_tree", annotations=annotate(READ, "Get Queue Tree"))
 async def mikrotik_get_queue_tree(ctx: Context, name: str) -> str:
     """Gets detailed information about a specific queue tree."""
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Getting queue tree details: name={name}")
 
     cmd = f'/queue tree print detail where name="{name}"'
@@ -396,6 +414,15 @@ async def mikrotik_update_queue_tree(
         burst_time: duration e.g. "8s"
         priority: 1 (highest) – 8 (lowest)
     """
+    validate_field(name, V.INTERFACE_NAME, "name")
+    validate_field(new_name, V.INTERFACE_NAME, "new_name")
+    validate_field(parent, V.INTERFACE_NAME, "parent")
+    validate_field(max_limit, V.BANDWIDTH, "max_limit")
+    validate_field(limit_at, V.BANDWIDTH, "limit_at")
+    validate_field(burst_limit, V.BANDWIDTH, "burst_limit")
+    validate_field(burst_threshold, V.BANDWIDTH, "burst_threshold")
+    validate_field(burst_time, V.DURATION, "burst_time")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Updating queue tree: name={name}")
 
     cmd = f'/queue tree set [find name="{name}"]'
@@ -446,6 +473,7 @@ async def mikrotik_update_queue_tree(
 @mcp.tool(name="remove_queue_tree", annotations=annotate(DESTRUCTIVE, "Remove Queue Tree"))
 async def mikrotik_remove_queue_tree(ctx: Context, name: str) -> str:
     """Removes a queue tree from the MikroTik device."""
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Removing queue tree: name={name}")
 
     cmd = f'/queue tree remove [find name="{name}"]'
@@ -459,6 +487,7 @@ async def mikrotik_remove_queue_tree(ctx: Context, name: str) -> str:
 @mcp.tool(name="enable_queue_tree", annotations=annotate(WRITE_IDEMPOTENT, "Enable Queue Tree"))
 async def mikrotik_enable_queue_tree(ctx: Context, name: str) -> str:
     """Enables a queue tree."""
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Enabling queue tree: name={name}")
 
     cmd = f'/queue tree set [find name="{name}"] disabled=no'
@@ -475,6 +504,7 @@ async def mikrotik_enable_queue_tree(ctx: Context, name: str) -> str:
 @mcp.tool(name="disable_queue_tree", annotations=annotate(WRITE_IDEMPOTENT, "Disable Queue Tree"))
 async def mikrotik_disable_queue_tree(ctx: Context, name: str) -> str:
     """Disables a queue tree."""
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Disabling queue tree: name={name}")
 
     cmd = f'/queue tree set [find name="{name}"] disabled=yes'
@@ -520,6 +550,13 @@ async def mikrotik_create_simple_queue(
         burst_time: duration e.g. "8s"
         priority: 1 (highest) – 8 (lowest)
     """
+    validate_field(name, V.INTERFACE_NAME, "name")
+    validate_field(max_limit, V.BANDWIDTH, "max_limit")
+    validate_field(limit_at, V.BANDWIDTH, "limit_at")
+    validate_field(burst_limit, V.BANDWIDTH, "burst_limit")
+    validate_field(burst_threshold, V.BANDWIDTH, "burst_threshold")
+    validate_field(burst_time, V.DURATION, "burst_time")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Creating simple queue: name={name}, target={target}")
 
     cmd = f"/queue simple add name={name} target={target}"
@@ -580,6 +617,7 @@ async def mikrotik_list_simple_queues(
     invalid_only: bool = False,
 ) -> str:
     """Lists simple queues on the MikroTik device."""
+    validate_field(name_filter, V.INTERFACE_NAME, "name_filter")
     await ctx.info("Listing simple queues")
 
     cmd = "/queue simple print"
@@ -605,6 +643,7 @@ async def mikrotik_list_simple_queues(
 @mcp.tool(name="get_simple_queue", annotations=annotate(READ, "Get Simple Queue"))
 async def mikrotik_get_simple_queue(ctx: Context, name: str) -> str:
     """Gets detailed information about a specific simple queue."""
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Getting simple queue details: name={name}")
 
     cmd = f'/queue simple print detail where name="{name}"'
@@ -643,6 +682,14 @@ async def mikrotik_update_simple_queue(
         burst_time: duration e.g. "8s"
         priority: 1 (highest) – 8 (lowest)
     """
+    validate_field(name, V.INTERFACE_NAME, "name")
+    validate_field(new_name, V.INTERFACE_NAME, "new_name")
+    validate_field(max_limit, V.BANDWIDTH, "max_limit")
+    validate_field(limit_at, V.BANDWIDTH, "limit_at")
+    validate_field(burst_limit, V.BANDWIDTH, "burst_limit")
+    validate_field(burst_threshold, V.BANDWIDTH, "burst_threshold")
+    validate_field(burst_time, V.DURATION, "burst_time")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Updating simple queue: name={name}")
 
     cmd = f'/queue simple set [find name="{name}"]'
@@ -697,6 +744,7 @@ async def mikrotik_update_simple_queue(
 @mcp.tool(name="remove_simple_queue", annotations=annotate(DESTRUCTIVE, "Remove Simple Queue"))
 async def mikrotik_remove_simple_queue(ctx: Context, name: str) -> str:
     """Removes a simple queue from the MikroTik device."""
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Removing simple queue: name={name}")
 
     cmd = f'/queue simple remove [find name="{name}"]'
@@ -710,6 +758,7 @@ async def mikrotik_remove_simple_queue(ctx: Context, name: str) -> str:
 @mcp.tool(name="enable_simple_queue", annotations=annotate(WRITE_IDEMPOTENT, "Enable Simple Queue"))
 async def mikrotik_enable_simple_queue(ctx: Context, name: str) -> str:
     """Enables a simple queue."""
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Enabling simple queue: name={name}")
 
     cmd = f'/queue simple set [find name="{name}"] disabled=no'
@@ -726,6 +775,7 @@ async def mikrotik_enable_simple_queue(ctx: Context, name: str) -> str:
 @mcp.tool(name="disable_simple_queue", annotations=annotate(WRITE_IDEMPOTENT, "Disable Simple Queue"))
 async def mikrotik_disable_simple_queue(ctx: Context, name: str) -> str:
     """Disables a simple queue."""
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Disabling simple queue: name={name}")
 
     cmd = f'/queue simple set [find name="{name}"] disabled=yes'

--- a/src/mcp_mikrotik/scope/routes.py
+++ b/src/mcp_mikrotik/scope/routes.py
@@ -2,6 +2,7 @@ from typing import Optional, List
 from ..connector import execute_mikrotik_command
 from mcp.server.fastmcp import Context
 from ..app import mcp, READ, WRITE, WRITE_IDEMPOTENT, DESTRUCTIVE, annotate
+from ..security import SecurityError, V, validate_field
 
 @mcp.tool(name="add_route", annotations=annotate(WRITE, "Add Route"))
 async def mikrotik_add_route(
@@ -25,6 +26,12 @@ async def mikrotik_add_route(
         check_gateway: "ping" or "arp"
         distance: 1-255 (lower = higher priority)
     """
+    validate_field(dst_address, V.IP_CIDR, "dst_address")
+    validate_field(gateway, V.IP_CIDR, "gateway")
+    validate_field(routing_mark, V.ROUTING_MARK, "routing_mark")
+    validate_field(comment, V.COMMENT, "comment")
+    validate_field(vrf_interface, V.INTERFACE_NAME, "vrf_interface")
+    validate_field(pref_src, V.IP_CIDR, "pref_src")
     await ctx.info(f"Adding route: dst={dst_address}, gateway={gateway}")
 
     cmd = f"/ip route add dst-address={dst_address} gateway={gateway}"
@@ -84,6 +91,9 @@ async def mikrotik_list_routes(
     static_only: bool = False
 ) -> str:
     """Lists routes in MikroTik routing table."""
+    validate_field(dst_filter, V.IP_CIDR, "dst_filter")
+    validate_field(gateway_filter, V.IP_CIDR, "gateway_filter")
+    validate_field(routing_mark_filter, V.ROUTING_MARK, "routing_mark_filter")
     await ctx.info(f"Listing routes with filters: dst={dst_filter}, gateway={gateway_filter}")
 
     cmd = "/ip route print"
@@ -123,6 +133,7 @@ async def mikrotik_get_route(ctx: Context, route_id: str) -> str:
     Notes:
         route_id: "*N" or "N" from list output e.g. "*3"
     """
+    validate_field(route_id, V.ROUTEROS_ID, "route_id")
     await ctx.info(f"Getting route details: route_id={route_id}")
 
     cmd = f"/ip route print detail where .id={route_id}"
@@ -158,6 +169,16 @@ async def mikrotik_update_route(
         distance: 1-255
         Pass "" to routing_mark, vrf_interface, or pref_src to clear them.
     """
+    validate_field(route_id, V.ROUTEROS_ID, "route_id")
+    validate_field(dst_address, V.IP_CIDR, "dst_address")
+    validate_field(gateway, V.IP_CIDR, "gateway")
+    if routing_mark:
+        validate_field(routing_mark, V.ROUTING_MARK, "routing_mark")
+    validate_field(comment, V.COMMENT, "comment")
+    if vrf_interface:
+        validate_field(vrf_interface, V.INTERFACE_NAME, "vrf_interface")
+    if pref_src:
+        validate_field(pref_src, V.IP_CIDR, "pref_src")
     await ctx.info(f"Updating route: route_id={route_id}")
 
     cmd = f"/ip route set {route_id}"
@@ -217,6 +238,7 @@ async def mikrotik_remove_route(ctx: Context, route_id: str) -> str:
     Notes:
         route_id: "*N" or "N" from list output e.g. "*3"
     """
+    validate_field(route_id, V.ROUTEROS_ID, "route_id")
     await ctx.info(f"Removing route: route_id={route_id}")
 
     check_cmd = f"/ip route print count-only where .id={route_id}"
@@ -259,6 +281,7 @@ async def mikrotik_get_routing_table(
     active_only: bool = True
 ) -> str:
     """Gets a specific routing table."""
+    validate_field(table_name, V.ROUTING_MARK, "table_name")
     await ctx.info(f"Getting routing table: table={table_name}")
 
     cmd = "/ip route print"
@@ -289,6 +312,9 @@ async def mikrotik_check_route_path(
     routing_mark: Optional[str] = None
 ) -> str:
     """Checks the route path to a destination."""
+    validate_field(destination, V.IP_CIDR, "destination")
+    validate_field(source, V.IP_CIDR, "source")
+    validate_field(routing_mark, V.ROUTING_MARK, "routing_mark")
     await ctx.info(f"Checking route path to: {destination}")
 
     cmd = f"/ip route check {destination}"
@@ -362,6 +388,8 @@ async def mikrotik_add_blackhole_route(
         dst_address: CIDR e.g. "10.0.0.0/8"
         distance: 1-255
     """
+    validate_field(dst_address, V.IP_CIDR, "dst_address")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Adding blackhole route: dst={dst_address}")
 
     cmd = f"/ip route add dst-address={dst_address} type=blackhole distance={distance}"

--- a/src/mcp_mikrotik/scope/users.py
+++ b/src/mcp_mikrotik/scope/users.py
@@ -3,6 +3,7 @@ from ..connector import execute_mikrotik_command
 from mcp.server.fastmcp import Context
 import re
 from ..app import mcp, READ, WRITE, WRITE_IDEMPOTENT, DESTRUCTIVE, annotate
+from ..security import SecurityError, V, validate_field
 
 @mcp.tool(name="add_user", annotations=annotate(WRITE, "Add User"))
 async def mikrotik_add_user(
@@ -15,6 +16,9 @@ async def mikrotik_add_user(
     disabled: bool = False
 ) -> str:
     """Adds a user to MikroTik device."""
+    validate_field(name, V.USERNAME, "name")
+    validate_field(address, V.IP_CIDR, "address")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Adding user: name={name}, group={group}")
 
     cmd = f'/user add name="{name}" password="{password}" group={group}'
@@ -63,6 +67,7 @@ async def mikrotik_list_users(
     active_only: bool = False
 ) -> str:
     """Lists users on MikroTik device."""
+    validate_field(name_filter, V.USERNAME, "name_filter")
     await ctx.info(f"Listing users with filters: name={name_filter}, group={group_filter}")
 
     cmd = "/user print"
@@ -91,6 +96,7 @@ async def mikrotik_list_users(
 @mcp.tool(name="get_user", annotations=annotate(READ, "Get User"))
 async def mikrotik_get_user(ctx: Context, name: str) -> str:
     """Gets detailed information about a specific user."""
+    validate_field(name, V.USERNAME, "name")
     await ctx.info(f"Getting user details: name={name}")
 
     cmd = f'/user print detail where name="{name}"'
@@ -116,6 +122,11 @@ async def mikrotik_update_user(
     disabled: Optional[bool] = None
 ) -> str:
     """Updates a user."""
+    validate_field(name, V.USERNAME, "name")
+    validate_field(new_name, V.USERNAME, "new_name")
+    if address:
+        validate_field(address, V.IP_CIDR, "address")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Updating user: name={name}")
 
     cmd = f'/user set [find name="{name}"]'
@@ -159,6 +170,7 @@ async def mikrotik_update_user(
 @mcp.tool(name="remove_user", annotations=annotate(DESTRUCTIVE, "Remove User"))
 async def mikrotik_remove_user(ctx: Context, name: str) -> str:
     """Removes a user."""
+    validate_field(name, V.USERNAME, "name")
     await ctx.info(f"Removing user: name={name}")
 
     # Don't allow removal of admin user
@@ -198,6 +210,8 @@ async def mikrotik_add_user_group(
     comment: Optional[str] = None
 ) -> str:
     """Adds a user group."""
+    validate_field(name, V.USERNAME, "name")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Adding user group: name={name}")
 
     # Valid policies
@@ -250,6 +264,7 @@ async def mikrotik_list_user_groups(
     policy_filter: Optional[str] = None
 ) -> str:
     """Lists user groups on MikroTik device."""
+    validate_field(name_filter, V.USERNAME, "name_filter")
     await ctx.info(f"Listing user groups with filters: name={name_filter}")
 
     cmd = "/user group print"
@@ -273,6 +288,7 @@ async def mikrotik_list_user_groups(
 @mcp.tool(name="get_user_group", annotations=annotate(READ, "Get User Group"))
 async def mikrotik_get_user_group(ctx: Context, name: str) -> str:
     """Gets detailed information about a specific user group."""
+    validate_field(name, V.USERNAME, "name")
     await ctx.info(f"Getting user group details: name={name}")
 
     cmd = f'/user group print detail where name="{name}"'
@@ -293,6 +309,9 @@ async def mikrotik_update_user_group(
     comment: Optional[str] = None
 ) -> str:
     """Updates a user group."""
+    validate_field(name, V.USERNAME, "name")
+    validate_field(new_name, V.USERNAME, "new_name")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Updating user group: name={name}")
 
     # Don't allow modification of built-in groups
@@ -333,6 +352,7 @@ async def mikrotik_update_user_group(
 @mcp.tool(name="remove_user_group", annotations=annotate(DESTRUCTIVE, "Remove User Group"))
 async def mikrotik_remove_user_group(ctx: Context, name: str) -> str:
     """Removes a user group."""
+    validate_field(name, V.USERNAME, "name")
     await ctx.info(f"Removing user group: name={name}")
 
     # Don't allow removal of built-in groups
@@ -409,6 +429,7 @@ async def mikrotik_set_user_ssh_keys(
     key_file: str
 ) -> str:
     """Sets SSH keys for a specific user."""
+    validate_field(username, V.USERNAME, "username")
     await ctx.info(f"Setting SSH keys for user: {username}")
 
     cmd = f'/user ssh-keys import user="{username}" public-key-file="{key_file}"'
@@ -422,6 +443,7 @@ async def mikrotik_set_user_ssh_keys(
 @mcp.tool(name="list_user_ssh_keys", annotations=annotate(READ, "List User SSH Keys"))
 async def mikrotik_list_user_ssh_keys(ctx: Context, username: str) -> str:
     """Lists SSH keys for a specific user."""
+    validate_field(username, V.USERNAME, "username")
     await ctx.info(f"Listing SSH keys for user: {username}")
 
     cmd = f'/user ssh-keys print where user="{username}"'

--- a/src/mcp_mikrotik/scope/vlan.py
+++ b/src/mcp_mikrotik/scope/vlan.py
@@ -3,6 +3,7 @@ from pydantic import Field
 from ..connector import execute_mikrotik_command
 from mcp.server.fastmcp import Context
 from ..app import mcp, READ, WRITE, WRITE_IDEMPOTENT, DESTRUCTIVE, annotate
+from ..security import SecurityError, V, validate_field
 
 @mcp.tool(name="create_vlan_interface", annotations=annotate(WRITE, "Create VLAN"))
 async def mikrotik_create_vlan_interface(
@@ -18,6 +19,9 @@ async def mikrotik_create_vlan_interface(
     arp_timeout: Optional[str] = None
 ) -> str:
     """Creates a VLAN interface on the MikroTik device with the given VLAN ID and parent interface."""
+    validate_field(name, V.INTERFACE_NAME, "name")
+    validate_field(interface, V.INTERFACE_NAME, "interface")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Creating VLAN interface: name={name}, vlan_id={vlan_id}, interface={interface}")
 
     # Build the command
@@ -78,6 +82,8 @@ async def mikrotik_list_vlan_interfaces(
     disabled_only: bool = False
 ) -> str:
     """Lists VLAN interfaces on the MikroTik device."""
+    validate_field(name_filter, V.INTERFACE_NAME, "name_filter")
+    validate_field(interface_filter, V.INTERFACE_NAME, "interface_filter")
     await ctx.info(f"Listing VLAN interfaces with filters: name={name_filter}, vlan_id={vlan_id_filter}, interface={interface_filter}")
 
     # Build the command
@@ -108,6 +114,7 @@ async def mikrotik_list_vlan_interfaces(
 @mcp.tool(name="get_vlan_interface", annotations=annotate(READ, "Get VLAN"))
 async def mikrotik_get_vlan_interface(ctx: Context, name: str) -> str:
     """Gets detailed information about a specific VLAN interface."""
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Getting VLAN interface details: name={name}")
 
     cmd = f'/interface vlan print detail where name="{name}"'
@@ -133,6 +140,10 @@ async def mikrotik_update_vlan_interface(
     arp_timeout: Optional[str] = None
 ) -> str:
     """Updates an existing VLAN interface's settings on the MikroTik device."""
+    validate_field(name, V.INTERFACE_NAME, "name")
+    validate_field(new_name, V.INTERFACE_NAME, "new_name")
+    validate_field(interface, V.INTERFACE_NAME, "interface")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Updating VLAN interface: name={name}")
 
     # Build the command
@@ -180,6 +191,7 @@ async def mikrotik_update_vlan_interface(
 @mcp.tool(name="remove_vlan_interface", annotations=annotate(DESTRUCTIVE, "Remove VLAN"))
 async def mikrotik_remove_vlan_interface(ctx: Context, name: str) -> str:
     """Removes a VLAN interface from the MikroTik device."""
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Removing VLAN interface: name={name}")
 
     # First check if the interface exists

--- a/src/mcp_mikrotik/scope/wireguard.py
+++ b/src/mcp_mikrotik/scope/wireguard.py
@@ -4,6 +4,7 @@ from mcp.server.fastmcp import Context
 
 from ..connector import execute_mikrotik_command
 from ..app import mcp, READ, WRITE, WRITE_IDEMPOTENT, DESTRUCTIVE, annotate
+from ..security import SecurityError, V, validate_field
 
 
 # ---------------------------------------------------------------------------
@@ -21,6 +22,9 @@ async def mikrotik_create_wireguard_interface(
     disabled: bool = False,
 ) -> str:
     """Creates a WireGuard interface on the MikroTik device."""
+    validate_field(name, V.INTERFACE_NAME, "name")
+    validate_field(private_key, V.WG_KEY, "private_key")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Creating WireGuard interface: name={name}")
 
     cmd = f"/interface wireguard add name={name}"
@@ -57,6 +61,7 @@ async def mikrotik_list_wireguard_interfaces(
     running_only: bool = False,
 ) -> str:
     """Lists WireGuard interfaces on the MikroTik device."""
+    validate_field(name_filter, V.INTERFACE_NAME, "name_filter")
     await ctx.info("Listing WireGuard interfaces")
 
     cmd = "/interface wireguard print"
@@ -83,6 +88,7 @@ async def mikrotik_list_wireguard_interfaces(
 @mcp.tool(name="get_wireguard_interface", annotations=annotate(READ, "Get WireGuard Interface"))
 async def mikrotik_get_wireguard_interface(ctx: Context, name: str) -> str:
     """Gets detailed information about a specific WireGuard interface."""
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Getting WireGuard interface details: name={name}")
 
     cmd = f'/interface wireguard print detail where name="{name}"'
@@ -106,6 +112,10 @@ async def mikrotik_update_wireguard_interface(
     disabled: Optional[bool] = None,
 ) -> str:
     """Updates an existing WireGuard interface's settings on the MikroTik device."""
+    validate_field(name, V.INTERFACE_NAME, "name")
+    validate_field(new_name, V.INTERFACE_NAME, "new_name")
+    validate_field(private_key, V.WG_KEY, "private_key")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Updating WireGuard interface: name={name}")
 
     updates = []
@@ -141,6 +151,7 @@ async def mikrotik_update_wireguard_interface(
 @mcp.tool(name="remove_wireguard_interface", annotations=annotate(DESTRUCTIVE, "Remove WireGuard Interface"))
 async def mikrotik_remove_wireguard_interface(ctx: Context, name: str) -> str:
     """Removes a WireGuard interface from the MikroTik device."""
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Removing WireGuard interface: name={name}")
 
     check_cmd = f'/interface wireguard print count-only where name="{name}"'
@@ -161,6 +172,7 @@ async def mikrotik_remove_wireguard_interface(ctx: Context, name: str) -> str:
 @mcp.tool(name="enable_wireguard_interface", annotations=annotate(WRITE_IDEMPOTENT, "Enable WireGuard Interface"))
 async def mikrotik_enable_wireguard_interface(ctx: Context, name: str) -> str:
     """Enables a WireGuard interface."""
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Enabling WireGuard interface: name={name}")
 
     cmd = f'/interface wireguard enable [find name="{name}"]'
@@ -175,6 +187,7 @@ async def mikrotik_enable_wireguard_interface(ctx: Context, name: str) -> str:
 @mcp.tool(name="disable_wireguard_interface", annotations=annotate(WRITE_IDEMPOTENT, "Disable WireGuard Interface"))
 async def mikrotik_disable_wireguard_interface(ctx: Context, name: str) -> str:
     """Disables a WireGuard interface."""
+    validate_field(name, V.INTERFACE_NAME, "name")
     await ctx.info(f"Disabling WireGuard interface: name={name}")
 
     cmd = f'/interface wireguard disable [find name="{name}"]'
@@ -210,6 +223,13 @@ async def mikrotik_add_wireguard_peer(
         endpoint_address: remote host IP or hostname e.g. "203.0.113.1"
         persistent_keepalive: seconds as string e.g. "25"
     """
+    validate_field(interface, V.INTERFACE_NAME, "interface")
+    validate_field(public_key, V.WG_KEY, "public_key")
+    validate_field(allowed_address, V.IP_CIDR, "allowed_address")
+    validate_field(endpoint_address, V.HOSTNAME, "endpoint_address")
+    validate_field(preshared_key, V.WG_KEY, "preshared_key")
+    validate_field(persistent_keepalive, V.DURATION, "persistent_keepalive")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Adding WireGuard peer: interface={interface}, public_key={public_key[:12]}...")
 
     cmd = (
@@ -254,6 +274,7 @@ async def mikrotik_list_wireguard_peers(
     disabled_only: bool = False,
 ) -> str:
     """Lists WireGuard peers on the MikroTik device."""
+    validate_field(interface_filter, V.INTERFACE_NAME, "interface_filter")
     await ctx.info("Listing WireGuard peers")
 
     cmd = "/interface wireguard peers print"
@@ -282,6 +303,7 @@ async def mikrotik_get_wireguard_peer(ctx: Context, peer_id: str) -> str:
     Notes:
         peer_id: "*N" or "N" from list output e.g. "*2"
     """
+    validate_field(peer_id, V.ROUTEROS_ID, "peer_id")
     await ctx.info(f"Getting WireGuard peer details: peer_id={peer_id}")
 
     cmd = f"/interface wireguard peers print detail where .id={peer_id}"
@@ -313,6 +335,15 @@ async def mikrotik_update_wireguard_peer(
         persistent_keepalive: seconds as string e.g. "25"
         Pass "" for endpoint_address or preshared_key to clear them.
     """
+    validate_field(peer_id, V.ROUTEROS_ID, "peer_id")
+    validate_field(allowed_address, V.IP_CIDR, "allowed_address")
+    if endpoint_address:
+        validate_field(endpoint_address, V.HOSTNAME, "endpoint_address")
+    if preshared_key:
+        validate_field(preshared_key, V.WG_KEY, "preshared_key")
+    if persistent_keepalive:
+        validate_field(persistent_keepalive, V.DURATION, "persistent_keepalive")
+    validate_field(comment, V.COMMENT, "comment")
     await ctx.info(f"Updating WireGuard peer: peer_id={peer_id}")
 
     updates = []
@@ -359,6 +390,7 @@ async def mikrotik_remove_wireguard_peer(ctx: Context, peer_id: str) -> str:
     Notes:
         peer_id: "*N" or "N" from list output e.g. "*2"
     """
+    validate_field(peer_id, V.ROUTEROS_ID, "peer_id")
     await ctx.info(f"Removing WireGuard peer: peer_id={peer_id}")
 
     check_cmd = f"/interface wireguard peers print count-only where .id={peer_id}"
@@ -383,6 +415,7 @@ async def mikrotik_enable_wireguard_peer(ctx: Context, peer_id: str) -> str:
     Notes:
         peer_id: "*N" or "N" from list output e.g. "*2"
     """
+    validate_field(peer_id, V.ROUTEROS_ID, "peer_id")
     await ctx.info(f"Enabling WireGuard peer: peer_id={peer_id}")
 
     cmd = f"/interface wireguard peers enable {peer_id}"
@@ -401,6 +434,7 @@ async def mikrotik_disable_wireguard_peer(ctx: Context, peer_id: str) -> str:
     Notes:
         peer_id: "*N" or "N" from list output e.g. "*2"
     """
+    validate_field(peer_id, V.ROUTEROS_ID, "peer_id")
     await ctx.info(f"Disabling WireGuard peer: peer_id={peer_id}")
 
     cmd = f"/interface wireguard peers disable {peer_id}"
@@ -425,6 +459,12 @@ async def mikrotik_generate_wireguard_client_config(
     persistent_keepalive: int = 25,
 ) -> str:
     """Generates a wg0.conf client config string from the given keys and server endpoint. Does not communicate with the router."""
+    validate_field(client_private_key, V.WG_KEY, "client_private_key")
+    validate_field(client_address, V.IP_CIDR, "client_address")
+    validate_field(server_public_key, V.WG_KEY, "server_public_key")
+    validate_field(server_endpoint, V.HOSTNAME, "server_endpoint")
+    validate_field(allowed_ips, V.IP_CIDR, "allowed_ips")
+    validate_field(dns, V.HOSTNAME, "dns")
     await ctx.info("Generating WireGuard client configuration")
 
     lines = [

--- a/src/mcp_mikrotik/security.py
+++ b/src/mcp_mikrotik/security.py
@@ -1,0 +1,193 @@
+"""Input validation for MikroTik MCP (issue #53).
+
+Two layers of protection, zero external dependencies:
+
+Layer 1 — Structural command-injection check (always active)
+    check_command_safety() rejects characters that never appear in a
+    legitimate RouterOS command but enable command-injection:
+    ; ` { } newline carriage-return
+
+Layer 2 — Per-field allowlist (always active)
+    validate_field() applies a tight character allowlist matched to each
+    RouterOS field type. Rather than blocking a known-bad set, it only
+    allows a known-good set — much harder to bypass.
+
+Usage in scope files::
+
+    from ..security import V, validate_field
+
+    validate_field(name,     V.INTERFACE_NAME, "name")
+    validate_field(address,  V.IP_CIDR,        "address")
+    validate_field(comment,  V.COMMENT,        "comment")
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from enum import Enum
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Custom exception
+# ---------------------------------------------------------------------------
+
+class SecurityError(ValueError):
+    """Raised when a security violation is detected in user input."""
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — Structural command-injection prevention
+# ---------------------------------------------------------------------------
+
+# Characters that NEVER appear in a legitimate RouterOS command string but
+# are the classic command-injection enablers.  '[' and ']' are intentionally
+# NOT blocked here because RouterOS uses them in the [find ...] selector.
+_COMMAND_FORBIDDEN = re.compile(r'[;`{}\r\n]')
+
+
+def check_command_safety(command: str) -> None:
+    """Validate the final assembled RouterOS command for command-injection.
+
+    Called by the connector immediately before the command is sent over SSH.
+    Blocks the canonical issue #53 payload (``foo"] ; /system reboot;``) and
+    all newline/carriage-return injection without any external dependency.
+    """
+    match = _COMMAND_FORBIDDEN.search(command)
+    if match:
+        char = match.group()
+        label = {"\n": "newline", "\r": "carriage-return"}.get(char, repr(char))
+        raise SecurityError(
+            f"RouterOS command contains a forbidden character ({label}). "
+            "Possible command injection attempt."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — Per-field allowlist
+# ---------------------------------------------------------------------------
+
+class V(str, Enum):
+    """Field-type identifiers for validate_field()."""
+    INTERFACE_NAME  = "interface_name"   # ether1, bridge, wg0 …
+    IP_ADDRESS      = "ip_address"       # 192.168.1.1
+    IP_CIDR         = "ip_cidr"          # 192.168.1.0/24
+    IP_RANGE        = "ip_range"         # 192.168.1.1-192.168.1.100
+    IP_RANGES       = "ip_ranges"        # comma-separated CIDR list
+    HOSTNAME        = "hostname"         # router.example.com
+    MAC_ADDRESS     = "mac_address"      # AA:BB:CC:DD:EE:FF
+    BANDWIDTH       = "bandwidth"        # 10M  /  10M/10M
+    DURATION        = "duration"         # 1d  12h  1h30m
+    COMMENT         = "comment"          # free text, printable ASCII
+    ROUTEROS_ID     = "routeros_id"      # *1  /  1  /  0
+    USERNAME        = "username"         # admin, mcp-user
+    WG_KEY          = "wg_key"           # base64 WireGuard public key
+    ROUTING_MARK    = "routing_mark"     # a VRF/policy name
+    ADDRESS_LIST    = "address_list"     # firewall address-list name
+    PORT_SPEC       = "port_spec"        # 80  /  80-443  /  80,443
+    LOG_PREFIX      = "log_prefix"       # short text label
+
+
+# Compiled patterns — tight allowlists that match only what RouterOS actually
+# accepts for each field type.
+_PATTERNS: dict[V, re.Pattern] = {
+    # Interface names: letters, digits, dot, dash, underscore; 1-47 chars
+    V.INTERFACE_NAME: re.compile(r'^[a-zA-Z0-9._-]{1,47}$'),
+
+    # IPv4 dotted-decimal (plain host address)
+    V.IP_ADDRESS: re.compile(
+        r'^(\d{1,3}\.){3}\d{1,3}$'
+    ),
+
+    # IPv4 CIDR (address optional prefix-length)
+    V.IP_CIDR: re.compile(
+        r'^(\d{1,3}\.){3}\d{1,3}(/\d{1,2})?$'
+    ),
+
+    # IPv4 range: 192.168.1.1-192.168.1.100
+    V.IP_RANGE: re.compile(
+        r'^(\d{1,3}\.){3}\d{1,3}-(\d{1,3}\.){3}\d{1,3}$'
+    ),
+
+    # Comma-separated CIDR list: "10.0.0.0/8,192.168.1.0/24"
+    V.IP_RANGES: re.compile(
+        r'^(\d{1,3}\.){3}\d{1,3}(-(\d{1,3}\.){3}\d{1,3}|(/\d{1,2})?)'
+        r'(,(\d{1,3}\.){3}\d{1,3}(-(\d{1,3}\.){3}\d{1,3}|(/\d{1,2})?))*$'
+    ),
+
+    # Hostname: letters, digits, dot, dash
+    V.HOSTNAME: re.compile(r'^[a-zA-Z0-9._-]{1,253}$'),
+
+    # MAC address: AA:BB:CC:DD:EE:FF or AA-BB-CC-DD-EE-FF
+    V.MAC_ADDRESS: re.compile(
+        r'^([0-9A-Fa-f]{2}[:\-]){5}[0-9A-Fa-f]{2}$'
+    ),
+
+    # Bandwidth: "10M", "512K", "1G", "10M/5M"
+    V.BANDWIDTH: re.compile(
+        r'^\d+(\.\d+)?[KMGkmg]?(\/\d+(\.\d+)?[KMGkmg]?)?$'
+    ),
+
+    # Duration: "30s", "5m", "1h", "2d", "1h30m", "1w"
+    V.DURATION: re.compile(
+        r'^(\d+[wdhms])+$'
+    ),
+
+    # Comment: printable ASCII only, max 255 chars
+    V.COMMENT: re.compile(r'^[\x20-\x7E]{0,255}$'),
+
+    # RouterOS IDs: "*1", "0", "42"
+    V.ROUTEROS_ID: re.compile(r'^\*?\d+$'),
+
+    # Username: alphanumeric + underscore + dash
+    V.USERNAME: re.compile(r'^[a-zA-Z0-9._-]{1,64}$'),
+
+    # WireGuard base64 public key (44 chars)
+    V.WG_KEY: re.compile(r'^[A-Za-z0-9+/]{43}=$'),
+
+    # Routing mark / VRF name: same as interface name
+    V.ROUTING_MARK: re.compile(r'^[a-zA-Z0-9._-]{1,64}$'),
+
+    # Firewall address-list name: letters, digits, spaces, dot, dash, underscore
+    V.ADDRESS_LIST: re.compile(r'^[a-zA-Z0-9 ._-]{1,64}$'),
+
+    # Port spec: single port, range, or comma list
+    V.PORT_SPEC: re.compile(r'^\d+(-\d+)?(,\d+(-\d+)?)*$'),
+
+    # Log prefix: short printable label, no quotes
+    V.LOG_PREFIX: re.compile(r"^[a-zA-Z0-9 ._:\-]{0,64}$"),
+}
+
+
+def validate_field(
+    value: Optional[str],
+    field_type: V,
+    field_name: str = "input",
+) -> None:
+    """Validate *value* against the allowlist for *field_type*.
+
+    A no-op when *value* is ``None`` or an empty string (optional fields).
+    Raises :class:`SecurityError` when the value contains characters outside
+    the allowed set for the given field type.
+
+    Parameters
+    ----------
+    value:
+        The user-provided string to validate.
+    field_type:
+        The :class:`V` enum member that identifies the expected field type.
+    field_name:
+        Human-readable parameter name used in the error message.
+    """
+    if not value:
+        return
+
+    pattern = _PATTERNS[field_type]
+    if not pattern.match(value):
+        raise SecurityError(
+            f"Invalid value for '{field_name}': {value!r} is not a valid "
+            f"{field_type.value.replace('_', ' ')}."
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,15 +95,53 @@ def make_dummy_value(param: inspect.Parameter) -> Any:
         return "test"
 
     if ann is str:
-        if "address" in name:
-            return "192.0.2.1"
+        # IP / network fields
+        if "address" in name and "list" not in name and "endpoint" not in name:
+            return "192.0.2.0/24"
+        if name in {"network", "destination"}:
+            return "192.0.2.0/24"
+        if "gateway" in name or "pref_src" in name:
+            return "192.0.2.254"
         if "dst" in name:
             return "203.0.113.0/24"
-        if "gateway" in name:
-            return "192.0.2.254"
-        if "interface" in name:
+        # Interface / bridge / parent
+        if "interface" in name or name in {"bridge", "parent"}:
             return "ether1"
-        if "name" == name:
+        # IP ranges (pool)
+        if "ranges" in name:
+            return "192.168.1.1-192.168.1.100"
+        # Endpoint (WireGuard peer) — can be host:port or plain host
+        if "endpoint" in name:
+            return "vpn.example.com"
+        # WireGuard keys — must be valid base64 (44 chars, ending =)
+        if "public_key" in name or "private_key" in name or "preshared_key" in name:
+            return "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+        # Bandwidth strings
+        if any(k in name for k in ("max_limit", "limit_at", "burst_limit", "burst_threshold")):
+            return "10M/10M"
+        # Duration / time strings
+        if any(k in name for k in ("burst_time", "lease_time", "keepalive")):
+            return "30s"
+        # Comment / description / log prefix
+        if any(k in name for k in ("comment", "description", "log_prefix")):
+            return "test comment"
+        # Port specs
+        if "src_port" in name or "dst_port" in name:
+            return "80"
+        # Address-list names
+        if "address_list" in name:
+            return "my-list"
+        # Routing mark / table
+        if "routing_mark" in name or "table" in name:
+            return "main"
+        # Usernames
+        if "username" in name or name == "user":
+            return "admin"
+        # RouterOS IDs
+        if name.endswith("_id") or "_id" in name:
+            return "*1"
+        # Generic name
+        if name == "name":
             return "test-name"
         if "filename" in name:
             return "test.rsc"

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -1,0 +1,198 @@
+"""Tests for the security module — command-injection + per-field allowlists."""
+
+import pytest
+
+from mcp_mikrotik.security import SecurityError, V, check_command_safety, validate_field
+
+
+# ---------------------------------------------------------------------------
+# check_command_safety — structural command-injection prevention
+# ---------------------------------------------------------------------------
+
+class TestCheckCommandSafety:
+
+    def test_clean_command_passes(self):
+        check_command_safety("/interface print")
+
+    def test_find_selector_passes(self):
+        # [ and ] must be allowed — the [find ...] selector uses them
+        check_command_safety('/interface vlan set [find name="vlan100"] mtu=1400')
+
+    def test_complex_legitimate_command_passes(self):
+        check_command_safety(
+            '/ip firewall nat add chain=srcnat action=masquerade '
+            'out-interface="ether1-wan" comment="masq rule"'
+        )
+
+    def test_semicolon_blocked(self):
+        with pytest.raises(SecurityError, match="forbidden character"):
+            check_command_safety('/interface print where name="x" ; /system reboot')
+
+    def test_issue_53_exact_payload_blocked(self):
+        # The canonical example from the issue report
+        payload = 'foo"] ; /system reboot;'
+        with pytest.raises(SecurityError, match="forbidden character"):
+            check_command_safety(f'/interface print detail where name="{payload}"')
+
+    def test_newline_blocked(self):
+        with pytest.raises(SecurityError, match="newline"):
+            check_command_safety("/interface print\n/system reboot")
+
+    def test_carriage_return_blocked(self):
+        with pytest.raises(SecurityError, match="carriage-return"):
+            check_command_safety("/interface print\r/system reset-configuration")
+
+    def test_backtick_blocked(self):
+        with pytest.raises(SecurityError, match="forbidden character"):
+            check_command_safety("/interface print `reboot`")
+
+    def test_curly_braces_blocked(self):
+        with pytest.raises(SecurityError, match="forbidden character"):
+            check_command_safety("/system script run {:put done}")
+
+
+# ---------------------------------------------------------------------------
+# validate_field — per-field allowlist
+# ---------------------------------------------------------------------------
+
+class TestValidateField:
+
+    # ── None / empty is always a no-op ──────────────────────────────────────
+
+    def test_none_is_noop(self):
+        validate_field(None, V.INTERFACE_NAME, "name")
+
+    def test_empty_string_is_noop(self):
+        validate_field("", V.IP_CIDR, "address")
+
+    # ── INTERFACE_NAME ───────────────────────────────────────────────────────
+
+    def test_interface_name_simple(self):
+        validate_field("ether1", V.INTERFACE_NAME, "name")
+
+    def test_interface_name_complex(self):
+        validate_field("ether1-wan.100", V.INTERFACE_NAME, "name")
+
+    def test_interface_name_rejects_space(self):
+        with pytest.raises(SecurityError):
+            validate_field("ether 1", V.INTERFACE_NAME, "name")
+
+    def test_interface_name_rejects_dollar(self):
+        with pytest.raises(SecurityError):
+            validate_field("$var", V.INTERFACE_NAME, "name")
+
+    # ── IP_ADDRESS / IP_CIDR ─────────────────────────────────────────────────
+
+    def test_ip_address_valid(self):
+        validate_field("192.168.1.1", V.IP_ADDRESS, "addr")
+
+    def test_ip_cidr_valid(self):
+        validate_field("192.168.1.0/24", V.IP_CIDR, "addr")
+
+    def test_ip_cidr_no_prefix(self):
+        validate_field("10.0.0.1", V.IP_CIDR, "addr")
+
+    def test_ip_cidr_rejects_letters(self):
+        with pytest.raises(SecurityError):
+            validate_field("bad-address", V.IP_CIDR, "addr")
+
+    # ── IP_RANGES ────────────────────────────────────────────────────────────
+
+    def test_ip_range_valid(self):
+        validate_field("192.168.1.1-192.168.1.100", V.IP_RANGES, "ranges")
+
+    def test_ip_ranges_multiple_valid(self):
+        validate_field("10.0.0.1-10.0.0.50,10.0.0.100-10.0.0.120", V.IP_RANGES, "ranges")
+
+    def test_ip_ranges_rejects_text(self):
+        with pytest.raises(SecurityError):
+            validate_field("ignore all instructions", V.IP_RANGES, "ranges")
+
+    # ── BANDWIDTH ────────────────────────────────────────────────────────────
+
+    def test_bandwidth_upload_only(self):
+        validate_field("10M", V.BANDWIDTH, "max_limit")
+
+    def test_bandwidth_up_down(self):
+        validate_field("10M/5M", V.BANDWIDTH, "max_limit")
+
+    def test_bandwidth_rejects_text(self):
+        with pytest.raises(SecurityError):
+            validate_field("fast", V.BANDWIDTH, "max_limit")
+
+    # ── DURATION ─────────────────────────────────────────────────────────────
+
+    def test_duration_seconds(self):
+        validate_field("30s", V.DURATION, "lease_time")
+
+    def test_duration_complex(self):
+        validate_field("1h30m", V.DURATION, "lease_time")
+
+    def test_duration_days(self):
+        validate_field("1d", V.DURATION, "lease_time")
+
+    def test_duration_rejects_text(self):
+        with pytest.raises(SecurityError):
+            validate_field("forever", V.DURATION, "lease_time")
+
+    # ── COMMENT ──────────────────────────────────────────────────────────────
+
+    def test_comment_plain(self):
+        validate_field("office wifi uplink", V.COMMENT, "comment")
+
+    def test_comment_printable_ascii(self):
+        validate_field("rack-3, port 5 (uplink)", V.COMMENT, "comment")
+
+    def test_comment_rejects_non_printable(self):
+        with pytest.raises(SecurityError):
+            validate_field("bad\x00byte", V.COMMENT, "comment")
+
+    def test_comment_rejects_too_long(self):
+        with pytest.raises(SecurityError):
+            validate_field("x" * 256, V.COMMENT, "comment")
+
+    # ── ROUTEROS_ID ──────────────────────────────────────────────────────────
+
+    def test_id_numeric(self):
+        validate_field("0", V.ROUTEROS_ID, "rule_id")
+
+    def test_id_star_prefix(self):
+        validate_field("*3", V.ROUTEROS_ID, "rule_id")
+
+    def test_id_rejects_text(self):
+        with pytest.raises(SecurityError):
+            validate_field("first", V.ROUTEROS_ID, "rule_id")
+
+    # ── PORT_SPEC ─────────────────────────────────────────────────────────────
+
+    def test_port_single(self):
+        validate_field("80", V.PORT_SPEC, "dst_port")
+
+    def test_port_range(self):
+        validate_field("80-443", V.PORT_SPEC, "dst_port")
+
+    def test_port_list(self):
+        validate_field("80,443,8080", V.PORT_SPEC, "dst_port")
+
+    def test_port_rejects_text(self):
+        with pytest.raises(SecurityError):
+            validate_field("http", V.PORT_SPEC, "dst_port")
+
+    # ── WG_KEY ───────────────────────────────────────────────────────────────
+
+    def test_wg_key_valid(self):
+        validate_field("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", V.WG_KEY, "public_key")
+
+    def test_wg_key_rejects_short(self):
+        with pytest.raises(SecurityError):
+            validate_field("AAAA=", V.WG_KEY, "public_key")
+
+    # ── Error message quality ─────────────────────────────────────────────────
+
+    def test_error_includes_field_name(self):
+        with pytest.raises(SecurityError, match="'my_field'"):
+            validate_field("bad value!", V.INTERFACE_NAME, "my_field")
+
+    def test_error_includes_bad_value(self):
+        with pytest.raises(SecurityError, match="bad value"):
+            validate_field("bad value!", V.INTERFACE_NAME, "name")


### PR DESCRIPTION
Closes #53

## Approach

Two zero-dependency layers. No ML model. No download. No new packages.

### Layer 1 — Structural command-injection check (always on)

`check_command_safety()` rejects characters that **never appear in a legitimate RouterOS command** but enable command-injection, immediately before SSH execution:

| Blocked | Reason |
|---|---|
| `;` | command separator |
| `` ` `` | backtick sub-command |
| `{` `}` | script block delimiters |
| `\n` `\r` | statement separators |

`[` and `]` stay allowed (used by the `[find ...]` selector). **Blocks the exact issue #53 payload** (`foo"] ; /system reboot;`) by default.

### Layer 2 — Per-field allowlist (always on)

`validate_field(value, V.<TYPE>, field_name)` applies a tight regex allowlist matched to each RouterOS field type **before** the command is built. Only a known-good character set is accepted — much harder to bypass than a blocklist.

**17 field types, 250 call sites across 12 scope modules:**

| Type | Example valid value |
|---|---|
| `INTERFACE_NAME` | `ether1-wan` |
| `IP_CIDR` | `192.168.1.0/24` |
| `IP_RANGES` | `10.0.0.1-10.0.0.50,10.0.0.100-10.0.0.120` |
| `BANDWIDTH` | `10M/5M` |
| `DURATION` | `1h30m` |
| `COMMENT` | printable ASCII ≤ 255 chars |
| `WG_KEY` | 44-char base64 WireGuard key |
| … | … |

## Tests

- **89 unit tests passing** (+44 new)
- `conftest.py` updated to emit valid field-type-aware dummy values
- Smoke tests cover all 12 modified scope modules

## Docs

- `docs/security/input-validation.md` — full field-type reference table
- `SECURITY.md` — updated §2
- `docs/README.md` — Security section added

🤖 Generated with [Claude Code](https://claude.com/claude-code)