### PR TITLE
fix(security): warn on plaintext password in container at startup

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -94,13 +94,31 @@ MikroTik MCP uses SSH to connect to RouterOS devices. Be aware of the following:
 
 ### 8. Docker Security
 
-When running MikroTik MCP in Docker:
+> ⚠️ **Environment variables are exposed by `docker inspect`.** Any value passed
+> to a container as an environment variable — whether via `-e VAR=value`,
+> `-e VAR` (inherited from the host shell), or `--env-file` — is stored in the
+> container's configuration and shown in full by `docker inspect`. Reading a
+> file into a variable (`export VAR=$(cat secret.txt)`) does **not** help: the
+> resolved value still ends up in the container's environment.
 
-- Don't pass credentials via command-line arguments (visible in `docker ps`)
-- Use Docker secrets or environment variables for credentials
+To keep credentials out of `docker inspect`, prefer (in order):
+
+1. **SSH key-based authentication** (`MIKROTIK_KEY_FILENAME` / `--key-filename`) —
+   no password is stored in the environment at all. This is the recommended
+   approach and is natively supported.
+2. **Docker / Swarm secrets** — mounted as files under `/run/secrets/`, never
+   placed in the environment. (Requires an entrypoint that reads the file into
+   the process environment at startup, which keeps it out of `docker inspect`.)
+3. **Runtime fetch from a secrets manager** (HashiCorp Vault, AWS Secrets
+   Manager, etc.) performed inside the container, rather than injecting the
+   secret at `docker run` time.
+
+Additional hardening:
+
+- Don't pass credentials as literal command-line arguments (also visible in
+  `docker ps` and shell history)
 - Run containers with minimal privileges
-- Keep Docker images updated
-- Use specific version tags instead of `latest`
+- Keep Docker images updated and use specific version tags instead of `latest`
 - Scan images for vulnerabilities regularly
 
 ### 9. API Exposure
@@ -156,6 +174,11 @@ When exposing MikroTik MCP via REST API (using MCPO):
 
 ## Secure Configuration Example
 
+Passing the password as an environment variable — in **any** form — leaves it
+visible in `docker inspect`. The configuration below instead uses **SSH
+key-based authentication**, so no secret is stored in the container's
+environment:
+
 ```json
 {
   "mcpServers": {
@@ -165,10 +188,10 @@ When exposing MikroTik MCP via REST API (using MCPO):
         "run",
         "--rm",
         "-i",
-        "-e", "MIKROTIK_HOST",
-        "-e", "MIKROTIK_USERNAME",
-        "-e", "MIKROTIK_PASSWORD",
-        "-e", "MIKROTIK_PORT=22",
+        "-e", "MIKROTIK_HOST=192.168.88.1",
+        "-e", "MIKROTIK_USERNAME=mcp_user",
+        "-e", "MIKROTIK_KEY_FILENAME=/keys/id_ed25519",
+        "-v", "/secure/path/keys:/keys:ro",
         "mikrotik-mcp"
       ]
     }
@@ -176,13 +199,20 @@ When exposing MikroTik MCP via REST API (using MCPO):
 }
 ```
 
-Set environment variables securely instead of hardcoding credentials:
+> ❌ **Not safe from `docker inspect`:** the example below is a common but
+> mistaken pattern. `export MIKROTIK_PASSWORD=$(cat ...)` followed by
+> `docker run -e MIKROTIK_PASSWORD` still copies the resolved password into the
+> container's environment, where `docker inspect` reveals it:
+>
+> ```bash
+> # DON'T rely on this for secrecy — the value still shows in `docker inspect`:
+> export MIKROTIK_PASSWORD=$(cat /secure/path/password.txt)
+> docker run -e MIKROTIK_PASSWORD ... mikrotik-mcp
+> ```
 
-```bash
-export MIKROTIK_HOST=192.168.88.1
-export MIKROTIK_USERNAME=mcp_user
-export MIKROTIK_PASSWORD=$(cat /secure/path/password.txt)
-```
+If you must use a password instead of an SSH key, supply it via Docker secrets
+(mounted as a file under `/run/secrets/`) with an entrypoint that loads it into
+the process environment at startup — that keeps it out of `docker inspect`.
 
 ## Compliance and Standards
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -101,25 +101,18 @@ MikroTik MCP uses SSH to connect to RouterOS devices. Be aware of the following:
 > file into a variable (`export VAR=$(cat secret.txt)`) does **not** help: the
 > resolved value still ends up in the container's environment.
 
