### PR TITLE
fix: wireless tools query an empty /interface wifi menu on legacy-driver devices; /log print has no limit parameter

### DIFF
--- a/src/mcp_mikrotik/scope/logs.py
+++ b/src/mcp_mikrotik/scope/logs.py
@@ -6,6 +6,34 @@ from ..app import mcp, READ, DESTRUCTIVE, annotate
 import re
 from datetime import datetime, timedelta
 
+
+def _apply_log_limit(result: str, limit: Optional[int], print_as: str = "terse") -> str:
+    """Trim log output to the most recent `limit` entries, client-side.
+
+    RouterOS `/log print` has no `limit` parameter -- passing one aborts the
+    whole command with "bad parameter limit (line 1 column 23)" and returns no
+    logs at all. Plain `/log print` and `print terse` emit one line per entry,
+    so those can be sliced safely; `value` and `detail` spread a single entry
+    across several lines (and `value` transposes them into columns), where
+    cutting lines would corrupt the record. Callers using a line-per-entry
+    format pass print_as="terse".
+    """
+    if not limit or limit <= 0 or not result:
+        return result
+
+    if print_as != "terse":
+        return (
+            f"{result}\n\n[note: limit={limit} not applied -- RouterOS /log print "
+            f"has no limit parameter, and print_as={print_as!r} does not emit one "
+            f"line per entry. Use print_as=\"terse\" for a limited view.]"
+        )
+
+    lines = [ln for ln in result.splitlines() if ln.strip()]
+    if len(lines) <= limit:
+        return result
+    return "\n".join(lines[-limit:])
+
+
 @mcp.tool(name="get_logs", annotations=annotate(READ, "Get Logs"))
 async def mikrotik_get_logs(
     ctx: Context,
@@ -20,6 +48,15 @@ async def mikrotik_get_logs(
 ) -> str:
     """Gets logs from the MikroTik device with optional topic, time, and message filters."""
     await ctx.info(f"Getting logs with filters: topics={topics}, action={action}, time={time_filter}")
+
+    # `value` transposes entries into parallel columns, so there is no way to
+    # keep only the last N records once RouterOS has rendered it. A caller
+    # asking for a limit wants fewer entries far more than they want that
+    # particular layout, so fall back to the one-line-per-entry format, which
+    # can be sliced exactly. Without this, limit= silently returns everything.
+    if limit and limit > 0 and print_as == "value":
+        await ctx.debug(f"limit={limit} requested; using terse output so it can be applied")
+        print_as = "terse"
 
     # Build the command
     cmd = f"/log print {print_as}"
@@ -52,9 +89,6 @@ async def mikrotik_get_logs(
     if filters:
         cmd += " where " + " and ".join(filters)
 
-    if limit:
-        cmd += f" limit={limit}"
-
     if follow:
         cmd += " follow"
 
@@ -62,6 +96,8 @@ async def mikrotik_get_logs(
 
     if not result or result.strip() == "" or result.strip() == "no such item":
         return "No log entries found matching the criteria."
+
+    result = _apply_log_limit(result, limit, print_as)
 
     return f"LOG ENTRIES:\n\n{result}"
 
@@ -192,13 +228,12 @@ async def mikrotik_get_security_logs(
     if time_filter:
         cmd += f" and time > ([:timestamp] - {time_filter})"
 
-    if limit:
-        cmd += f" limit={limit}"
-
     result = await execute_mikrotik_command(cmd, ctx)
 
     if not result or result.strip() == "" or result.strip() == "no such item":
         return "No security-related log entries found."
+
+    result = _apply_log_limit(result, limit, "terse")
 
     return f"SECURITY LOG ENTRIES:\n\n{result}"
 
@@ -304,9 +339,9 @@ async def mikrotik_monitor_logs(
     if action:
         cmd += f' action="{action}"'
 
-    # Add a limit to prevent overwhelming output
-    cmd += " limit=100"
-
     result = await execute_mikrotik_command(cmd, ctx)
+
+    # Cap the output client-side; /log print has no `limit` parameter.
+    result = _apply_log_limit(result, 100, "terse")
 
     return f"LOG MONITOR (last {duration} seconds):\n\n{result}"

--- a/src/mcp_mikrotik/scope/wireless.py
+++ b/src/mcp_mikrotik/scope/wireless.py
@@ -38,13 +38,28 @@ async def mikrotik_detect_wireless_interface_type(ctx: Context) -> Optional[str]
                 if ("bad command name" in result_lower or
                         "failure:" in result_lower or
                         "no such command prefix" in result_lower or
+                        "no such item" in result_lower or
+                        "expected end of command" in result_lower or
                         "invalid command name" in result_lower):
                     await ctx.debug(f"Interface type {interface_type} not supported")
                     continue
-                else:
-                    # If we get a numeric result or no error, this type is supported
-                    await ctx.info(f"Detected wireless interface type: {interface_type}")
-                    return interface_type
+
+                # A menu can exist while holding no interfaces. RouterOS 7.x
+                # ships the /interface wifi menu even when only the legacy
+                # `wireless` package is installed, so `print count-only`
+                # succeeds and returns 0. Accepting that sends every
+                # subsequent command to an empty menu, which then reports
+                # "no clients"/"not found" instead of falling through to
+                # /interface wireless. Only accept a menu that has radios.
+                if result.strip().isdigit() and int(result.strip()) == 0:
+                    await ctx.debug(
+                        f"Interface type {interface_type} exists but has no interfaces"
+                    )
+                    continue
+
+                # If we get a numeric result or no error, this type is supported
+                await ctx.info(f"Detected wireless interface type: {interface_type}")
+                return interface_type
 
         except Exception as e:
             await ctx.debug(f"Interface type {interface_type} failed with exception: {e}")


### PR DESCRIPTION
Two independent bugs found while auditing a hAP ac² running RouterOS 7.23.2 with only the legacy `wireless` package installed. One commit each — happy to split into separate PRs if you prefer.

## 1. Wireless detection selects an existing but empty menu

`mikrotik_detect_wireless_interface_type()` probes `/interface wifi` → `wifiwave2` → `wireless` → `wlan` and accepts the first whose `print count-only` doesn't error.

**RouterOS 7.x ships the `/interface wifi` menu even when only the legacy `wireless` package is installed.** The probe succeeds and returns `0`, so the detector accepts `/interface wifi` and every tool downstream queries an empty menu:

| Tool | Behaviour on an affected device |
|---|---|
| `get_wireless_interface` | returns the flags legend and zero rows |
| `get_wireless_registration_table` | reports "No wireless clients registered" with 7 clients associated |
| `scan_wireless_networks` | `no such item (/interface/wifi/scan; line 1)` |
| `check_wireless_support` | reports "Detected Wireless Interface Type: /interface wifi" |

The false-negative registration table is the nastiest one — it looks like a valid answer rather than an error.

The tell is that `get_wireless_interface` returned the **new** wifi flag legend (`M - master`, `B - bound`, `D - dynamic`) rather than the legacy `X - disabled; R - running`, confirming it had queried `/interface wifi`.

`list_wireless_interfaces` is unaffected because it probes all four paths and aggregates rather than using this helper — which is why the bug presents as "some wireless tools work, others don't" instead of a clean failure.

**Fix:** skip a menu that exists but holds no interfaces, so detection falls through to `/interface wireless`. Also treat `no such item` and `expected end of command` as unsupported alongside the existing patterns.

## 2. `/log print limit=N` is not valid RouterOS

`get_logs`, `get_security_logs` and `monitor_logs` append `limit=N` to `/log print`. There is no such parameter, so the command aborts:

```
bad parameter limit (line 1 column 23)
```

and **no logs are returned at all**. Every caller forwarding a limit is affected: `get_logs_by_topic`, `get_logs_by_severity`, `search_logs`, `get_system_events`.

**Fix:** drop the parameter, trim client-side in `_apply_log_limit()`.

Only one-line-per-entry formats can be sliced safely — `value` transposes entries into parallel columns and `detail` spans several lines each, so cutting lines there corrupts records. Since a caller passing a limit wants fewer entries more than that particular layout, `get_logs` switches to `terse` when a limit is requested and the format is still the default `value`. An explicit `detail` is passed through and annotated rather than silently unlimited.

## Verification

Hardware: hAP ac² (RBD52G-5HacD2HnD, arm), RouterOS 7.23.2 stable, packages `routeros` + `wireless` only.

| Call | Before | After |
|---|---|---|
| `get_wireless_registration_table()` | `No wireless clients registered.` | 7 clients with signal + tx-rate |
| `get_wireless_interface("wlan1")` | flags legend, 0 rows | full `/interface wireless` detail |
| `scan_wireless_networks("wlan1")` | `no such item (/interface/wifi/scan)` | 30 neighbouring APs |
| `get_logs_by_topic("wireless", limit=5)` | `bad parameter limit` | exactly 5 entries |

I don't have a device running the new `/interface wifi` stack to regression-test against, so a second pair of eyes on that path would be welcome — though the change only makes detection *stricter* for menus reporting zero interfaces, and a real wifi-stack device reports a non-zero count.

## Note on a third issue (not fixed here)

Safe mode can't work as currently designed: the connector opens a new SSH session per command, and RouterOS binds safe mode to a session. `enable_safe_mode` takes it, the session closes, and it's silently released — so `enable_safe_mode` → change → `commit_safe_mode` reports success while the change lands unprotected. On this device `enable_safe_mode` returned an error while the router replied `Taking Safe Mode session... Success!`, and a follow-up `safe_mode_status` in the next session reported safe mode inactive.

That needs a persistent channel rather than a small patch, so I've left it alone — flagging it since it's a data-loss-shaped footgun. Happy to open a separate issue if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)