### PR TITLE
feat(ci): publish multi-arch Docker image to GHCR

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Ensure shell scripts always use LF line endings so Docker images built on
+# any host (including Windows checkouts) have a working entrypoint.
+*.sh text eol=lf
+docker-entrypoint.sh text eol=lf

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,80 @@
+# =============================================================================
+# GitHub Actions Workflow: Build and Publish multi-arch Docker image to GHCR
+# =============================================================================
+#
+# Purpose:
+#   Builds the Docker image for linux/amd64 + linux/arm64 and publishes it to
+#   the GitHub Container Registry (ghcr.io/<owner>/<repo>).
+#
+# Tagging strategy:
+#   Push to master              -> :edge        + :sha-<short>
+#   Push of a vX.Y.Z git tag    -> :X.Y.Z, :X.Y, :latest + :sha-<short>
+#
+#   The PyPI release pipeline (publish.yml) creates the vX.Y.Z stable tags via
+#   GitVersion, so a tagged release automatically produces a versioned image
+#   and updates :latest. Master builds get the moving :edge tag.
+#
+# Registry:
+#   ghcr.io/jeff-nasseri/mikrotik-mcp
+#
+# Authentication:
+#   Uses the built-in GITHUB_TOKEN (no extra secret required). The token needs
+#   packages: write, which is granted in the job permissions block below.
+# =============================================================================
+name: Publish Docker Image
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            # Stable releases (vX.Y.Z tags): semantic version tags + latest
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            # Master branch: a moving 'edge' tag
+            type=raw,value=edge,enable={{is_default_branch}}
+            # Always include a short-SHA tag for traceability
+            type=sha,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -62,6 +62,34 @@ HTTP-based transports (`sse`, `streamable-http`) expose a `GET /health` endpoint
 
 The easiest way to run the MCP MikroTik server is using Docker.
 
+### Official prebuilt image (GitHub Container Registry)
+
+A multi-arch image (`linux/amd64` + `linux/arm64`) is published to GHCR, so you
+can pull it directly instead of building from source:
+
+```bash
+# Latest stable release
+docker pull ghcr.io/jeff-nasseri/mikrotik-mcp:latest
+
+# A specific version
+docker pull ghcr.io/jeff-nasseri/mikrotik-mcp:0.9.2
+
+# Bleeding-edge build from the master branch
+docker pull ghcr.io/jeff-nasseri/mikrotik-mcp:edge
+```
+
+| Tag | Points to |
+|-----|-----------|
+| `latest` | The most recent stable release |
+| `X.Y.Z` / `X.Y` | A specific released version |
+| `edge` | The latest commit on `master` |
+| `sha-<short>` | A specific commit |
+
+In the examples below, substitute `ghcr.io/jeff-nasseri/mikrotik-mcp:latest` for
+`mikrotik-mcp` to use the prebuilt image instead of a locally built one.
+
+### Build from source
+
 1. **Clone the repository:**
    ```bash
    git clone https://github.com/jeff-nasseri/mikrotik-mcp.git
@@ -120,3 +148,39 @@ The easiest way to run the MCP MikroTik server is using Docker.
    | `MIKROTIK_MCP__TRANSPORT` | Transport type: `stdio`, `sse`, `streamable-http` | `stdio` |
    | `MIKROTIK_MCP__HOST` | HTTP server listen address | `0.0.0.0` |
    | `MIKROTIK_MCP__PORT` | HTTP server listen port | `8000` |
+
+### Docker Compose
+
+For a long-running, self-hosted setup, use an HTTP-based transport
+(`sse` or `streamable-http`) so MCP clients can connect over the network. The
+`stdio` transport is meant for direct IDE integration where the client attaches
+to the process's stdin/stdout, not for a standalone background service.
+
+```yaml
+services:
+  mikrotik-mcp:
+    image: ghcr.io/jeff-nasseri/mikrotik-mcp:latest
+    container_name: mikrotik-mcp
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    environment:
+      MIKROTIK_HOST: "192.168.88.1"
+      MIKROTIK_USERNAME: "admin"
+      MIKROTIK_PASSWORD: "change-me"
+      MIKROTIK_PORT: "22"                      # SSH port of the RouterOS device
+      MIKROTIK_MCP__TRANSPORT: "streamable-http"
+      MIKROTIK_MCP__HOST: "0.0.0.0"
+      MIKROTIK_MCP__PORT: "8000"
+```
+
+```bash
+docker compose up -d
+```
+
+The server is then reachable at `http://localhost:8000/mcp` (streamable HTTP)
+or `http://localhost:8000/sse` (if you set `MIKROTIK_MCP__TRANSPORT: sse`), and
+`GET http://localhost:8000/health` returns `OK`.
+
+> ⚠️ Passing `MIKROTIK_PASSWORD` as an environment variable makes it visible via
+> `docker inspect`. See [SECURITY.md](../../SECURITY.md) for safer alternatives.


### PR DESCRIPTION
Closes #86

## What this adds

A GitHub Actions workflow (`.github/workflows/docker-publish.yml`) that builds and publishes an official **multi-arch** Docker image to the GitHub Container Registry.

- **Registry:** `ghcr.io/jeff-nasseri/mikrotik-mcp`
- **Platforms:** `linux/amd64` + `linux/arm64` (via QEMU + Buildx)
- **Actions used:** `docker/setup-qemu-action`, `docker/setup-buildx-action`, `docker/login-action`, `docker/metadata-action`, `docker/build-push-action` (exactly as suggested in the issue)
- **Auth:** built-in `GITHUB_TOKEN` with `packages: write` — no extra secret needed
- **Layer caching:** GitHub Actions cache (`type=gha`)

## Tagging strategy

| Trigger | Tags produced |
|---|---|
| Push to `master` | `:edge`, `:sha-<short>` |
| Push of a `vX.Y.Z` git tag | `:X.Y.Z`, `:X.Y`, `:latest`, `:sha-<short>` |

The existing PyPI pipeline (`publish.yml`) already creates the `vX.Y.Z` stable tags via GitVersion, so a tagged release automatically produces a versioned image and updates `:latest`. Master builds get the moving `:edge` tag, keeping `:latest` pointed at stable releases (per the issue's request).

## Docs

`docs/getting-started/installation.md`:
- "Official prebuilt image (GHCR)" section with `docker pull` instructions and a tag-meaning table
- A **Docker Compose** example

> Two intentional corrections to the issue's example compose file:
> - `MIKROTIK_PORT` → `22` (the issue used `8728`, the RouterOS *API* port; this MCP connects over **SSH**)
> - transport → `streamable-http` with port `8000` exposed (the issue used `stdio`, which can't work for a long-running `restart: unless-stopped` service — stdio needs a client attached to the process's stdin/stdout)

## Extra: `.gitattributes`

Forces LF on shell scripts so `docker-entrypoint.sh` always has a working line ending in the built image, regardless of the contributor's OS.

## Notes / things to confirm in review

- **First publish & package visibility:** the first push creates the GHCR package as **private** by default. You'll need to flip it to public in the repo's *Packages* settings (or it requires auth to pull). I can't change that from code.
- **arm64 build time:** the image is Alpine-based and compiles `cryptography`/`paramiko` from source under QEMU for arm64, so the first (uncached) build may take a while. Caching mitigates subsequent runs.

Happy to adjust the tagging strategy, platforms, or trigger conditions based on your preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)