### PR TITLE
feat(ipv6): add IPv6 address management scope

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -7,7 +7,8 @@ Complete reference documentation for all MikroTik MCP tools.
 - **[Interfaces](interfaces/README.md)** - All Interface Management (ethernet, bridge, PPPoE, SFP, LTE …)
 - **[PoE](poe/README.md)** - Power over Ethernet monitoring
 - **[VLAN](vlan/README.md)** - VLAN Interface Management
-- **[IP Address](ip-address/README.md)** - IP Address Management
+- **[IP Address](ip-address/README.md)** - IPv4 Address Management
+- **[IPv6 Address](ipv6-address/README.md)** - IPv6 Address Management
 - **[DHCP](dhcp/README.md)** - DHCP Server Management
 - **[NAT](nat/README.md)** - NAT Rules Management
 - **[IP Pool](ip-pool/README.md)** - IP Pool Management

--- a/docs/reference/ipv6-address/README.md
+++ b/docs/reference/ipv6-address/README.md
@@ -1,0 +1,72 @@
+# IPv6 Address Management
+
+Tools for managing IPv6 addresses on interfaces, under the RouterOS
+`/ipv6 address` command tree. This is the IPv6 counterpart of the
+[IP Address](../ip-address/README.md) (IPv4) scope.
+
+> IPv6 lives in a separate command tree from IPv4 (`/ipv6 …` vs `/ip …`).
+> These tools cover IPv6 *addressing*; IPv6 routing, firewall, DHCPv6/ND, and
+> pools are separate areas.
+
+## `add_ipv6_address`
+
+Adds an IPv6 address to an interface. Runs `/ipv6 address add …`.
+
+- Parameters:
+  - `address` (required): IPv6 address with prefix length, e.g. `2001:db8::1/64`
+    or `fe80::1/64`. With `from_pool`, supply the host part only (e.g. `::1/64`).
+  - `interface` (required): interface name, e.g. `ether1`, `bridge`
+  - `advertise` (optional): include this prefix in Router Advertisements
+  - `eui_64` (optional): derive the host part of the address from the interface MAC
+  - `from_pool` (optional): name of an IPv6 pool to take the prefix from
+  - `no_dad` (optional): skip Duplicate Address Detection
+  - `comment` (optional), `disabled` (optional)
+
+- Examples:
+  ```
+  add_ipv6_address(address="2001:db8:1::1/64", interface="bridge")
+  add_ipv6_address(address="2001:db8:1::1/64", interface="bridge", advertise=True)
+  add_ipv6_address(address="::1/64", interface="bridge", from_pool="isp-pd")
+  ```
+
+## `list_ipv6_addresses`
+
+Lists IPv6 addresses, with optional filtering. Runs `/ipv6 address print`.
+
+- Parameters:
+  - `interface_filter` (optional): filter by interface
+  - `address_filter` (optional): partial match on the address, e.g. `"2001:db8"` or `"fe80"`
+  - `disabled_only`, `dynamic_only`, `global_only`, `link_local_only` (optional)
+
+- Examples:
+  ```
+  list_ipv6_addresses()
+  list_ipv6_addresses(interface_filter="bridge")
+  list_ipv6_addresses(global_only=True)        # routable addresses only
+  list_ipv6_addresses(link_local_only=True)    # fe80::/10 only
+  ```
+
+## `get_ipv6_address`
+
+Gets details for a single IPv6 address by RouterOS id or by address value.
+Runs `/ipv6 address print detail where …`.
+
+- Parameters:
+  - `address_id` (required): internal id (e.g. `*1`) or the address value (e.g. `2001:db8::1/64`)
+
+- Example:
+  ```
+  get_ipv6_address(address_id="2001:db8:1::1/64")
+  ```
+
+## `remove_ipv6_address`
+
+Removes an IPv6 address by id or address value. Runs `/ipv6 address remove [find …]`.
+
+- Parameters:
+  - `address_id` (required): internal id (e.g. `*1`) or the address value
+
+- Example:
+  ```
+  remove_ipv6_address(address_id="2001:db8:1::1/64")
+  ```

--- a/src/mcp_mikrotik/app.py
+++ b/src/mcp_mikrotik/app.py
@@ -47,5 +47,5 @@ async def health_check(request: Request) -> Response:
 # Import scope modules to trigger @mcp.tool() registration
 from mcp_mikrotik.scope import (  # noqa: F401, E402
     backup, dhcp, dns, firewall_filter, firewall_nat,
-    interfaces, ip_address, ip_pool, logs, poe, queue, safe_mode, routes, users, vlan, wireless, wireguard,
+    interfaces, ip_address, ipv6_address, ip_pool, logs, poe, queue, safe_mode, routes, users, vlan, wireless, wireguard,
 )

