### PR TITLE
feat(poe): add Ethernet PoE monitoring tools

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -5,6 +5,7 @@ Complete reference documentation for all MikroTik MCP tools.
 ## Available Tool Categories
 
 - **[Interfaces](interfaces/README.md)** - All Interface Management (ethernet, bridge, PPPoE, SFP, LTE …)
+- **[PoE](poe/README.md)** - Power over Ethernet monitoring
 - **[VLAN](vlan/README.md)** - VLAN Interface Management
 - **[IP Address](ip-address/README.md)** - IP Address Management
 - **[DHCP](dhcp/README.md)** - DHCP Server Management

--- a/docs/reference/poe/README.md
+++ b/docs/reference/poe/README.md
@@ -1,0 +1,50 @@
+# PoE (Power over Ethernet) Monitoring
+
+Read-only tools for inspecting Power-over-Ethernet status and configuration on
+PoE-capable MikroTik devices, under `/interface ethernet poe`.
+
+> PoE is a hardware feature — these tools return data only on devices with
+> PoE-out ports. On hardware without PoE (e.g. CHR/virtual routers) they report
+> that no PoE data is available.
+
+## `get_poe_monitor`
+
+Reads **real-time** PoE monitor data (PoE-out status, voltage, current, power)
+for one or more ethernet interfaces. Runs
+`/interface ethernet poe monitor <interfaces> once`.
+
+- Parameters:
+  - `interfaces` (required): comma-separated ethernet interface name(s)
+
+- Examples:
+  ```
+  get_poe_monitor(interfaces="ether1")
+  get_poe_monitor(interfaces="ether9-ap,ether10-ap,ether11-ap,ether12-ap")
+  ```
+
+## `list_poe`
+
+Lists the PoE-out configuration (PoE-out mode, priority) of PoE-capable
+ethernet interfaces. Runs `/interface ethernet poe print`.
+
+- Parameters:
+  - `interface_filter` (optional): partial name match, e.g. `"ether"`
+
+- Examples:
+  ```
+  list_poe()                          # all PoE-capable interfaces
+  list_poe(interface_filter="ether")  # interfaces whose name contains "ether"
+  ```
+
+## `get_poe_settings`
+
+Gets the detailed PoE-out settings of a specific ethernet interface. Runs
+`/interface ethernet poe print detail where name=<name>`.
+
+- Parameters:
+  - `name` (required): exact ethernet interface name
+
+- Example:
+  ```
+  get_poe_settings(name="ether1")
+  ```

--- a/src/mcp_mikrotik/app.py
+++ b/src/mcp_mikrotik/app.py
@@ -47,5 +47,5 @@ async def health_check(request: Request) -> Response:
 # Import scope modules to trigger @mcp.tool() registration
 from mcp_mikrotik.scope import (  # noqa: F401, E402
     backup, dhcp, dns, firewall_filter, firewall_nat,
-    interfaces, ip_address, ip_pool, logs, queue, safe_mode, routes, users, vlan, wireless, wireguard,
+    interfaces, ip_address, ip_pool, logs, poe, queue, safe_mode, routes, users, vlan, wireless, wireguard,
 )

--- a/src/mcp_mikrotik/scope/poe.py
+++ b/src/mcp_mikrotik/scope/poe.py
@@ -1,0 +1,79 @@
+from typing import Optional
+from ..connector import execute_mikrotik_command
+from mcp.server.fastmcp import Context
+from ..app import mcp, READ, annotate
+
+
+@mcp.tool(name="get_poe_monitor", annotations=annotate(READ, "PoE Monitor"))
+async def mikrotik_get_poe_monitor(ctx: Context, interfaces: str) -> str:
+    """Reads real-time Power-over-Ethernet (PoE) monitor data for one or more
+    ethernet interfaces — PoE-out status, voltage, current, and power.
+
+    Runs ``/interface ethernet poe monitor <interfaces> once``.
+
+    Notes:
+        interfaces: comma-separated ethernet interface name(s), e.g.
+            "ether1" or "ether9-ap,ether10-ap,ether11-ap,ether12-ap"
+    """
+    await ctx.info(f"Reading PoE monitor for: {interfaces}")
+
+    # `once` is required — without it the monitor streams continuously and the
+    # command never returns (it would hang the SSH session).
+    cmd = f"/interface ethernet poe monitor {interfaces} once"
+    result = await execute_mikrotik_command(cmd, ctx)
+
+    if not result or not result.strip():
+        return (
+            f"No PoE monitor data returned for: {interfaces}. "
+            "The interface(s) may not exist or the device may not support PoE."
+        )
+
+    return f"POE MONITOR:\n\n{result}"
+
+
+@mcp.tool(name="list_poe", annotations=annotate(READ, "List PoE"))
+async def mikrotik_list_poe(ctx: Context, interface_filter: Optional[str] = None) -> str:
+    """Lists the Power-over-Ethernet (PoE) configuration of PoE-capable
+    ethernet interfaces (PoE-out mode, priority).
+
+    Runs ``/interface ethernet poe print``.
+
+    Notes:
+        interface_filter: partial name match, e.g. "ether" matches ether1, ether2 …
+    """
+    await ctx.info("Listing PoE configuration")
+
+    cmd = "/interface ethernet poe print"
+    if interface_filter:
+        cmd += f' where name~"{interface_filter}"'
+
+    result = await execute_mikrotik_command(cmd, ctx)
+
+    if not result or not result.strip():
+        return (
+            "No PoE-capable ethernet interfaces found. "
+            "The device may not support PoE."
+        )
+
+    return f"POE CONFIGURATION:\n\n{result}"
+
+
+@mcp.tool(name="get_poe_settings", annotations=annotate(READ, "PoE Settings"))
+async def mikrotik_get_poe_settings(ctx: Context, name: str) -> str:
+    """Gets the detailed PoE-out settings of a specific ethernet interface
+    (PoE-out mode, priority, voltage, low/high thresholds, …).
+
+    Runs ``/interface ethernet poe print detail where name=<name>``.
+
+    Notes:
+        name: exact ethernet interface name, e.g. "ether1"
+    """
+    await ctx.info(f"Getting PoE settings for: {name}")
+
+    cmd = f'/interface ethernet poe print detail where name="{name}"'
+    result = await execute_mikrotik_command(cmd, ctx)
+
+    if not result or not result.strip():
+        return f"No PoE settings found for interface '{name}'."
+
+    return f"POE SETTINGS:\n\n{result}"

