### PR TITLE
ci(docker): publish version-tagged image aligned with the release (0.10.1, latest)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,22 +4,29 @@
 #
 # Purpose:
 #   Builds the Docker image for linux/amd64 + linux/arm64 and publishes it to
-#   the GitHub Container Registry (ghcr.io/<owner>/<repo>).
+#   the GitHub Container Registry (ghcr.io/<owner>/<repo>) with a tag that
+#   matches the project version — kept in lock-step with the PyPI release.
 #
-# Tagging strategy:
-#   Push to master              -> :edge        + :sha-<short>
-#   Push of a vX.Y.Z git tag    -> :X.Y.Z, :X.Y, :latest + :sha-<short>
+# Versioning:
+#   The version is computed with GitVersion (the same tool and GitVersion.yml
+#   that publish.yml uses for PyPI), so the image version always matches the
+#   package version. We compute it on the master push rather than reacting to
+#   the vX.Y.Z git tag, because that tag is created by github-actions[bot] with
+#   GITHUB_TOKEN — and GitHub does NOT trigger workflows from token-created
+#   tags, so a `tags: ['v*']` trigger would never fire.
 #
-#   The PyPI release pipeline (publish.yml) creates the vX.Y.Z stable tags via
-#   GitVersion, so a tagged release automatically produces a versioned image
-#   and updates :latest. Master builds get the moving :edge tag.
+# Tagging strategy (every push to master):
+#   :X.Y.Z      e.g. :0.10.1   (majorMinorPatch — matches the vX.Y.Z git tag)
+#   :X.Y        e.g. :0.10      (floating minor)
+#   :latest                     (newest release)
+#   :sha-<short>                (exact commit, for traceability)
 #
 # Registry:
 #   ghcr.io/jeff-nasseri/mikrotik-mcp
 #
 # Authentication:
 #   Uses the built-in GITHUB_TOKEN (no extra secret required). The token needs
-#   packages: write, which is granted in the job permissions block below.
+#   packages: write, granted in the job permissions block below.
 # =============================================================================
 name: Publish Docker Image
 
@@ -27,8 +34,6 @@ on:
   push:
     branches:
       - master
-    tags:
-      - 'v*'
 
 jobs:
   docker:
@@ -39,6 +44,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history required for GitVersion
+
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.10.2
+        with:
+          versionSpec: '6.x'
+
+      - name: Determine Version
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0.10.2
+        with:
+          useConfigFile: true
+
+      - name: Display resolved version
+        run: |
+          echo "majorMinorPatch: ${{ steps.gitversion.outputs.majorMinorPatch }}"
+          echo "assemblySemVer:  ${{ steps.gitversion.outputs.assemblySemVer }}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -58,14 +81,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
+          # Tags are fed from the GitVersion-computed version so the image
+          # version stays aligned with the vX.Y.Z git tag / PyPI release.
           tags: |
-            # Stable releases (vX.Y.Z tags): semantic version tags + latest
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            # Master branch: a moving 'edge' tag
-            type=raw,value=edge,enable={{is_default_branch}}
-            # Always include a short-SHA tag for traceability
+            type=raw,value=${{ steps.gitversion.outputs.majorMinorPatch }}
+            type=raw,value=${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}
+            type=raw,value=latest
             type=sha,format=short
 
       - name: Build and push

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -68,21 +68,18 @@ A multi-arch image (`linux/amd64` + `linux/arm64`) is published to GHCR, so you
 can pull it directly instead of building from source:
 
 ```bash
-# Latest stable release
+# Latest release
 docker pull ghcr.io/jeff-nasseri/mikrotik-mcp:latest
 
-# A specific version
-docker pull ghcr.io/jeff-nasseri/mikrotik-mcp:0.9.2
-
-# Bleeding-edge build from the master branch
-docker pull ghcr.io/jeff-nasseri/mikrotik-mcp:edge
+# A specific version (matches the PyPI / git tag version)
+docker pull ghcr.io/jeff-nasseri/mikrotik-mcp:0.10.1
 ```
 
 | Tag | Points to |
 |-----|-----------|
-| `latest` | The most recent stable release |
-| `X.Y.Z` / `X.Y` | A specific released version |
-| `edge` | The latest commit on `master` |
+| `latest` | The most recent release |
+| `X.Y.Z` | A specific released version (e.g. `0.10.1`), aligned with the PyPI release |
+| `X.Y` | The latest patch of a minor line (e.g. `0.10`) |
 | `sha-<short>` | A specific commit |
 
 In the examples below, substitute `ghcr.io/jeff-nasseri/mikrotik-mcp:latest` for


### PR DESCRIPTION
## Problem

The Docker image is never published with a **version** tag — only `:edge` and `:sha-*` exist. So `docker pull ...:0.10.1` and `...:latest` both fail.

**Root cause:** the `vX.Y.Z` git tag is created by `github-actions[bot]` using `GITHUB_TOKEN`, and **GitHub does not trigger workflows from token-created tags** (anti-recursion safeguard). So the workflow's `on: push: tags: ['v*']` trigger **never fires** — the only build comes from the master push, which produced `:edge` + `:sha-*`.

(Confirmed on the last release: `v0.10.1` → commit `bf13c54`, but the only images published are `sha-bf13c54` / `edge`.)

## Fix

Compute the version with **GitVersion on the master push** — the same tool and `GitVersion.yml` that `publish.yml` already uses for PyPI — and tag the image from it. This keeps the image version in lock-step with the package version without depending on the token-created tag.

**Tags published on every master push:**

| Tag | Example | Meaning |
|---|---|---|
| `X.Y.Z` | `0.10.1` | the release version (matches the `vX.Y.Z` git tag) |
| `X.Y` | `0.10` | latest patch of that minor line |
| `latest` | | most recent release |
| `sha-<short>` | `sha-bf13c54` | exact commit |

Also:
- Dropped the never-firing `tags: ['v*']` trigger.
- Dropped the redundant `:edge` tag — every master push is already a versioned release, so `:latest` covers it. (The existing `:edge` tag in the registry simply stops being updated.)
- Updated the docs tag table in `installation.md`.

## Validation

- Workflow YAML validated; tag template uses `gitversion.outputs.majorMinorPatch` / `major` / `minor`, the same outputs the working `publish.yml` relies on.
- Can't run the publish until merged (it triggers on master push). On the **next merge to master**, the image should appear as `:X.Y.Z`, `:X.Y`, `:latest`, `:sha-<short>` — I'll confirm `docker pull ...:latest` and the version tag once it runs.

> Note: this aligns Docker with the project's existing cadence — `publish.yml` already publishes a new PyPI version on every master push, so the Docker image now mirrors that exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)