### PR TITLE
Fix file download/upload: real SFTP transfer instead of broken/simulated stubs

### DIFF
--- a/src/mcp_mikrotik/connector.py
+++ b/src/mcp_mikrotik/connector.py
@@ -36,6 +36,46 @@ def _execute_sync(command: str) -> str:
         ssh_client.disconnect()
 
 
+def download_file_sync(filename: str) -> bytes:
+    """Download a file from the MikroTik device over SFTP and return its bytes (blocking)."""
+    logger.info(f"Downloading MikroTik file: {filename}")
+
+    ssh_client = MikroTikSSHClient(
+        host=config.mikrotik_config.host,
+        username=config.mikrotik_config.username,
+        password=config.mikrotik_config.password,
+        key_filename=config.mikrotik_config.key_filename,
+        port=config.mikrotik_config.port
+    )
+
+    try:
+        if not ssh_client.connect():
+            raise ConnectionError("Failed to connect to MikroTik device")
+        return ssh_client.download_file(filename)
+    finally:
+        ssh_client.disconnect()
+
+
+def upload_file_sync(filename: str, data: bytes) -> None:
+    """Upload bytes to a file on the MikroTik device over SFTP (blocking)."""
+    logger.info(f"Uploading MikroTik file: {filename} ({len(data)} bytes)")
+
+    ssh_client = MikroTikSSHClient(
+        host=config.mikrotik_config.host,
+        username=config.mikrotik_config.username,
+        password=config.mikrotik_config.password,
+        key_filename=config.mikrotik_config.key_filename,
+        port=config.mikrotik_config.port
+    )
+
+    try:
+        if not ssh_client.connect():
+            raise ConnectionError("Failed to connect to MikroTik device")
+        ssh_client.upload_file(filename, data)
+    finally:
+        ssh_client.disconnect()
+
+
 async def execute_mikrotik_command(command: str, ctx: Context) -> str:
     """Execute a MikroTik command via SSH and return the output.
 

--- a/src/mcp_mikrotik/mikrotik_ssh_client.py
+++ b/src/mcp_mikrotik/mikrotik_ssh_client.py
@@ -1,3 +1,4 @@
+import io
 import logging
 from typing import Optional
 
@@ -80,6 +81,34 @@ class MikroTikSSHClient:
         except Exception as e:
             logger.error(f"Error executing command: {e}")
             raise
+
+    def download_file(self, remote_filename: str) -> bytes:
+        """Download a file from the device over SFTP and return its raw bytes.
+
+        RouterOS exposes its file store over the SSH/SFTP subsystem, so binary
+        backups and text exports alike can be transferred without mangling.
+        """
+        if not self.client:
+            raise Exception("Not connected to MikroTik device")
+
+        sftp = self.client.open_sftp()
+        try:
+            buffer = io.BytesIO()
+            sftp.getfo(remote_filename, buffer)
+            return buffer.getvalue()
+        finally:
+            sftp.close()
+
+    def upload_file(self, remote_filename: str, data: bytes) -> None:
+        """Upload raw bytes to a file on the device over SFTP."""
+        if not self.client:
+            raise Exception("Not connected to MikroTik device")
+
+        sftp = self.client.open_sftp()
+        try:
+            sftp.putfo(io.BytesIO(data), remote_filename)
+        finally:
+            sftp.close()
 
     def disconnect(self):
         """Close SSH connection."""

--- a/src/mcp_mikrotik/scope/backup.py
+++ b/src/mcp_mikrotik/scope/backup.py
@@ -1,7 +1,8 @@
 from typing import Literal, Optional, List
 from ..app import mcp, READ, WRITE, DANGEROUS, annotate
-from ..connector import execute_mikrotik_command
+from ..connector import execute_mikrotik_command, download_file_sync, upload_file_sync
 from mcp.server.fastmcp import Context
+import asyncio
 import base64
 import time
 import os
@@ -189,24 +190,22 @@ async def mikrotik_download_file(
     """Downloads a backup or export file from the MikroTik device as base64-encoded content."""
     await ctx.info(f"Downloading file: filename={filename}, type={file_type}")
 
-    # First, check if file exists
-    check_cmd = f"/file print count-only where name={filename}"
+    # First, check if the file exists.
+    check_cmd = f'/file print count-only where name="{filename}"'
     count = await execute_mikrotik_command(check_cmd, ctx)
 
     if count.strip() == "0":
         return f"File '{filename}' not found."
 
-    # Get file content (this is a simplified version)
-    # In a real implementation, you'd need to handle file transfer properly
-    content_cmd = f"/file print file={filename}"
-    content = await execute_mikrotik_command(content_cmd, ctx)
+    # Transfer the raw bytes over SFTP, then base64-encode for safe transport.
+    # This preserves binary backups (.backup) as well as text exports (.rsc).
+    try:
+        content = await asyncio.to_thread(download_file_sync, filename)
+    except Exception as e:
+        return f"Failed to download file '{filename}': {str(e)}"
 
-    if content:
-        # Encode content to base64 for safe transmission
-        encoded = base64.b64encode(content.encode('utf-8')).decode('utf-8')
-        return f"FILE_CONTENT_BASE64:{encoded}"
-    else:
-        return f"Failed to download file '{filename}'."
+    encoded = base64.b64encode(content).decode('ascii')
+    return f"FILE_CONTENT_BASE64:{encoded}"
 
 @mcp.tool(name="upload_file", annotations=annotate(WRITE, "Upload File"))
 async def mikrotik_upload_file(
@@ -217,15 +216,19 @@ async def mikrotik_upload_file(
     """Uploads a base64-encoded file to the MikroTik device (for restore operations)."""
     await ctx.info(f"Uploading file: filename={filename}")
 
-    # Decode base64 content
+    # Decode the base64 payload to raw bytes (keep binary intact — no utf-8 decode).
     try:
-        content = base64.b64decode(content_base64).decode('utf-8')
+        content = base64.b64decode(content_base64)
     except Exception as e:
         return f"Failed to decode file content: {str(e)}"
 
-    # This is a simplified version - actual implementation would need proper file upload
-    # For now, we'll simulate it
-    return f"File '{filename}' uploaded successfully (simulated)."
+    # Push the bytes to the device over SFTP.
+    try:
+        await asyncio.to_thread(upload_file_sync, filename, content)
+    except Exception as e:
+        return f"Failed to upload file '{filename}': {str(e)}"
+
+    return f"File '{filename}' uploaded successfully."
 
 @mcp.tool(name="restore_backup", annotations=annotate(DANGEROUS, "Restore Backup"))
 async def mikrotik_restore_backup(

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -1,5 +1,7 @@
 import asyncio
 
+import pytest
+
 
 def test_execute_sync_success(monkeypatch):
     from mcp_mikrotik import connector
@@ -62,6 +64,89 @@ def test_execute_sync_exception(monkeypatch):
     monkeypatch.setattr(connector, "MikroTikSSHClient", lambda **kw: DummyClient())
     result = connector._execute_sync("/system identity print")
     assert result.startswith("Error executing command: boom")
+    assert disconnected["called"] == 1
+
+
+def test_download_file_sync_success(monkeypatch):
+    from mcp_mikrotik import connector
+
+    disconnected = {"called": 0}
+
+    class DummyClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def connect(self):
+            return True
+
+        def download_file(self, filename: str) -> bytes:
+            assert filename == "backup_1.backup"
+            return b"\x00binary"
+
+        def disconnect(self):
+            disconnected["called"] += 1
+
+    monkeypatch.setattr(connector, "MikroTikSSHClient", lambda **kw: DummyClient(**kw))
+    assert connector.download_file_sync("backup_1.backup") == b"\x00binary"
+    assert disconnected["called"] == 1
+
+
+def test_download_file_sync_connect_failure(monkeypatch):
+    from mcp_mikrotik import connector
+
+    disconnected = {"called": 0}
+
+    class DummyClient:
+        def connect(self):
+            return False
+
+        def disconnect(self):
+            disconnected["called"] += 1
+
+    monkeypatch.setattr(connector, "MikroTikSSHClient", lambda **kw: DummyClient())
+    with pytest.raises(ConnectionError):
+        connector.download_file_sync("x.backup")
+    assert disconnected["called"] == 1
+
+
+def test_upload_file_sync_success(monkeypatch):
+    from mcp_mikrotik import connector
+
+    captured = {}
+    disconnected = {"called": 0}
+
+    class DummyClient:
+        def connect(self):
+            return True
+
+        def upload_file(self, filename: str, data: bytes) -> None:
+            captured["filename"] = filename
+            captured["data"] = data
+
+        def disconnect(self):
+            disconnected["called"] += 1
+
+    monkeypatch.setattr(connector, "MikroTikSSHClient", lambda **kw: DummyClient())
+    connector.upload_file_sync("restore.rsc", b"config-bytes")
+    assert captured == {"filename": "restore.rsc", "data": b"config-bytes"}
+    assert disconnected["called"] == 1
+
+
+def test_upload_file_sync_connect_failure(monkeypatch):
+    from mcp_mikrotik import connector
+
+    disconnected = {"called": 0}
+
+    class DummyClient:
+        def connect(self):
+            return False
+
+        def disconnect(self):
+            disconnected["called"] += 1
+
+    monkeypatch.setattr(connector, "MikroTikSSHClient", lambda **kw: DummyClient())
+    with pytest.raises(ConnectionError):
+        connector.upload_file_sync("x.rsc", b"data")
     assert disconnected["called"] == 1
 
 

--- a/tests/unit/test_ssh_client.py
+++ b/tests/unit/test_ssh_client.py
@@ -172,3 +172,93 @@ def test_ssh_client_returns_stderr_when_no_stdout(monkeypatch):
     assert client.connect() is True
     assert client.execute_command("/x") == "failure: nope"
 
+
+# ---------------------------------------------------------------------------
+# SFTP file transfer: download_file / upload_file
+# ---------------------------------------------------------------------------
+
+def _connect_client_with_sftp(monkeypatch, sftp):
+    from mcp_mikrotik.mikrotik_ssh_client import MikroTikSSHClient
+    import mcp_mikrotik.mikrotik_ssh_client as mod
+
+    class DummySSH:
+        def set_missing_host_key_policy(self, _policy):
+            pass
+
+        def connect(self, **kwargs):
+            pass
+
+        def open_sftp(self):
+            return sftp
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(mod.paramiko, "SSHClient", lambda: DummySSH())
+    client = MikroTikSSHClient(host="h", username="u", password="p", key_filename=None)
+    assert client.connect() is True
+    return client
+
+
+def test_ssh_client_download_file_via_sftp(monkeypatch):
+    class DummySFTP:
+        def __init__(self, payload):
+            self.payload = payload
+            self.closed = False
+            self.requested = None
+
+        def getfo(self, remotepath, fileobj):
+            self.requested = remotepath
+            fileobj.write(self.payload)
+
+        def close(self):
+            self.closed = True
+
+    # Binary payload that is NOT valid UTF-8 — proves raw bytes survive intact.
+    sftp = DummySFTP(b"\x00\x01\x02backup\xff")
+    client = _connect_client_with_sftp(monkeypatch, sftp)
+
+    data = client.download_file("backup_123.backup")
+    assert data == b"\x00\x01\x02backup\xff"
+    assert sftp.requested == "backup_123.backup"
+    assert sftp.closed is True
+
+
+def test_ssh_client_upload_file_via_sftp(monkeypatch):
+    captured = {}
+
+    class DummySFTP:
+        def __init__(self):
+            self.closed = False
+
+        def putfo(self, fileobj, remotepath):
+            captured["remotepath"] = remotepath
+            captured["data"] = fileobj.read()
+
+        def close(self):
+            self.closed = True
+
+    sftp = DummySFTP()
+    client = _connect_client_with_sftp(monkeypatch, sftp)
+
+    client.upload_file("restore.rsc", b"/system identity\n")
+    assert captured["remotepath"] == "restore.rsc"
+    assert captured["data"] == b"/system identity\n"
+    assert sftp.closed is True
+
+
+def test_ssh_client_download_requires_connect():
+    from mcp_mikrotik.mikrotik_ssh_client import MikroTikSSHClient
+
+    client = MikroTikSSHClient(host="h", username="u", password="p", key_filename=None, port=22)
+    with pytest.raises(Exception, match="Not connected"):
+        client.download_file("x.backup")
+
+
+def test_ssh_client_upload_requires_connect():
+    from mcp_mikrotik.mikrotik_ssh_client import MikroTikSSHClient
+
+    client = MikroTikSSHClient(host="h", username="u", password="p", key_filename=None, port=22)
+    with pytest.raises(Exception, match="Not connected"):
+        client.upload_file("x.rsc", b"data")
+


### PR DESCRIPTION
## Problem

The `download_file` and `upload_file` tools don't actually transfer files:

- **`download_file`** runs `/file print file=<name>`. On RouterOS that *writes a
  new file* (the print output) rather than returning the target file's contents,
  so the tool never returns real data — callers get `Failed to download file`
  (or a base64 blob of unrelated text). The code even carries a
  `# this is a simplified version` note.
- **`upload_file`** is an explicit no-op: it decodes the base64 and returns
  `File '<name>' uploaded successfully (simulated)` without touching the device.

Both are central to the backup/restore and export workflows, so today those
flows can create a file on the router but never retrieve it (and never push one
back).

## Fix

Use the **SFTP subsystem of the existing paramiko SSH connection** — no new
dependency, RouterOS already serves files over SSH/SFTP:

- `MikroTikSSHClient.download_file()` / `upload_file()` — stream bytes via
  `client.open_sftp()` (`getfo` / `putfo`), with a not-connected guard matching
  `execute_command`.
- `connector.download_file_sync()` / `upload_file_sync()` — blocking helpers
  that mirror the existing `_execute_sync()` connect/disconnect pattern.
- `download_file` / `upload_file` tools call those via `asyncio.to_thread`.
  Binary content is preserved (no `utf-8` round-trip that previously corrupted
  `.backup` files); base64 is used only for transport across the tool boundary.

## Tests

- Unit tests for the new SFTP client methods and connector helpers (mocked
  `open_sftp` / `MikroTikSSHClient`, in the existing style). Full unit suite:
  **40 passed**.
- Verified end-to-end against a live **RouterOS 6.49.19** (RB951G-2HnD):
  - downloaded a real `/export` file (5,397 bytes, correct contents)
  - upload → download round-trip returns identical bytes

## Notes

- No API/signature changes to the MCP tools; `upload_file` simply stops
  returning "(simulated)" and now actually uploads.
- The existence pre-check in `download_file` now quotes the filename in the
  `where name=` query.
