### PR TITLE
docs(articles): fleet-management article and multi-device prompt examples

### DIFF
--- a/docs/articles/README.md
+++ b/docs/articles/README.md
@@ -15,6 +15,10 @@ MikroTik MCP is an AI-powered interface that allows you to manage and configure 
    *Author: [@jeff-nasseri](https://medium.com/@sir.jeff.nasseri)*  
    An introductory guide exploring how AI transforms traditional network management workflows, with practical examples using MikroTik MCP.
 
+2. **[Managing a Whole MikroTik Fleet from One MCP Server](https://medium.com/@sir.jeff.nasseri/managing-a-whole-mikrotik-fleet-from-one-mcp-server-60245de07073)**  
+   *Author: [@jeff-nasseri](https://medium.com/@sir.jeff.nasseri)*  
+   How to manage multiple MikroTik devices from a single MCP server using the inventory: configuring the YAML file, wiring it up (including Docker), and prompt patterns for fleet work. Also available [in this repository](managing-a-mikrotik-fleet.md).
+
 ### Example Workflow
 
 ```
@@ -32,7 +36,10 @@ Result: Guest network is ready and operational!
 
 ## 📋 Example Library
 
-We provide **20 comprehensive examples** covering common network scenarios:
+We provide **25 comprehensive examples** covering common network scenarios,
+including five dedicated to **multi-device (inventory) prompt engineering**:
+discovering the fleet, rolling a change out across tagged devices, comparing
+configuration between routers, safe-mode-guarded changes on one device of the
+fleet, and fleet-wide changes with per-device verification.
 
-
-[**View All 20 Examples →**](examples.md)
+[**View All 25 Examples →**](examples.md)

--- a/docs/articles/examples.md
+++ b/docs/articles/examples.md
@@ -1,30 +1,4 @@
-## Example 20: Complete Backup and Restore Strategy
-
-**Prompt to AI**:
-```
-Set up an automated backup system for my router. Create manual backup named 
-"daily-backup", export configuration to "daily-config" file. Schedule automatic 
-backups to run daily at 2:00 AM with date in filename. Schedule weekly cleanup 
-at 3:00 AM on Sundays to delete backups older than 7 days. If USB drive is 
-mounted as usb1, copy backups to USB drive in a backups folder.
-```
-
-**What AI Will Do**:
-1. Execute system backup save command with name "daily-backup"
-2. Execute export command to create "daily-config" file
-3. Create system scheduler named "daily-backup"
-4. Set start time to 02:00:00 with 1-day interval
-5. Configure script to create backup with date-stamped filename
-6. Add comment "Daily Backup"
-7. Create system scheduler named "cleanup-old-backups"
-8. Set start time to 03:00:00 with 7-day interval
-9. Configure script to remove files older than 7 days (604800 seconds)
-10. Use regex pattern to match backup files
-11. Add comment "Weekly Cleanup"
-12. Create file copy operation to USB drive (if mounted)
-13. Copy all backup files to usb1/backups/ directory
-14. Ensure backup rotation maintains only recent backups
-15. Configure error handling for USB drive availability# MikroTik MCP - 20 Practical Examples
+# MikroTik MCP - 25 Practical Examples
 
 This guide provides practical examples for developers learning to interact with MikroTik devices using the MCP (Model Context Protocol) tools.
 
@@ -617,7 +591,31 @@ and create firewall rule to allow SNMP (UDP port 161) from the monitoring subnet
 
 ## Example 20: Complete Backup and Restore Strategy
 
-**Scenario**: Automated daily backups with cloud upload.
+**Prompt to AI**:
+```
+Set up an automated backup system for my router. Create manual backup named 
+"daily-backup", export configuration to "daily-config" file. Schedule automatic 
+backups to run daily at 2:00 AM with date in filename. Schedule weekly cleanup 
+at 3:00 AM on Sundays to delete backups older than 7 days. If USB drive is 
+mounted as usb1, copy backups to USB drive in a backups folder.
+```
+
+**What AI Will Do**:
+1. Execute system backup save command with name "daily-backup"
+2. Execute export command to create "daily-config" file
+3. Create system scheduler named "daily-backup"
+4. Set start time to 02:00:00 with 1-day interval
+5. Configure script to create backup with date-stamped filename
+6. Add comment "Daily Backup"
+7. Create system scheduler named "cleanup-old-backups"
+8. Set start time to 03:00:00 with 7-day interval
+9. Configure script to remove files older than 7 days (604800 seconds)
+10. Use regex pattern to match backup files
+11. Add comment "Weekly Cleanup"
+12. Create file copy operation to USB drive (if mounted)
+13. Copy all backup files to usb1/backups/ directory
+14. Ensure backup rotation maintains only recent backups
+15. Configure error handling for USB drive availability
 
 **Manual Commands**:
 ```bash
@@ -681,3 +679,180 @@ Use these commands to verify your configurations:
 /interface print stats
 ```
 
+
+---
+
+# Multi-Device Examples (Inventory)
+
+The examples above target a single router. With an [inventory](../reference/inventory/README.md)
+configured, one MCP server manages a whole fleet: every tool accepts a `device`
+argument naming the inventory `title` to target, and a `list_devices` tool lets
+the AI discover the fleet on its own.
+
+The prompt engineering pattern is simple: **name your devices the way you talk
+about them** (`office-core`, `branch-berlin`), then refer to them by name, by
+tag, or just say "all devices". The AI resolves the rest. If it ever omits or
+mistypes a device, the server answers with the list of valid titles, so the AI
+corrects itself on the next call.
+
+These examples assume this inventory:
+
+```yaml
+- title: office-core
+  host: 192.168.88.1
+  username: admin
+  tags: [office, core]
+  region: NL
+
+- title: branch-berlin
+  host: 10.20.0.1
+  username: admin
+  tags: [branch]
+  region: DE
+```
+
+---
+
+## Example 21: Discover and Audit the Fleet
+
+**Prompt to AI**:
+```
+Which MikroTik devices do you manage? For each one, show me its identity, 
+RouterOS version, and which interfaces are actually running.
+```
+
+**What AI Will Do**:
+1. Call `list_devices` to discover the fleet (titles, hosts, tags, regions)
+2. Call `list_interfaces(device="office-core")` and filter for running interfaces
+3. Call `list_interfaces(device="branch-berlin")` and do the same
+4. Export the system identity from each device
+5. Summarize the fleet in one table: title, host, identity, version, running interfaces
+
+**Manual Commands**:
+```bash
+# on office-core
+/system identity print
+/system resource print
+/interface print where running
+
+# on branch-berlin
+/system identity print
+/system resource print
+/interface print where running
+```
+
+---
+
+## Example 22: Roll Out a VLAN Across Tagged Devices
+
+**Prompt to AI**:
+```
+On every device tagged "office", create VLAN 40 on ether2 named vlan40-voip 
+with IP 10.40.0.1/24. Verify each device afterwards and tell me if any of 
+them failed.
+```
+
+**What AI Will Do**:
+1. Call `list_devices` and select the devices whose tags include "office"
+2. For each matching device (here only office-core):
+   - `create_vlan_interface(device="office-core", name="vlan40-voip", vlan_id=40, interface="ether2")`
+   - `add_ip_address(device="office-core", address="10.40.0.1/24", interface="vlan40-voip")`
+3. Verify with `list_vlan_interfaces(device="office-core")` and `list_ip_addresses(device="office-core")`
+4. Report per-device success or failure instead of assuming the writes landed
+
+**Manual Commands**:
+```bash
+# on each device tagged "office"
+/interface vlan add name=vlan40-voip vlan-id=40 interface=ether2
+/ip address add address=10.40.0.1/24 interface=vlan40-voip
+/interface vlan print
+/ip address print where interface=vlan40-voip
+```
+
+---
+
+## Example 23: Compare Configuration Between Two Devices
+
+**Prompt to AI**:
+```
+Compare the firewall filter rules on office-core and branch-berlin. 
+Summarize what exists on one but not the other, and flag anything on 
+branch-berlin that allows traffic office-core would drop.
+```
+
+**What AI Will Do**:
+1. Call `list_filter_rules(device="office-core")`
+2. Call `list_filter_rules(device="branch-berlin")`
+3. Diff the two rule sets by chain, action, and match criteria
+4. Highlight rules present on only one device
+5. Call out permissive rules on branch-berlin that contradict office-core policy
+6. Present the result as a summary, not a raw dump
+
+**Manual Commands**:
+```bash
+# on office-core
+/ip firewall filter print detail
+
+# on branch-berlin
+/ip firewall filter print detail
+
+# then compare the two outputs by hand
+```
+
+---
+
+## Example 24: Risky Change on One Device, Guarded by Safe Mode
+
+**Prompt to AI**:
+```
+I need to tighten the firewall on branch-berlin, but I'm remote and can't 
+afford to lock myself out. Enable safe mode on it first, add a forward-chain 
+drop rule for 203.0.113.0/24, show me the resulting rules, and only commit 
+if the rule looks correct. office-core must not be touched.
+```
+
+**What AI Will Do**:
+1. Call `enable_safe_mode(device="branch-berlin")` — safe mode is tracked per
+   device, so office-core is unaffected
+2. Create the rule with `create_filter_rule(device="branch-berlin", chain="forward", action="drop", dst_address="203.0.113.0/24")`
+3. Verify with `list_filter_rules(device="branch-berlin")`
+4. If correct: `commit_safe_mode(device="branch-berlin")` to persist
+5. If wrong: `rollback_safe_mode(device="branch-berlin")` and the router reverts
+   the change automatically
+6. Confirm `safe_mode_status(device="office-core")` still reports inactive
+
+**Manual Commands**:
+```bash
+# on branch-berlin (interactive session)
+# Ctrl+X                                  <- enter safe mode
+/ip firewall filter add chain=forward action=drop dst-address=203.0.113.0/24
+/ip firewall filter print
+# Ctrl+X                                  <- commit and leave safe mode
+# (or drop the session to auto-revert)
+```
+
+---
+
+## Example 25: Fleet-Wide DNS Record with Per-Device Verification
+
+**Prompt to AI**:
+```
+Add a static DNS record printer.lan pointing to 192.168.88.50 on all devices. 
+Then query each device to prove the record resolves everywhere.
+```
+
+**What AI Will Do**:
+1. Call `list_devices` to enumerate the fleet
+2. For each device:
+   - `add_dns_static(device=..., name="printer.lan", address="192.168.88.50")`
+   - `list_dns_static(device=...)` to confirm the record exists
+   - `test_dns_query(device=..., hostname="printer.lan")` to prove resolution
+3. Report a per-device table: created, verified, resolved
+
+**Manual Commands**:
+```bash
+# on every device
+/ip dns static add name=printer.lan address=192.168.88.50
+/ip dns static print
+/resolve printer.lan
+```

--- a/docs/articles/managing-a-mikrotik-fleet.md
+++ b/docs/articles/managing-a-mikrotik-fleet.md
@@ -1,0 +1,179 @@
+# Managing a Whole MikroTik Fleet from One MCP Server
+
+> Originally published on Medium:
+> [Managing a Whole MikroTik Fleet from One MCP Server](https://medium.com/@sir.jeff.nasseri/managing-a-whole-mikrotik-fleet-from-one-mcp-server-60245de07073)
+> by [@jeff-nasseri](https://medium.com/@sir.jeff.nasseri)
+
+For a long time, [mikrotik-mcp](https://github.com/jeff-nasseri/mikrotik-mcp) could talk to exactly one router. You gave it a host, a username and a password, and your AI assistant could manage that single device over SSH. That was fine for a home lab, but the moment you have a second router (a branch office, a datacenter box, a test bench), you had to run a second server instance with its own configuration.
+
+Not anymore. mikrotik-mcp now supports a device **inventory**: one server, one configuration file, and as many MikroTik devices as you want. The LLM discovers the fleet on its own, targets devices by name, and gets a helpful error (not silent misbehavior) when it points at a device that does not exist.
+
+In this article I will walk through how to configure the inventory YAML file, how to wire it up so the MCP server connects to multiple devices, and some example prompts to get you started.
+
+## The inventory YAML file
+
+The inventory is a plain YAML list. Each entry is one device. Network engineers live in YAML anyway, so this should feel familiar:
+
+```yaml
+- title: office-core
+  host: 192.168.88.1
+  port: 22
+  username: admin
+  password: change-me
+  tags: [office, core]
+  region: NL
+
+- title: branch-berlin
+  host: 10.20.0.1
+  username: admin
+  key_filename: /config/keys/id_ed25519
+  tags: [branch]
+  region: DE
+```
+
+There is a ready-to-copy template in the repository root: [`inventory.example.yml`](https://github.com/jeff-nasseri/mikrotik-mcp/blob/master/inventory.example.yml).
+
+Only two fields are required:
+
+| Field | Required | What it does |
+|---|---|---|
+| `title` | yes | The unique name the LLM uses to target this device. Matching is case-insensitive. |
+| `host` | yes | IP address or hostname |
+| `port` | no | SSH port, defaults to `22` |
+| `username` | no | Defaults to `admin` |
+| `password` | no | Skip it when you use `key_filename` |
+| `key_filename` | no | Path to an SSH private key. Prefer this over a password. |
+| `tags` | no | Free-form labels, like `[branch, eu]` |
+| `region` | no | Free-form label, like `NL` |
+
+A few things worth knowing:
+
+- **`title` is the whole targeting story.** Pick names you would naturally use in a prompt, like `office-core` or `branch-berlin`, because that is literally what you will type.
+- **Titles must be unique**, and the server checks that at startup, case-insensitively.
+- **The file is a secret.** It holds credentials for your whole fleet, so `chmod 600` it, keep it out of version control, and prefer SSH keys over passwords. Validation errors never echo the file contents back, so a typo cannot leak a password into a log, but the file itself is still yours to protect.
+- **Broken inventories fail fast.** A missing file, a YAML syntax error or an invalid entry stops the server at startup with one clear message naming the position and field. You will not discover a typo three tool calls deep.
+- JSON still works too. JSON is a subset of YAML, so if you already have an `inventory.json` from an earlier setup, it keeps loading unchanged.
+
+## Connecting the MCP server to multiple devices
+
+There are two ways to hand the inventory to the server, and they cover different situations.
+
+### Option 1: point at the file (recommended)
+
+Set `MIKROTIK_INVENTORY_FILE` in the `env` block of your MCP client configuration (Claude Desktop, Cursor, or whatever client you use):
+
+```json
+{
+  "mcpServers": {
+    "mikrotik": {
+      "command": "python",
+      "args": ["-m", "mcp_mikrotik.server"],
+      "env": {
+        "MIKROTIK_INVENTORY_FILE": "/etc/mikrotik/inventory.yaml"
+      }
+    }
+  }
+}
+```
+
+This keeps your client config short and your credentials out of it.
+
+### Option 2: inline, no file at all
+
+If you would rather keep everything in one place, put the inventory itself in `MIKROTIK_INVENTORY`. Environment values have to be strings, so you cannot nest a real JSON object there, but YAML flow syntax gives you the same structure with zero escaped quotes:
+
+```json
+{
+  "mcpServers": {
+    "mikrotik": {
+      "command": "python",
+      "args": ["-m", "mcp_mikrotik.server"],
+      "env": {
+        "MIKROTIK_INVENTORY": "[{title: office-core, host: 192.168.88.1, username: admin, password: change-me}, {title: branch-berlin, host: 10.20.0.1, username: admin}]"
+      }
+    }
+  }
+}
+```
+
+When both are set, the inline inventory wins and the file is ignored. And if you configure neither, nothing changes for you: the classic single-device variables (`MIKROTIK_HOST`, `MIKROTIK_USERNAME`, `MIKROTIK_PASSWORD`, `MIKROTIK_PORT`) keep working exactly as before.
+
+### Running in Docker
+
+If you run mikrotik-mcp from the Docker image, the inventory file lives on your host, so you have to **mount it into the container as a volume**. The image ships `/config` as the mount point:
+
+```bash
+docker run --rm -i \
+  -v "$PWD/inventory.yaml:/config/inventory.yaml:ro" \
+  -e MIKROTIK_INVENTORY_FILE=/config/inventory.yaml \
+  ghcr.io/jeff-nasseri/mikrotik-mcp:latest
+```
+
+Or with Docker Compose, for a long-running setup:
+
+```yaml
+services:
+  mikrotik-mcp:
+    image: ghcr.io/jeff-nasseri/mikrotik-mcp:latest
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./inventory.yaml:/config/inventory.yaml:ro
+    environment:
+      MIKROTIK_INVENTORY_FILE: "/config/inventory.yaml"
+      MIKROTIK_MCP__TRANSPORT: "streamable-http"
+```
+
+Two classic traps, both of which the container now catches with an explicit error instead of starting a broken server:
+
+1. The container runs as uid 1000, so the mounted file must be readable by that uid. `chmod 644 inventory.yaml` is usually enough.
+2. If `inventory.yaml` does not exist on the host when you start the container, Docker silently creates a directory in its place. Create the file first, then start the container.
+
+A mounted file is also safer than the inline environment variable in Docker, because environment values show up in `docker inspect` and file contents do not.
+
+## How the LLM actually uses the fleet
+
+Once the server is up, three things make multi-device work smooth:
+
+1. **A `list_devices` tool.** The model can ask the server what it manages and gets back the titles, hosts, tags and regions. Credentials are never returned.
+2. **A `device` argument on every tool.** All of the existing tools (interfaces, VLANs, firewall, DNS, DHCP, WireGuard, backups and so on) accept an optional `device` parameter naming the title to target.
+3. **Self-correcting errors.** With one device configured, `device` can be omitted and everything works like the old single-device setup. With several devices, omitting it (or typo-ing a title) returns an error that lists the valid titles, so the model fixes itself on the next call instead of quietly running your command on the wrong router.
+
+Each command opens its own SSH connection and closes it when done, so parallel sessions cannot step on each other. And safe mode is tracked per device: enabling safe mode on one router does not touch the others.
+
+## Example prompts
+
+Here are some prompts I actually use. Notice that once you name your devices well, the prompts read like you are talking to a network engineer, not an API.
+
+**Discover the fleet:**
+
+> Which MikroTik devices do you manage? Show me their hosts and tags.
+
+**Read from one device:**
+
+> List the interfaces on office-core and tell me which ones are actually running.
+
+**Configure one device:**
+
+> On branch-berlin, create VLAN 30 on ether2, name it vlan30-guests, and give it the address 10.30.0.1/24.
+
+**Compare devices:**
+
+> Compare the firewall filter rules on office-core and branch-berlin and summarize what is different.
+
+**Work across the fleet:**
+
+> Add a static DNS record printer.lan pointing to 192.168.88.50 on every device tagged office.
+
+**Make risky changes safely:**
+
+> Enable safe mode on office-core first. Then add a forward-chain drop rule for 203.0.113.50. Show me the rule, and if it looks right, commit the safe mode session.
+
+That last one deserves a note: MikroTik safe mode means the changes are held in memory and revert automatically if the session drops before you commit. Having the LLM work inside safe mode gives you an undo button for AI-driven changes, per device, which is exactly where you want one.
+
+## Wrapping up
+
+The inventory turns mikrotik-mcp from a single-router tool into a fleet tool: one YAML file, one server, and natural-language control over every MikroTik device you own. Point `MIKROTIK_INVENTORY_FILE` at your inventory, ask "which devices do you manage?", and go from there.
+
+The project lives at [github.com/jeff-nasseri/mikrotik-mcp](https://github.com/jeff-nasseri/mikrotik-mcp). Issues and pull requests are welcome, and if you try it against your own fleet, I would love to hear how it goes.


### PR DESCRIPTION
Follows up on #56 (multi-device inventory), documentation only.

## What's included

**1. The Medium article, mirrored in the repo**

[`docs/articles/managing-a-mikrotik-fleet.md`](https://github.com/jeff-nasseri/mikrotik-mcp/blob/docs/fleet-article-and-examples/docs/articles/managing-a-mikrotik-fleet.md) carries the full text of [Managing a Whole MikroTik Fleet from One MCP Server](https://medium.com/@sir.jeff.nasseri/managing-a-whole-mikrotik-fleet-from-one-mcp-server-60245de07073), with the Medium URL noted as the canonical source. The learning hub ([`docs/articles/README.md`](https://github.com/jeff-nasseri/mikrotik-mcp/blob/docs/fleet-article-and-examples/docs/articles/README.md)) lists it as Medium article #2.

**2. Five multi-device prompt-engineering examples (21–25)**

Appended to [`examples.md`](https://github.com/jeff-nasseri/mikrotik-mcp/blob/docs/fleet-article-and-examples/docs/articles/examples.md) in the established *Prompt to AI / What AI Will Do / Manual Commands* format, each spelling out the `device="..."` targeting so readers see exactly how the AI addresses individual routers in an inventory:

| # | Scenario |
|---|---|
| 21 | Discover and audit the fleet (`list_devices` + per-device reads) |
| 22 | Roll a VLAN out across devices selected by tag |
| 23 | Compare firewall rules between two routers |
| 24 | Safe-mode-guarded change on one device, others untouched |
| 25 | Fleet-wide DNS record with per-device verification |

The section opens with a short primer on the prompt pattern (name devices the way you talk about them, target by title/tag/"all devices") and the self-correcting error behaviour.

**3. Drive-by repair in `examples.md`**

Example 20's prompt and steps had been pasted above the document title (with the title glued onto its last line), while the real Example 20 at the bottom carried only the commands. The two halves are reunited in the standard format and the title is back on line 1. Counts updated 20 → 25 everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)