--- a/tests/unit/test_scope_poe.py
+++ b/tests/unit/test_scope_poe.py
@@ -1,0 +1,69 @@
+"""Unit tests for the PoE scope (issue #90)."""
+
+import asyncio
+
+from tests.conftest import FakeExecutor
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_get_poe_monitor_uses_once_flag(ctx, monkeypatch):
+    """The monitor command MUST include `once`, or it streams forever and hangs."""
+    from mcp_mikrotik.scope import poe
+
+    fake = FakeExecutor()
+    monkeypatch.setattr(poe, "execute_mikrotik_command", fake, raising=True)
+
+    _run(poe.mikrotik_get_poe_monitor(ctx, interfaces="ether9-ap,ether10-ap"))
+
+    assert fake.commands == [
+        "/interface ethernet poe monitor ether9-ap,ether10-ap once"
+    ]
+
+
+def test_get_poe_monitor_returns_data(ctx, monkeypatch):
+    from mcp_mikrotik.scope import poe
+
+    async def fake(cmd, _ctx):
+        return "name: ether9-ap\npoe-out-status: powered-on\npoe-out-power: 4.2W"
+
+    monkeypatch.setattr(poe, "execute_mikrotik_command", fake, raising=True)
+    out = _run(poe.mikrotik_get_poe_monitor(ctx, interfaces="ether9-ap"))
+    assert "POE MONITOR" in out
+    assert "powered-on" in out
+
+
+def test_get_poe_monitor_handles_empty(ctx, monkeypatch):
+    from mcp_mikrotik.scope import poe
+
+    async def fake(cmd, _ctx):
+        return ""
+
+    monkeypatch.setattr(poe, "execute_mikrotik_command", fake, raising=True)
+    out = _run(poe.mikrotik_get_poe_monitor(ctx, interfaces="ether1"))
+    assert "No PoE monitor data" in out
+
+
+def test_list_poe_command_and_filter(ctx, monkeypatch):
+    from mcp_mikrotik.scope import poe
+
+    fake = FakeExecutor()
+    monkeypatch.setattr(poe, "execute_mikrotik_command", fake, raising=True)
+
+    _run(poe.mikrotik_list_poe(ctx))
+    assert fake.commands[-1] == "/interface ethernet poe print"
+
+    _run(poe.mikrotik_list_poe(ctx, interface_filter="ether"))
+    assert fake.commands[-1] == '/interface ethernet poe print where name~"ether"'
+
+
+def test_get_poe_settings_command(ctx, monkeypatch):
+    from mcp_mikrotik.scope import poe
+
+    fake = FakeExecutor()
+    monkeypatch.setattr(poe, "execute_mikrotik_command", fake, raising=True)
+
+    _run(poe.mikrotik_get_poe_settings(ctx, name="ether1"))
+    assert fake.commands[-1] == '/interface ethernet poe print detail where name="ether1"'

--- a/tests/unit/test_scopes_smoke.py
+++ b/tests/unit/test_scopes_smoke.py
@@ -15,6 +15,7 @@ SCOPE_MODULES = [
     "ip_address",
     "ip_pool",
     "logs",
+    "poe",
     "queue",
     "routes",
     "users",


### PR DESCRIPTION
Closes #90

## What this adds

Read-only Power-over-Ethernet tools under `/interface ethernet poe`:

| Tool | RouterOS command | Purpose |
|---|---|---|
| `get_poe_monitor(interfaces)` | `/interface ethernet poe monitor <interfaces> once` | Real-time PoE-out **status, voltage, current, power** for one or more comma-separated ethernet interfaces — the exact command from the issue |
| `list_poe(interface_filter?)` | `/interface ethernet poe print` | PoE-out **configuration** (mode, priority) of PoE-capable interfaces |
| `get_poe_settings(name)` | `/interface ethernet poe print detail where name=…` | Detailed PoE-out settings for one interface |

Example (matching the issue):
```
get_poe_monitor(interfaces="ether9-ap,ether10-ap,ether11-ap,ether12-ap,ether13-ap")
```

## Notes

- **The `once` flag is required.** Without it, `poe monitor` streams continuously and the SSH command never returns (it would hang the session). All three tools are read-only.
- They **degrade gracefully** on hardware without PoE (e.g. CHR / virtual routers), returning a clear "no PoE data available" message rather than an error.

## Tests & docs

- 5 unit tests (including one that asserts the required `once` flag and the exact commands) + smoke-test coverage — **59 → 64 tests pass**
- `docs/reference/poe/README.md` + reference index entry (the issue is also labelled `documentation`)

> Live note: my local RouterOS is a CHR (virtual) instance with **no PoE hardware**, so it can only exercise the graceful "no PoE" path, not real PoE readings. The command construction and output handling are covered by unit tests. Real PoE values need a physical PoE-capable device to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)