-To keep credentials out of `docker inspect`, prefer (in order):
+When running MikroTik MCP in a container, the MikroTik password is therefore
+visible to anyone who can run `docker inspect` on the host. The server logs a
+warning at startup when it detects this. To reduce the exposure:
 
-1. **SSH key-based authentication** (`MIKROTIK_KEY_FILENAME` / `--key-filename`) —
-   no password is stored in the environment at all. This is the recommended
-   approach and is natively supported.
-2. **Docker / Swarm secrets** — mounted as files under `/run/secrets/`, never
-   placed in the environment. (Requires an entrypoint that reads the file into
-   the process environment at startup, which keeps it out of `docker inspect`.)
-3. **Runtime fetch from a secrets manager** (HashiCorp Vault, AWS Secrets
-   Manager, etc.) performed inside the container, rather than injecting the
-   secret at `docker run` time.
-
-Additional hardening:
-
+- Manage the secret through your infrastructure — Docker / Swarm secrets
+  (mounted as files under `/run/secrets/`) or a secrets manager (HashiCorp
+  Vault, AWS Secrets Manager) — rather than a plain environment variable
+- Restrict which users can run `docker inspect` / access the Docker socket
 - Don't pass credentials as literal command-line arguments (also visible in
   `docker ps` and shell history)
-- Run containers with minimal privileges
-- Keep Docker images updated and use specific version tags instead of `latest`
-- Scan images for vulnerabilities regularly
+- Run containers with minimal privileges, keep images updated, and use pinned
+  version tags
 
 ### 9. API Exposure
 
@@ -171,48 +164,6 @@ When exposing MikroTik MCP via REST API (using MCPO):
 2. **Password Logging**: Passwords are not logged, but be cautious with debug logging that might expose sensitive command parameters.
 
 3. **Command Execution**: Direct command execution on RouterOS requires careful input validation at the application level.
-
-## Secure Configuration Example
-
-Passing the password as an environment variable — in **any** form — leaves it
-visible in `docker inspect`. The configuration below instead uses **SSH
-key-based authentication**, so no secret is stored in the container's
-environment:
-
-```json
-{
-  "mcpServers": {
-    "mikrotik-mcp-server": {
-      "command": "docker",
-      "args": [
-        "run",
-        "--rm",
-        "-i",
-        "-e", "MIKROTIK_HOST=192.168.88.1",
-        "-e", "MIKROTIK_USERNAME=mcp_user",
-        "-e", "MIKROTIK_KEY_FILENAME=/keys/id_ed25519",
-        "-v", "/secure/path/keys:/keys:ro",
-        "mikrotik-mcp"
-      ]
-    }
-  }
-}
-```
-
-> ❌ **Not safe from `docker inspect`:** the example below is a common but
-> mistaken pattern. `export MIKROTIK_PASSWORD=$(cat ...)` followed by
-> `docker run -e MIKROTIK_PASSWORD` still copies the resolved password into the
-> container's environment, where `docker inspect` reveals it:
->
-> ```bash
-> # DON'T rely on this for secrecy — the value still shows in `docker inspect`:
-> export MIKROTIK_PASSWORD=$(cat /secure/path/password.txt)
-> docker run -e MIKROTIK_PASSWORD ... mikrotik-mcp
-> ```
-
-If you must use a password instead of an SSH key, supply it via Docker secrets
-(mounted as a file under `/run/secrets/`) with an entrypoint that loads it into
-the process environment at startup — that keeps it out of `docker inspect`.
 
 ## Compliance and Standards
 

--- a/src/mcp_mikrotik/server.py
+++ b/src/mcp_mikrotik/server.py
@@ -8,24 +8,23 @@ from mcp_mikrotik.config import MikrotikConfig
 
 
 def _warn_if_plaintext_password_in_container(cfg: MikrotikConfig, logger: logging.Logger) -> None:
-    """Emit a security warning when a plaintext password is detected inside a container.
+    """Warn when running inside a container with a plaintext password in the env.
 