--- a/src/mcp_mikrotik/scope/ipv6_address.py
+++ b/src/mcp_mikrotik/scope/ipv6_address.py
@@ -1,0 +1,197 @@
+import ipaddress
+from typing import Optional
+
+from ..connector import execute_mikrotik_command
+from mcp.server.fastmcp import Context
+from ..app import mcp, READ, WRITE, DESTRUCTIVE, annotate
+
+
+def _canonical_ipv6(value: str) -> str:
+    """Return the RouterOS-canonical form of an IPv6 address or address/prefix.
+
+    RouterOS stores IPv6 addresses lowercase and maximally zero-compressed
+    (e.g. ``2001:db8::1/64``). User input may be uppercase or expanded
+    (``2001:DB8:0:0::1/64``), which would not match an exact ``where address=``
+    comparison and cause a spurious "not found". Canonicalizing the input makes
+    the match reliable. Returns the input unchanged if it is not parseable as
+    IPv6 (e.g. a RouterOS ``.id`` like ``*1``).
+    """
+    try:
+        if "/" in value:
+            return str(ipaddress.ip_interface(value))
+        return str(ipaddress.ip_address(value))
+    except ValueError:
+        return value
+
+
+@mcp.tool(name="add_ipv6_address", annotations=annotate(WRITE, "Add IPv6 Address"))
+async def mikrotik_add_ipv6_address(
+    ctx: Context,
+    address: str,
+    interface: str,
+    advertise: Optional[bool] = None,
+    eui_64: Optional[bool] = None,
+    from_pool: Optional[str] = None,
+    no_dad: Optional[bool] = None,
+    comment: Optional[str] = None,
+    disabled: bool = False,
+) -> str:
+    """Adds an IPv6 address to an interface on the MikroTik device.
+
+    Notes:
+        address: IPv6 address with prefix length, e.g. "2001:db8::1/64" or
+            "fe80::1/64". When `from_pool` is used, supply the host part only,
+            e.g. "::1/64".
+        advertise: include this prefix in Router Advertisements (default no).
+        eui_64: derive the host part of the address from the interface MAC.
+        from_pool: name of an IPv6 pool to take the prefix from.
+        no_dad: skip Duplicate Address Detection.
+    """
+    await ctx.info(f"Adding IPv6 address: address={address}, interface={interface}")
+
+    cmd = f"/ipv6 address add address={address} interface={interface}"
+
+    if advertise is not None:
+        cmd += f" advertise={'yes' if advertise else 'no'}"
+    if eui_64:
+        cmd += " eui-64=yes"
+    if from_pool:
+        cmd += f' from-pool="{from_pool}"'
+    if no_dad:
+        cmd += " no-dad=yes"
+    if comment:
+        cmd += f' comment="{comment}"'
+    if disabled:
+        cmd += " disabled=yes"
+
+    result = await execute_mikrotik_command(cmd, ctx)
+
+    if "failure:" in result.lower() or "error" in result.lower():
+        return f"Failed to add IPv6 address: {result}"
+
+    # Confirm by listing the interface's addresses. We deliberately query by
+    # interface (not by the input address): with from_pool the stored prefix
+    # comes from the pool, and with eui_64 the host part is derived from the
+    # MAC — in both cases the stored address differs from the input, so a
+    # by-address lookup would miss the very entry we just created.
+    details_cmd = f'/ipv6 address print detail where interface="{interface}"'
+    details = await execute_mikrotik_command(details_cmd, ctx)
+
+    if details.strip() and "address=" in details:
+        return f"IPv6 address added successfully (addresses on {interface}):\n\n{details}"
+    return f"IPv6 address '{address}' added on interface '{interface}'."
+
+
+@mcp.tool(name="list_ipv6_addresses", annotations=annotate(READ, "List IPv6 Addresses"))
+async def mikrotik_list_ipv6_addresses(
+    ctx: Context,
+    interface_filter: Optional[str] = None,
+    address_filter: Optional[str] = None,
+    disabled_only: bool = False,
+    dynamic_only: bool = False,
+    global_only: bool = False,
+    link_local_only: bool = False,
+) -> str:
+    """Lists IPv6 addresses on the MikroTik device.
+
+    Notes:
+        address_filter: partial match on the address, e.g. "2001:db8" or "fe80".
+        global_only: show only global (routable) addresses.
+        link_local_only: show only link-local (fe80::/10) addresses.
+    """
+    await ctx.info(
+        f"Listing IPv6 addresses with filters: interface={interface_filter}, address={address_filter}"
+    )
+
+    cmd = "/ipv6 address print"
+
+    filters = []
+    if interface_filter:
+        filters.append(f'interface="{interface_filter}"')
+    if address_filter:
+        filters.append(f'address~"{address_filter}"')
+    if disabled_only:
+        filters.append("disabled=yes")
+    if dynamic_only:
+        filters.append("dynamic=yes")
+    if global_only:
+        filters.append("global=yes")
+    if link_local_only:
+        filters.append("link-local=yes")
+
+    if filters:
+        cmd += " where " + " ".join(filters)
+
+    result = await execute_mikrotik_command(cmd, ctx)
+
+    if not result or result.strip() == "":
+        return "No IPv6 addresses found matching the criteria."
+
+    return f"IPV6 ADDRESSES:\n\n{result}"
+
+
+@mcp.tool(name="get_ipv6_address", annotations=annotate(READ, "Get IPv6 Address"))
+async def mikrotik_get_ipv6_address(ctx: Context, address_id: str) -> str:
+    """Gets detailed information about a specific IPv6 address by ID or address value.
+
+    Notes:
+        address_id: a RouterOS internal id (e.g. "*1") or the address value
+            (e.g. "2001:db8::1/64").
+    """
+    await ctx.info(f"Getting IPv6 address details: address_id={address_id}")
+
+    # An IPv6 address value always contains ':'; a RouterOS internal id looks
+    # like "*1". Query by the matching attribute first. We validate on the
+    # presence of real entry data ("address=") rather than non-emptiness,
+    # because `print detail` returns the Flags legend (non-empty) even when no
+    # row matches — so an emptiness check would yield a header with no entry.
+    addr = _canonical_ipv6(address_id)
+    if ":" in address_id:
+        queries = [f'address="{addr}"', f'.id="{address_id}"']
+    else:
+        queries = [f'.id="{address_id}"', f'address="{addr}"']
+
+    for where in queries:
+        result = await execute_mikrotik_command(
+            f"/ipv6 address print detail where {where}", ctx
+        )
+        if result and "address=" in result:
+            return f"IPV6 ADDRESS DETAILS:\n\n{result}"
+
+    return f"IPv6 address '{address_id}' not found."
+
+
+@mcp.tool(name="remove_ipv6_address", annotations=annotate(DESTRUCTIVE, "Remove IPv6 Address"))
+async def mikrotik_remove_ipv6_address(ctx: Context, address_id: str) -> str:
+    """Removes an IPv6 address from the MikroTik device by ID or address value.
+
+    Notes:
+        address_id: a RouterOS internal id (e.g. "*1") or the address value
+            (e.g. "2001:db8::1/64").
+    """
+    await ctx.info(f"Removing IPv6 address: address_id={address_id}")
+
+    addr = _canonical_ipv6(address_id)
+
+    # Try to find by ID first
+    check_cmd = f'/ipv6 address print count-only where .id="{address_id}"'
+    count = await execute_mikrotik_command(check_cmd, ctx)
+
+    if count.strip() == "0":
+        # Try finding by (canonicalized) address value
+        check_cmd = f'/ipv6 address print count-only where address="{addr}"'
+        count = await execute_mikrotik_command(check_cmd, ctx)
+
+        if count.strip() == "0":
+            return f"IPv6 address '{address_id}' not found."
+
+        cmd = f'/ipv6 address remove [find address="{addr}"]'
+    else:
+        cmd = f'/ipv6 address remove [find .id="{address_id}"]'
+
+    result = await execute_mikrotik_command(cmd, ctx)
+
+    if "failure:" in result.lower() or "error" in result.lower():
+        return f"Failed to remove IPv6 address: {result}"
+
+    return f"IPv6 address '{address_id}' removed successfully."

