### PR TITLE
fix(http): configurable Host/Origin allowlist for HTTP transports (reverse-proxy 421)

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -148,6 +148,8 @@ In the examples below, substitute `ghcr.io/jeff-nasseri/mikrotik-mcp:latest` for
    | `MIKROTIK_MCP__TRANSPORT` | Transport type: `stdio`, `sse`, `streamable-http` | `stdio` |
    | `MIKROTIK_MCP__HOST` | HTTP server listen address | `0.0.0.0` |
    | `MIKROTIK_MCP__PORT` | HTTP server listen port | `8000` |
+   | `MIKROTIK_MCP__ALLOWED_HOSTS` | Comma-separated `Host` header allowlist for the HTTP transports (DNS-rebinding protection). Set to your domain behind a reverse proxy; `*` disables the check. | _(empty)_ |
+   | `MIKROTIK_MCP__ALLOWED_ORIGINS` | Comma-separated `Origin` header allowlist for the HTTP transports. | _(empty)_ |
 
 ### Docker Compose
 
@@ -181,6 +183,36 @@ docker compose up -d
 The server is then reachable at `http://localhost:8000/mcp` (streamable HTTP)
 or `http://localhost:8000/sse` (if you set `MIKROTIK_MCP__TRANSPORT: sse`), and
 `GET http://localhost:8000/health` returns `OK`.
+
+#### Behind a reverse proxy (or any non-localhost access)
+
+The HTTP transports (`sse` / `streamable-http`) apply DNS-rebinding protection,
+which validates the request's `Host` header. When the server is reached on a
+custom domain or a non-localhost IP — e.g. through a reverse proxy — you must
+allowlist that host, otherwise requests to `/mcp` are rejected with **HTTP 421
+"Invalid Host header"** (while `/health` still works, since it is exempt):
+
+```yaml
+    environment:
+      MIKROTIK_MCP__TRANSPORT: "streamable-http"
+      MIKROTIK_MCP__HOST: "0.0.0.0"
+      # Allowlist the Host header(s) clients use to reach the server:
+      MIKROTIK_MCP__ALLOWED_HOSTS: "mcp.example.com"
+      # Allowlist the Origin header(s) for browser-based clients:
+      MIKROTIK_MCP__ALLOWED_ORIGINS: "https://app.example.com"
+```
+
+Both accept a **comma-separated** list, e.g.:
+
+```yaml
+      MIKROTIK_MCP__ALLOWED_HOSTS: "mcp.example.com, mcp.example.com:*, 192.168.1.50:8000"
+      MIKROTIK_MCP__ALLOWED_ORIGINS: "https://app.example.com, https://admin.example.com"
+```
+
+- Append `:*` to a host (e.g. `mcp.example.com:*`) to allow it on any port.
+- Set `MIKROTIK_MCP__ALLOWED_HOSTS: "*"` to disable the host check entirely.
+- If you leave it unset on a non-localhost bind, the check is auto-disabled (a
+  warning is logged) so the server still works out of the box.
 
 > ⚠️ Passing `MIKROTIK_PASSWORD` as an environment variable makes it visible via
 > `docker inspect`. See [SECURITY.md](../../SECURITY.md) for safer alternatives.

--- a/src/mcp_mikrotik/config.py
+++ b/src/mcp_mikrotik/config.py
@@ -9,6 +9,15 @@ class McpServerSettings(BaseModel):
     host: str = "0.0.0.0"
     port: int = 8000
 
