### PR TITLE
fix(deps): pin mcp <2.0.0 to fix Docker startup crash (ModuleNotFoundError: mcp.server.fastmcp)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Topic :: System :: Networking",
 ]
 dependencies = [
-    "mcp>=1.8.0",
+    "mcp>=1.10.0,<2.0.0",
     "paramiko>=3.5.1",
     "pydantic>=2.11.4",
     "pydantic-settings>=2.9.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # MCP MikroTik Server Requirements
-mcp>=1.8.0
+mcp>=1.10.0,<2.0.0
 paramiko>=3.5.1
 pydantic>=2.11.4
 pydantic-settings>=2.9.1

--- a/tests/unit/test_mcp_version_bound.py
+++ b/tests/unit/test_mcp_version_bound.py
@@ -1,0 +1,53 @@
+"""Regression guard for issue #98.
+
+The `mcp` dependency must be upper-bounded (`<2.0.0`) so that a Docker/pip
+install never resolves to mcp 2.x, which removed `mcp.server.fastmcp` and
+breaks the server on startup. The floor must be >=1.10.0 — the first release
+that ships `mcp.server.transport_security` (used by the HTTP host-allowlist).
+"""
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _find_mcp_spec(text: str):
+    """Return the raw `mcp` requirement spec (e.g. 'mcp>=1.10.0,<2.0.0') or None."""
+    for raw in text.splitlines():
+        line = raw.strip().strip(",").strip('"').strip("'")
+        # 'mcp' followed by a version operator — excludes mcp-server-mikrotik / mcp_mikrotik
+        if re.match(r"^mcp[<>=!~]", line):
+            return line
+    return None
+
+
+def test_pyproject_mcp_is_upper_bounded():
+    spec = _find_mcp_spec((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    assert spec is not None, "no mcp dependency found in pyproject.toml"
+    assert "<2" in spec, (
+        f"mcp must be capped below 2.0 (got {spec!r}); mcp 2.x removed "
+        "mcp.server.fastmcp and breaks the server (issue #98)."
+    )
+
+
+def test_requirements_mcp_is_upper_bounded():
+    spec = _find_mcp_spec((ROOT / "requirements.txt").read_text(encoding="utf-8"))
+    assert spec is not None, "no mcp dependency found in requirements.txt"
+    assert "<2" in spec, f"mcp must be capped below 2.0 (got {spec!r}); issue #98."
+
+
+def test_mcp_floor_supports_transport_security():
+    # Our code imports mcp.server.transport_security, added in mcp 1.10.0.
+    spec = _find_mcp_spec((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    m = re.search(r">=\s*(\d+)\.(\d+)", spec or "")
+    assert m, f"mcp spec should declare a lower bound (got {spec!r})"
+    major, minor = int(m.group(1)), int(m.group(2))
+    assert (major, minor) >= (1, 10), (
+        f"mcp floor must be >=1.10.0 (transport_security), got {spec!r}"
+    )
+
+
+def test_pyproject_and_requirements_agree_on_mcp():
+    p = _find_mcp_spec((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    r = _find_mcp_spec((ROOT / "requirements.txt").read_text(encoding="utf-8"))
+    assert p == r, f"mcp constraint drift: pyproject={p!r} vs requirements={r!r}"


### PR DESCRIPTION
Closes #98

## Problem

`mcp` was declared unbounded (`mcp>=1.8.0`), so a fresh pip/Docker build now resolves to **mcp 2.0.0** (released recently), which **removed `mcp.server.fastmcp`** — the module the codebase imports. The server crashes immediately on startup:

```
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

## Fix

Cap the dependency below 2.0.0 in **both** `pyproject.toml` and `requirements.txt`:

```diff
- mcp>=1.8.0
+ mcp>=1.10.0,<2.0.0
```

**Two changes, both necessary:**
- **`<2.0.0`** — fixes the reported crash (2.0.0 removed `mcp.server.fastmcp`).
- **floor `>=1.10.0`** (was `1.8.0`) — the HTTP host-allowlist imports `mcp.server.transport_security`, which was **added in mcp 1.10.0**. So the old floor was already a latent lie: installing `mcp==1.8.0`–`1.9.4` would break with `ModuleNotFoundError: No module named 'mcp.server.transport_security'`. I verified this empirically across versions:

  | mcp | `mcp.server.fastmcp` | `mcp.server.transport_security` |
  |---|---|---|
  | 1.8.0 / 1.9.4 | ✅ | ❌ (missing) |
  | 1.10.0 – 1.9x | ✅ | ✅ |
  | 2.0.0 | ❌ (removed) | ✅ |

## Verification

Rebuilt the Docker image with the fix:
- Resolves **mcp 1.29.0** (latest 1.x, not 2.0.0)
- `mcp.server.fastmcp` **and** `mcp.server.transport_security` both import
- The **exact `docker run` from the issue** now prints `Starting MCP MikroTik server` — no traceback

Also added `tests/unit/test_mcp_version_bound.py` — a regression guard asserting mcp stays `<2.0.0`, the floor supports `transport_security`, and the two dep files agree. **90 tests pass.**

> Heads-up: the in-flight uv-migration PR (#47) also declares `mcp>=1.26.0` **without** an upper bound — it should get the same `<2.0.0` cap (its `uv.lock` currently pins 1.26.0, but the constraint itself is unbounded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)