--- a/tests/unit/test_scope_ipv6_address.py
+++ b/tests/unit/test_scope_ipv6_address.py
@@ -1,0 +1,289 @@
+"""Unit tests for the IPv6 address scope (issue #92)."""
+
+import asyncio
+
+from tests.conftest import FakeExecutor
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# add_ipv6_address — command construction
+# ---------------------------------------------------------------------------
+
+def test_add_minimal(ctx, monkeypatch):
+    from mcp_mikrotik.scope import ipv6_address as m
+
+    fake = FakeExecutor()
+    monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
+
+    _run(m.mikrotik_add_ipv6_address(ctx, address="2001:db8::1/64", interface="ether1"))
+    assert fake.commands[0] == "/ipv6 address add address=2001:db8::1/64 interface=ether1"
+
+
+def test_add_all_options(ctx, monkeypatch):
+    from mcp_mikrotik.scope import ipv6_address as m
+
+    fake = FakeExecutor()
+    monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
+
+    _run(m.mikrotik_add_ipv6_address(
+        ctx, address="::1/64", interface="bridge",
+        advertise=True, eui_64=True, from_pool="pool6", no_dad=True,
+        comment="lan", disabled=True,
+    ))
+    cmd = fake.commands[0]
+    assert cmd.startswith("/ipv6 address add address=::1/64 interface=bridge")
+    assert "advertise=yes" in cmd
+    assert "eui-64=yes" in cmd
+    assert 'from-pool="pool6"' in cmd
+    assert "no-dad=yes" in cmd
+    assert 'comment="lan"' in cmd
+    assert "disabled=yes" in cmd
+
+
+def test_add_advertise_false_is_explicit(ctx, monkeypatch):
+    from mcp_mikrotik.scope import ipv6_address as m
+
+    fake = FakeExecutor()
+    monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
+
+    _run(m.mikrotik_add_ipv6_address(ctx, address="2001:db8::1/64", interface="ether1", advertise=False))
+    assert "advertise=no" in fake.commands[0]
+
+
+def test_add_no_broadcast_field(ctx, monkeypatch):
+    """IPv6 has no broadcast — make sure we never emit one."""
+    from mcp_mikrotik.scope import ipv6_address as m
+
+    fake = FakeExecutor()
+    monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
+
+    _run(m.mikrotik_add_ipv6_address(ctx, address="2001:db8::1/64", interface="ether1"))
+    assert "broadcast" not in fake.commands[0]
+
+
+# ---------------------------------------------------------------------------
+# list_ipv6_addresses — filters
+# ---------------------------------------------------------------------------
+
+def test_list_no_filters(ctx, monkeypatch):
+    from mcp_mikrotik.scope import ipv6_address as m
+
+    fake = FakeExecutor()
+    monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
+
+    _run(m.mikrotik_list_ipv6_addresses(ctx))
+    assert fake.commands[0] == "/ipv6 address print"
+
+
+def test_list_with_filters(ctx, monkeypatch):
+    from mcp_mikrotik.scope import ipv6_address as m
+
+    fake = FakeExecutor()
+    monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
+
+    _run(m.mikrotik_list_ipv6_addresses(
+        ctx, interface_filter="ether1", address_filter="2001:db8",
+        global_only=True, link_local_only=False, dynamic_only=True, disabled_only=True,
+    ))
+    cmd = fake.commands[0]
+    assert cmd.startswith("/ipv6 address print where ")
+    assert 'interface="ether1"' in cmd
+    assert 'address~"2001:db8"' in cmd
+    assert "global=yes" in cmd
+    assert "dynamic=yes" in cmd
+    assert "disabled=yes" in cmd
+
+
+def test_list_link_local_filter(ctx, monkeypatch):
+    from mcp_mikrotik.scope import ipv6_address as m
+
+    fake = FakeExecutor()
+    monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
+
+    _run(m.mikrotik_list_ipv6_addresses(ctx, link_local_only=True))
+    assert fake.commands[0] == "/ipv6 address print where link-local=yes"
+
+
+def test_list_empty_message(ctx, monkeypatch):
+    from mcp_mikrotik.scope import ipv6_address as m
+
+    async def fake(cmd, _ctx):
+        return ""
+
+    monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
+    out = _run(m.mikrotik_list_ipv6_addresses(ctx))
+    assert "No IPv6 addresses found" in out
+
+
+# ---------------------------------------------------------------------------
+# get / remove — id-or-address resolution
+# ---------------------------------------------------------------------------
+
+def test_get_by_id_queries_id_first(ctx, monkeypatch):
+    """A non-colon value (a RouterOS id) is queried by .id first."""
+    from mcp_mikrotik.scope import ipv6_address as m
+
+    calls = []
+
+    async def fake(cmd, _ctx):
+        calls.append(cmd)
+        return "address=2001:db8::1/64 interface=ether1"  # real entry data
+
+    monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
+    out = _run(m.mikrotik_get_ipv6_address(ctx, address_id="*1"))
+    assert calls[0] == '/ipv6 address print detail where .id="*1"'
+    assert "IPV6 ADDRESS DETAILS" in out
+
+
+def test_get_by_address_queries_address_first(ctx, monkeypatch):
+    """A value containing ':' (an IPv6 address) is queried by address first."""
+    from mcp_mikrotik.scope import ipv6_address as m
+
+    calls = []
+
+    async def fake(cmd, _ctx):
+        calls.append(cmd)
+        return "address=2001:db8::1/64 interface=ether1"
+
+    monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
+    out = _run(m.mikrotik_get_ipv6_address(ctx, address_id="2001:db8::1/64"))
+    assert calls[0] == '/ipv6 address print detail where address="2001:db8::1/64"'
+    assert "IPV6 ADDRESS DETAILS" in out
+
+
+def test_get_legend_only_is_treated_as_not_found(ctx, monkeypatch):
+    """Regression (caught live): `print detail` returns the Flags legend even
+    when nothing matches — that must NOT be reported as a found entry."""
+    from mcp_mikrotik.scope import ipv6_address as m
+
+    legend = "Flags: X - disabled, I - invalid; D - dynamic; G - global, L - link-local"
+
+    async def fake(cmd, _ctx):
+        return legend  # non-empty, but no real "address=" row
+
+    monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
+    out = _run(m.mikrotik_get_ipv6_address(ctx, address_id="2001:db8::1/64"))
+    assert "not found" in out
+
+
+def test_remove_by_id(ctx, monkeypatch):
+    from mcp_mikrotik.scope import ipv6_address as m
+
+    async def fake(cmd, _ctx):
+        if "count-only" in cmd:
+            return "1"      # found by id
+        return ""           # remove succeeds
+
+    seen = []
+    async def tracking(cmd, _ctx):
+        seen.append(cmd)
+        return await fake(cmd, _ctx)
+
+    monkeypatch.setattr(m, "execute_mikrotik_command", tracking, raising=True)
+    out = _run(m.mikrotik_remove_ipv6_address(ctx, address_id="*2"))
+    assert '/ipv6 address remove [find .id="*2"]' in seen
+    assert "removed successfully" in out
+
+
+def test_remove_not_found(ctx, monkeypatch):
+    from mcp_mikrotik.scope import ipv6_address as m
+
+    async def fake(cmd, _ctx):
+        return "0"  # count-only returns 0 for both id and address
+
+    monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
+    out = _run(m.mikrotik_remove_ipv6_address(ctx, address_id="nope"))
+    assert "not found" in out
+
+
+# ---------------------------------------------------------------------------
+# IPv6 address normalization (review finding) — non-canonical input must match
+# the RouterOS-canonical stored form (lowercase, zero-compressed).
+# ---------------------------------------------------------------------------
+
+def test_get_canonicalizes_noncanonical_address(ctx, monkeypatch):
+    from mcp_mikrotik.scope import ipv6_address as m
+
+    calls = []
+
+    async def fake(cmd, _ctx):
+        calls.append(cmd)
+        return "address=2001:db8::1/64 interface=ether1"
+
+    monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
+    # Uppercase + expanded zeros -> must be normalized to 2001:db8::1/64
+    _run(m.mikrotik_get_ipv6_address(ctx, address_id="2001:DB8:0:0::1/64"))
+    assert calls[0] == '/ipv6 address print detail where address="2001:db8::1/64"'
+
+
+def test_remove_by_address_path_canonicalized(ctx, monkeypatch):
+    """The primary real-world path: .id lookup misses, address lookup matches,
+    and the input is canonicalized before the remove."""
+    from mcp_mikrotik.scope import ipv6_address as m
+
+    seen = []
+
+    async def fake(cmd, _ctx):
+        seen.append(cmd)
+        if "count-only" in cmd:
+            return "0" if ".id=" in cmd else "1"
+        return ""  # remove succeeds
+
+    monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
+    out = _run(m.mikrotik_remove_ipv6_address(ctx, address_id="2001:DB8::1/64"))
+    assert '/ipv6 address remove [find address="2001:db8::1/64"]' in seen
+    assert "removed successfully" in out
+
+
+# ---------------------------------------------------------------------------
+# from_pool / eui_64 confirmation + failure paths (review findings)
+# ---------------------------------------------------------------------------
+
+def test_add_from_pool_confirms_via_interface(ctx, monkeypatch):
+    """With from_pool the stored address differs from the input, so the
+    confirmation must look up by interface, not by the (host-only) input."""
+    from mcp_mikrotik.scope import ipv6_address as m
+
+    seen = []
+
+    async def fake(cmd, _ctx):
+        seen.append(cmd)
+        if cmd.startswith("/ipv6 address add"):
+            return ""  # success
+        if 'print detail where interface="bridge"' in cmd:
+            return "address=2001:db8:abcd::1/64 from-pool=pool6 interface=bridge"
+        return ""
+
+    monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
+    out = _run(m.mikrotik_add_ipv6_address(ctx, address="::1/64", interface="bridge", from_pool="pool6"))
+    assert any('print detail where interface="bridge"' in c for c in seen)
+    assert "added successfully" in out.lower()
+    assert "2001:db8:abcd::1" in out
+
+
+def test_add_failure_path(ctx, monkeypatch):
+    from mcp_mikrotik.scope import ipv6_address as m
+
+    async def fake(cmd, _ctx):
+        return "failure: already have such address"
+
+    monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
+    out = _run(m.mikrotik_add_ipv6_address(ctx, address="2001:db8::1/64", interface="ether1"))
+    assert "Failed to add IPv6 address" in out
+
+
+def test_remove_failure_path(ctx, monkeypatch):
+    from mcp_mikrotik.scope import ipv6_address as m
+
+    async def fake(cmd, _ctx):
+        if "count-only" in cmd:
+            return "1"  # found by id
+        return "failure: cannot remove"
+
+    monkeypatch.setattr(m, "execute_mikrotik_command", fake, raising=True)
+    out = _run(m.mikrotik_remove_ipv6_address(ctx, address_id="*1"))
+    assert "Failed to remove IPv6 address" in out