-    Credential management is an infrastructure concern, not an MCP concern — the
-    MCP server cannot solve it on its own. This warning nudges operators toward
-    safer alternatives (SSH keys, Docker secrets, a vault) without blocking startup.
+    Environment variables are visible via ``docker inspect``, so a password
+    passed this way is exposed to anyone with host access. This is purely a
+    nudge — it does not block startup. Credential management is ultimately an
+    infrastructure concern (Docker secrets, a vault, restricted host access).
     """
     in_container = os.path.exists("/.dockerenv") or os.environ.get("container") == "docker"
-    if in_container and cfg.password and not cfg.key_filename:
+    if in_container and cfg.password:
         logger.warning(
-            "Security notice: a plaintext password is set as an environment "
-            "variable inside a container, so it is visible to anyone who can run "
-            "'docker inspect' on the host. Passing it via --env-file or "
-            "'export VAR=$(cat file)' does NOT help — the resolved value still "
-            "ends up in the container's environment. To keep it out of "
-            "'docker inspect', prefer SSH key-based authentication "
-            "(MIKROTIK_KEY_FILENAME) so no password is stored, or inject the "
-            "secret via Docker secrets / a secrets manager at runtime. "
-            "See SECURITY.md."
+            "Security notice: MikroTik MCP is running inside a container with a "
+            "plaintext password set as an environment variable. Environment "
+            "variables are visible via 'docker inspect', so anyone with access "
+            "to the host can read the credential. In shared or production "
+            "environments, manage the secret through your infrastructure "
+            "(e.g. Docker secrets or a secrets manager) and restrict host "
+            "access. See SECURITY.md."
         )
 
 

--- a/src/mcp_mikrotik/server.py
+++ b/src/mcp_mikrotik/server.py
@@ -1,9 +1,30 @@
 import logging
+import os
 import sys
 
 from mcp_mikrotik import config
 from mcp_mikrotik.app import mcp
 from mcp_mikrotik.config import MikrotikConfig
+
+
+def _warn_if_plaintext_password_in_container(cfg: MikrotikConfig, logger: logging.Logger) -> None:
+    """Emit a security warning when a plaintext password is detected inside a container.
+
+    Credential management is an infrastructure concern, not an MCP concern — the
+    MCP server cannot solve it on its own. This warning nudges operators toward
+    safer alternatives (SSH keys, Docker secrets, a vault) without blocking startup.
+    """
+    in_container = os.path.exists("/.dockerenv") or os.environ.get("container") == "docker"
+    if in_container and cfg.password and not cfg.key_filename:
+        logger.warning(
+            "Security notice: a plaintext password is set via environment variable "
+            "inside a container. This password is visible to anyone who can run "
+            "'docker inspect' on the host. "
+            "Consider switching to SSH key-based authentication (--key-filename / "
+            "MIKROTIK_KEY_FILENAME) or supplying the password through Docker secrets "
+            "or a secrets manager rather than a plain environment variable. "
+            "See SECURITY.md for guidance."
+        )
 
 
 def main():
@@ -19,6 +40,8 @@ def main():
     logger.info(f"Using username: {config.mikrotik_config.username}")
     if config.mikrotik_config.key_filename:
         logger.info(f"Using key from: {config.mikrotik_config.key_filename}")
+
+    _warn_if_plaintext_password_in_container(config.mikrotik_config, logger)
 
     try:
         mcp.settings.host = config.mikrotik_config.mcp.host

--- a/src/mcp_mikrotik/server.py
+++ b/src/mcp_mikrotik/server.py
@@ -17,13 +17,15 @@ def _warn_if_plaintext_password_in_container(cfg: MikrotikConfig, logger: loggin
     in_container = os.path.exists("/.dockerenv") or os.environ.get("container") == "docker"
     if in_container and cfg.password and not cfg.key_filename:
         logger.warning(
-            "Security notice: a plaintext password is set via environment variable "
-            "inside a container. This password is visible to anyone who can run "
-            "'docker inspect' on the host. "
-            "Consider switching to SSH key-based authentication (--key-filename / "
-            "MIKROTIK_KEY_FILENAME) or supplying the password through Docker secrets "
-            "or a secrets manager rather than a plain environment variable. "
-            "See SECURITY.md for guidance."
+            "Security notice: a plaintext password is set as an environment "
+            "variable inside a container, so it is visible to anyone who can run "
+            "'docker inspect' on the host. Passing it via --env-file or "
+            "'export VAR=$(cat file)' does NOT help — the resolved value still "
+            "ends up in the container's environment. To keep it out of "
+            "'docker inspect', prefer SSH key-based authentication "
+            "(MIKROTIK_KEY_FILENAME) so no password is stored, or inject the "
+            "secret via Docker secrets / a secrets manager at runtime. "
+            "See SECURITY.md."
         )
 
 

--- a/tests/unit/test_server_main.py
+++ b/tests/unit/test_server_main.py
@@ -62,6 +62,61 @@ def test_server_main_exits_on_exception(monkeypatch):
     assert exc.value.code == 1
 
 
+def test_credential_warning_emitted_in_container_with_password(monkeypatch):
+    """Warning fires when a plaintext password is set inside a container."""
+    from mcp_mikrotik.server import _warn_if_plaintext_password_in_container
+    import logging, io, types
+
+    monkeypatch.setattr("os.path.exists", lambda p: p == "/.dockerenv")
+
+    cfg = types.SimpleNamespace(password="secret", key_filename=None)
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    logger = logging.getLogger("test_warn")
+    logger.addHandler(handler)
+    logger.setLevel(logging.WARNING)
+    _warn_if_plaintext_password_in_container(cfg, logger)
+    logger.removeHandler(handler)
+    assert "plaintext password" in stream.getvalue()
+
+
+def test_credential_warning_suppressed_with_key(monkeypatch):
+    """No warning when SSH key is configured (password exposure isn't an issue)."""
+    from mcp_mikrotik.server import _warn_if_plaintext_password_in_container
+    import logging, io, types
+
+    monkeypatch.setattr("os.path.exists", lambda p: p == "/.dockerenv")
+
+    cfg = types.SimpleNamespace(password="secret", key_filename="/keys/id_ed25519")
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    logger = logging.getLogger("test_warn_key")
+    logger.addHandler(handler)
+    logger.setLevel(logging.WARNING)
+    _warn_if_plaintext_password_in_container(cfg, logger)
+    logger.removeHandler(handler)
+    assert stream.getvalue() == ""
+
+
+def test_credential_warning_suppressed_outside_container(monkeypatch):
+    """No warning when not running inside a container."""
+    from mcp_mikrotik.server import _warn_if_plaintext_password_in_container
+    import logging, io, types
+
+    monkeypatch.setattr("os.path.exists", lambda p: False)
+    monkeypatch.delenv("container", raising=False)
+
+    cfg = types.SimpleNamespace(password="secret", key_filename=None)
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    logger = logging.getLogger("test_warn_nocontainer")
+    logger.addHandler(handler)
+    logger.setLevel(logging.WARNING)
+    _warn_if_plaintext_password_in_container(cfg, logger)
+    logger.removeHandler(handler)
+    assert stream.getvalue() == ""
+
+
 def test_server_main_handles_keyboard_interrupt(monkeypatch):
     from mcp_mikrotik import server
 

--- a/tests/unit/test_server_main.py
+++ b/tests/unit/test_server_main.py
@@ -80,17 +80,17 @@ def test_credential_warning_emitted_in_container_with_password(monkeypatch):
     assert "plaintext password" in stream.getvalue()
 
 
-def test_credential_warning_suppressed_with_key(monkeypatch):
-    """No warning when SSH key is configured (password exposure isn't an issue)."""
+def test_credential_warning_suppressed_without_password(monkeypatch):
+    """No warning when no password is set (e.g. key-only / unauthenticated setup)."""
     from mcp_mikrotik.server import _warn_if_plaintext_password_in_container
     import logging, io, types
 
     monkeypatch.setattr("os.path.exists", lambda p: p == "/.dockerenv")
 
-    cfg = types.SimpleNamespace(password="secret", key_filename="/keys/id_ed25519")
+    cfg = types.SimpleNamespace(password="", key_filename="/keys/id_ed25519")
     stream = io.StringIO()
     handler = logging.StreamHandler(stream)
-    logger = logging.getLogger("test_warn_key")
+    logger = logging.getLogger("test_warn_nopw")
     logger.addHandler(handler)
     logger.setLevel(logging.WARNING)
     _warn_if_plaintext_password_in_container(cfg, logger)


### PR DESCRIPTION
Closes #50

## Goal

Nudge users when MikroTik MCP is running **inside a Docker container with a plaintext password** — because environment variables are visible via `docker inspect`. Credential management itself is an infrastructure concern; this just makes the risk visible.

## Change

`server.py` logs a `WARNING` at startup when:
- it detects it's running in a container (`/.dockerenv` present, or `container=docker`), **and**
- a password is set

```
Security notice: MikroTik MCP is running inside a container with a plaintext
password set as an environment variable. Environment variables are visible via
'docker inspect', so anyone with access to the host can read the credential. In
shared or production environments, manage the secret through your infrastructure
(e.g. Docker secrets or a secrets manager) and restrict host access. See SECURITY.md.
```

No behaviour change, no blocking. Verified the warning actually fires inside a real container (`/.dockerenv` is present).

## Docs

- `SECURITY.md` §8 — clarified that env vars (any form) are exposed by `docker inspect`; listed infrastructure-level mitigations
- Removed the outdated "Secure Configuration Example" section

## Tests

3 unit tests: fires in container with password / suppressed without password / suppressed outside container. **48 total passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)