### PR TITLE
fix(ci): correct version reporting — bake release version into the image, honest placeholder in pyproject

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,6 +63,15 @@ jobs:
           echo "majorMinorPatch: ${{ steps.gitversion.outputs.majorMinorPatch }}"
           echo "assemblySemVer:  ${{ steps.gitversion.outputs.assemblySemVer }}"
 
+      # The repo's pyproject.toml carries a placeholder version; the real one is
+      # computed by GitVersion at release time. publish.yml already does this
+      # before building the PyPI artifact — do the same here so the version
+      # baked into the image matches its tag, instead of the placeholder.
+      - name: Update version in pyproject.toml
+        run: |
+          sed -i 's/version = ".*"/version = "${{ steps.gitversion.outputs.assemblySemVer }}"/' pyproject.toml
+          grep '^version' pyproject.toml
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-server-mikrotik"
-version = "0.1.14"
+# Placeholder only: the real version is computed by GitVersion and injected
+# into this line by CI at release time (see .github/workflows/publish.yml).
+version = "0.0.0"
 description = "MCP server for MikroTik integration with Claude and other AI assistants"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Two small, related fixes so the reported version is never misleading.

---

## 1. The Docker image baked in the wrong version

The freshly published `:0.13.0` image reported:

```python
importlib.metadata.version("mcp-server-mikrotik")   # -> 0.1.14  ❌
```

**Why:** `pyproject.toml` carries a placeholder; GitVersion computes the real version at release time. `publish.yml` (PyPI) seds it in before building — but `docker-publish.yml` used the computed version only for the image **tags**, never writing it into `pyproject.toml`. So `pip install .` inside the Dockerfile baked in the placeholder: the image was *tagged* `0.13.0` but *believed* it was `0.1.14`.

**Fix:** add the same step `publish.yml` already uses, before the build.

**Verified by building both ways:**

| Build | Image reports |
|---|---|
| without the step (today's `master`) | `0.1.14` ❌ reproduces the bug |
| with the step (this PR) | `0.13.0.0` ✅ matches the tag |

The fixed image was run against a live RouterOS: `/health` 200, **173 tools**, `list_interfaces` returned real data — nothing regressed.

---

## 2. The placeholder itself was misleading

```diff
+ # Placeholder only: the real version is computed by GitVersion and injected
+ # into this line by CI at release time (see .github/workflows/publish.yml).
- version = "0.1.14"
+ version = "0.0.0"
```

`0.1.14` **looks like a real (old) release** — which is precisely why the stale image metadata seemed plausible rather than obviously wrong. `0.0.0` unmistakably means "unreleased dev build", and already matches the fallback in `src/mcp_mikrotik/__init__.py`.

> The comment sits **above** the version line, not inline: the CI sed pattern `version = ".*"` is greedy, so a quote in a trailing comment would silently break version injection.

**Verified:** the real CI `sed` still rewrites the line correctly, the wheel builds (`mcp_server_mikrotik-0.0.0`), and **93 tests pass**.

---

### Why not fully dynamic versioning?

I evaluated `setuptools-scm` (version derived from git tags, no hardcoded value at all) and **rejected it for now** — it would trade a cosmetic problem for a build-fragility one:

| Scenario | Result |
|---|---|
| env var set, no `.git` | ✅ builds correctly |
| **no env var, no `.git`** | ❌ **hard build failure** |

`.dockerignore` excludes `.git`, so every Docker build would depend on `ARG`/`ENV` plumbing — a mistake there breaks the build instead of just mis-reporting a version. It would also conflict with **PR #47**, which switches the build backend to hatchling. Worth revisiting after that lands.

## Impact

**Cosmetic** — nothing at runtime reads these values, so current images work fine. This makes "which version is this container actually running?" answerable correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)