--- a/tests/unit/test_scopes_smoke.py
+++ b/tests/unit/test_scopes_smoke.py
@@ -13,6 +13,7 @@ SCOPE_MODULES = [
     "firewall_filter",
     "firewall_nat",
     "ip_address",
+    "ipv6_address",
     "ip_pool",
     "logs",
     "poe",


### PR DESCRIPTION
Closes #92 · first step of the IPv6 gap from #30 ([@stefanbosak's comment](https://github.com/jeff-nasseri/mikrotik-mcp/issues/30#issuecomment-3953910950)).

## What this adds

The MCP was **IPv4-only**. This adds the IPv6 *addressing* scope under `/ipv6 address`, mirroring the proven `ip_address` (IPv4) scope:

| Tool | RouterOS command |
|---|---|
| `add_ipv6_address` | `/ipv6 address add …` — supports `advertise`, `eui-64`, `from-pool`, `no-dad` |
| `list_ipv6_addresses` | `/ipv6 address print` — filters: interface, address, `global`, `link-local`, `dynamic`, `disabled` |
| `get_ipv6_address` | `/ipv6 address print detail` — by `.id` or address value |
| `remove_ipv6_address` | `/ipv6 address remove` — by `.id` or address value |

IPv6-specific vs the IPv4 scope: no `broadcast`; adds `advertise` / `eui-64` / `from-pool` / `no-dad`.

## Verified live against a real RouterOS

Ran the full **add → list → filter → get → remove** CRUD cycle through the MCP protocol against a live RouterOS (`/ipv6 address`), **8/8** checks. Testing + an adversarial review surfaced three real issues, all fixed and re-verified live:

1. **IPv6 normalization (most important).** RouterOS stores addresses canonically (lowercase, zero-compressed). An exact `where address="2001:DB8:0:0::1/64"` would *miss* the stored `2001:db8::1/64` and wrongly report "not found". Inputs are now canonicalized with Python's `ipaddress` before matching — **verified live** with an uppercase/expanded form.
2. **Legend-vs-data.** `/ipv6 address print detail` returns the Flags legend even when nothing matches, so an emptiness check returned a header with no entry. `get` now keys on real entry data (`address=`). *(Caught by the live test.)*
3. **`from_pool`/`eui-64` confirmation.** Those adds store an address different from the input, so the post-add lookup is by **interface**, ensuring the result is still shown.

## Tests & docs

- **18 IPv6 unit tests** (command strings, all filters, id/address resolution, normalization, legend regression, failure paths) + smoke coverage → **78 tests total pass**
- `docs/reference/ipv6-address/README.md` + reference index entry

## Scope

Addressing only. IPv6 routing, firewall, DHCPv6/ND, and pools are noted as separate follow-ups in #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)