### PR TITLE
feat(firewall): support in-interface-list/out-interface-list in filter rules

### DIFF
--- a/src/mcp_mikrotik/scope/firewall_filter.py
+++ b/src/mcp_mikrotik/scope/firewall_filter.py
@@ -15,6 +15,8 @@ async def mikrotik_create_filter_rule(
     protocol: Optional[str] = None,
     in_interface: Optional[str] = None,
     out_interface: Optional[str] = None,
+    in_interface_list: Optional[str] = None,
+    out_interface_list: Optional[str] = None,
     connection_state: Optional[str] = None,
     connection_nat_state: Optional[str] = None,
     src_address_list: Optional[str] = None,
@@ -35,6 +37,7 @@ async def mikrotik_create_filter_rule(
         limit: RouterOS rate/burst string e.g. "10,5:packet" or "10/1s:packet"
         tcp_flags: RouterOS flag expression e.g. "syn,!ack"
         place_before: rule number or ID (*N) to insert before e.g. "0" or "*3"
+        in_interface_list/out_interface_list: name of an /interface list (e.g. "LAN", "WAN") rather than a single interface
     """
     await ctx.info(f"Creating firewall filter rule: chain={chain}, action={action}")
 
@@ -62,6 +65,12 @@ async def mikrotik_create_filter_rule(
 
     if out_interface:
         cmd += f' out-interface="{out_interface}"'
+
+    if in_interface_list:
+        cmd += f' in-interface-list="{in_interface_list}"'
+
+    if out_interface_list:
+        cmd += f' out-interface-list="{out_interface_list}"'
 
     if connection_state:
         cmd += f" connection-state={connection_state}"
@@ -208,6 +217,8 @@ async def mikrotik_update_filter_rule(
     protocol: Optional[str] = None,
     in_interface: Optional[str] = None,
     out_interface: Optional[str] = None,
+    in_interface_list: Optional[str] = None,
+    out_interface_list: Optional[str] = None,
     connection_state: Optional[str] = None,
     connection_nat_state: Optional[str] = None,
     src_address_list: Optional[str] = None,
@@ -275,6 +286,16 @@ async def mikrotik_update_filter_rule(
             updates.append("!out-interface")
         else:
             updates.append(f'out-interface="{out_interface}"')
+    if in_interface_list is not None:
+        if in_interface_list == "":
+            updates.append("!in-interface-list")
+        else:
+            updates.append(f'in-interface-list="{in_interface_list}"')
+    if out_interface_list is not None:
+        if out_interface_list == "":
+            updates.append("!out-interface-list")
+        else:
+            updates.append(f'out-interface-list="{out_interface_list}"')
     if connection_state is not None:
         if connection_state == "":
             updates.append("!connection-state")


### PR DESCRIPTION
The create_filter_rule and update_filter_rule tools only exposed in_interface/out_interface, which map to single interfaces. RouterOS in-interface-list=/out-interface-list= matchers had no corresponding parameter anywhere in the codebase, so firewall rules targeting /interface lists (e.g. LAN, WAN zone-style rules) could not be expressed at all.

This adds optional in_interface_list and out_interface_list parameters to both tools, placed right after out_interface with device kept as the last parameter. Create emits in-interface-list="..."/out-interface-list="..." using the same quoting style as the existing in-interface handling; update follows the file's pass-"" -to-clear pattern (!in-interface-list / !out-interface-list). Values pass through unvalidated so RouterOS reports errors, consistent with every other parameter here, and behavior is unchanged when the new parameters are omitted.

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)