+    # DNS-rebinding protection for the HTTP transports (sse / streamable-http).
+    # Comma-separated allowlists for the Host and Origin request headers. Needed
+    # when serving behind a reverse proxy or on a non-localhost host — otherwise
+    # requests with an external Host header are rejected with HTTP 421
+    # "Invalid Host header". Set allowed_hosts to your domain (e.g.
+    # "mcp.example.com"); a value of "*" disables the host check entirely.
+    allowed_hosts: str = ""
+    allowed_origins: str = ""
+
 
 class MikrotikConfig(BaseSettings):
     model_config = SettingsConfigDict(

--- a/src/mcp_mikrotik/server.py
+++ b/src/mcp_mikrotik/server.py
@@ -2,9 +2,13 @@ import logging
 import os
 import sys
 
+from mcp.server.transport_security import TransportSecuritySettings
+
 from mcp_mikrotik import config
 from mcp_mikrotik.app import mcp
-from mcp_mikrotik.config import MikrotikConfig
+from mcp_mikrotik.config import McpServerSettings, MikrotikConfig
+
+_LOCALHOST_HOSTS = ("127.0.0.1", "localhost", "::1")
 
 
 def _warn_if_plaintext_password_in_container(cfg: MikrotikConfig, logger: logging.Logger) -> None:
@@ -28,6 +32,60 @@ def _warn_if_plaintext_password_in_container(cfg: MikrotikConfig, logger: loggin
         )
 
 
+def _build_transport_security(
+    mcp_cfg: McpServerSettings, logger: logging.Logger
+) -> TransportSecuritySettings:
+    """Build DNS-rebinding protection settings for the HTTP transports.
+
+    Why this is needed (issue #86): the FastMCP instance is constructed with the
+    default localhost bind, so FastMCP auto-enables DNS-rebinding protection with
+    a localhost-only Host allowlist. When the server is then bound to a
+    non-localhost host (e.g. ``0.0.0.0`` in a container) and fronted by a reverse
+    proxy, that localhost allowlist rejects every real request to ``/mcp`` with
+    HTTP 421 "Invalid Host header". Here we reconcile the protection settings
+    with the actual runtime host and any user-provided allowlist.
+
+    Resolution order:
+      1. ``allowed_hosts`` contains "*"        -> protection disabled (explicit opt-out)
+      2. ``allowed_hosts`` / ``allowed_origins`` set -> protection on, with that allowlist
+      3. host is localhost                     -> secure localhost allowlist (default)
+      4. host is non-localhost, no allowlist    -> protection disabled + a warning
+    """
+    hosts = [h.strip() for h in mcp_cfg.allowed_hosts.split(",") if h.strip()]
+    origins = [o.strip() for o in mcp_cfg.allowed_origins.split(",") if o.strip()]
+
+    if "*" in hosts:
+        logger.warning(
+            "DNS-rebinding protection is DISABLED (MIKROTIK_MCP__ALLOWED_HOSTS=*). "
+            "Ensure the server is only reachable by trusted clients."
+        )
+        return TransportSecuritySettings(enable_dns_rebinding_protection=False)
+
+    if hosts or origins:
+        logger.info(f"DNS-rebinding protection enabled for hosts={hosts or '[]'} origins={origins or '[]'}")
+        return TransportSecuritySettings(
+            enable_dns_rebinding_protection=True,
+            allowed_hosts=hosts,
+            allowed_origins=origins,
+        )
+
+    if mcp_cfg.host in _LOCALHOST_HOSTS:
+        return TransportSecuritySettings(
+            enable_dns_rebinding_protection=True,
+            allowed_hosts=["127.0.0.1:*", "localhost:*", "[::1]:*"],
+            allowed_origins=["http://127.0.0.1:*", "http://localhost:*", "http://[::1]:*"],
+        )
+
+    logger.warning(
+        "Serving the HTTP transport on a non-localhost host (%s) without "
+        "MIKROTIK_MCP__ALLOWED_HOSTS set, so DNS-rebinding protection is "
+        "disabled. Behind a reverse proxy, set MIKROTIK_MCP__ALLOWED_HOSTS to "
+        "your domain (e.g. 'mcp.example.com') to re-enable it.",
+        mcp_cfg.host,
+    )
+    return TransportSecuritySettings(enable_dns_rebinding_protection=False)
+
+
 def main():
     """
     Entry point for the MCP MikroTik server when run as a command-line program.
@@ -47,6 +105,12 @@ def main():
     try:
         mcp.settings.host = config.mikrotik_config.mcp.host
         mcp.settings.port = config.mikrotik_config.mcp.port
+        # Reconcile DNS-rebinding protection with the actual runtime host so the
+        # HTTP transports work behind a reverse proxy / on non-localhost (#86).
+        if config.mikrotik_config.mcp.transport in ("sse", "streamable-http"):
+            mcp.settings.transport_security = _build_transport_security(
+                config.mikrotik_config.mcp, logger
+            )
         mcp.run(transport=config.mikrotik_config.mcp.transport)
     except KeyboardInterrupt:
         logger.info("MCP MikroTik server stopped by user")

--- a/tests/unit/test_server_main.py
+++ b/tests/unit/test_server_main.py
@@ -117,6 +117,71 @@ def test_credential_warning_suppressed_outside_container(monkeypatch):
     assert stream.getvalue() == ""
 
 
+def _mcp_cfg(host="0.0.0.0", allowed_hosts="", allowed_origins=""):
+    import types
+    return types.SimpleNamespace(
+        host=host, allowed_hosts=allowed_hosts, allowed_origins=allowed_origins
+    )
+
+
+def test_transport_security_localhost_uses_localhost_allowlist():
+    """Localhost bind with no allowlist keeps the secure localhost default."""
+    import logging
+    from mcp_mikrotik.server import _build_transport_security
+
+    s = _build_transport_security(_mcp_cfg(host="127.0.0.1"), logging.getLogger("t"))
+    assert s.enable_dns_rebinding_protection is True
+    assert "127.0.0.1:*" in s.allowed_hosts
+
+
+def test_transport_security_non_localhost_disables_without_allowlist(caplog):
+    """Non-localhost bind with no allowlist disables protection (and warns)."""
+    import logging
+    from mcp_mikrotik.server import _build_transport_security
+
+    with caplog.at_level(logging.WARNING):
+        s = _build_transport_security(_mcp_cfg(host="0.0.0.0"), logging.getLogger("t"))
+    assert s.enable_dns_rebinding_protection is False
+    assert "non-localhost" in caplog.text
+
+
+def test_transport_security_explicit_allowlist_enabled():
+    """A configured allowlist enables protection with those hosts (the #86 fix)."""
+    import logging
+    from mcp_mikrotik.server import _build_transport_security
+
+    s = _build_transport_security(
+        _mcp_cfg(host="0.0.0.0", allowed_hosts="mcp.example.com, mcp.example.com:*"),
+        logging.getLogger("t"),
+    )
+    assert s.enable_dns_rebinding_protection is True
+    assert s.allowed_hosts == ["mcp.example.com", "mcp.example.com:*"]
+
+
+def test_transport_security_wildcard_disables():
+    """allowed_hosts='*' is an explicit opt-out."""
+    import logging
+    from mcp_mikrotik.server import _build_transport_security
+
+    s = _build_transport_security(
+        _mcp_cfg(host="0.0.0.0", allowed_hosts="*"), logging.getLogger("t")
+    )
+    assert s.enable_dns_rebinding_protection is False
+
+
+def test_transport_security_allowed_origins_parsed():
+    """Origins are parsed and protection is enabled."""
+    import logging
+    from mcp_mikrotik.server import _build_transport_security
+
+    s = _build_transport_security(
+        _mcp_cfg(host="0.0.0.0", allowed_origins="https://app.example.com"),
+        logging.getLogger("t"),
+    )
+    assert s.enable_dns_rebinding_protection is True
+    assert s.allowed_origins == ["https://app.example.com"]
+
+
 def test_server_main_handles_keyboard_interrupt(monkeypatch):
     from mcp_mikrotik import server
 


### PR DESCRIPTION
Fixes the "Invalid Host header" report on #86 ([comment](https://github.com/jeff-nasseri/mikrotik-mcp/issues/86#issuecomment-4591185544)) — reported both behind a reverse proxy **and** with a bare IP from another network.

## The bug

On the HTTP transports, `/health` returned `200` but `/mcp` returned **HTTP 421 "Invalid Host header"** for any non-localhost `Host`:

```
POST /mcp  Host: domain.example.com   -> 421
POST /mcp  Host: 192.168.50.10:8000   -> 421   (bare IP, no proxy)
POST /mcp  Host: localhost:8000       -> 200
GET  /health (any host)               -> 200
```

## Root cause

The MCP SDK's DNS-rebinding protection validates the `Host` header. FastMCP auto-enables it with a **localhost-only** allowlist when constructed with the default localhost bind (how `app.py` builds it). `server.py` then rebinds to `0.0.0.0` but never reconciled that allowlist — so the server **listened on all interfaces yet rejected every non-localhost `Host`**. `/health` escaped because it's a custom route the middleware doesn't wrap.

## Fix — optional MCP settings

Two new optional `mcp.*` settings, passable via env var or CLI flag (`--mcp.allowed-hosts` / `--mcp.allowed-origins`):

| `MIKROTIK_MCP__ALLOWED_HOSTS` | Behaviour |
|---|---|
| a domain/IP (e.g. `mcp.example.com`) | protection **ON**, that host allowed |
| `*` | protection **off** (explicit opt-out) |
| unset + localhost bind | secure localhost allowlist (unchanged) |
| unset + non-localhost bind | protection **off** + a warning to set `ALLOWED_HOSTS` |

`MIKROTIK_MCP__ALLOWED_ORIGINS` does the same for `Origin`. Both comma-separated.

## Verified in a freshly built image

| Config | `Host` header | Result |
|---|---|---|
| `0.0.0.0`, no allowlist | `192.168.5.9:8001` (bare IP) | **200** (was 421) |
| `ALLOWED_HOSTS=mcp.example.com` | `mcp.example.com` | **200** |
| `ALLOWED_HOSTS=mcp.example.com` | `evil.example.com` | **421** (protection preserved) |

Also ran a **full MCP session (166 tools) returning live RouterOS data** with protection ON via an allowlist — real clients still work.

## Tests & docs
- **53 unit tests pass** (+5 for `_build_transport_security`)
- `installation.md`: documents the env vars and shows `ALLOWED_HOSTS` / `ALLOWED_ORIGINS` examples (single + comma-separated)

> Note: the Docker HEALTHCHECK that was previously explored here has been dropped from this PR to keep it focused on the Host-header fix. Happy to handle it separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)