### PR TITLE
fix: correct ctx argument binding in enable/disable_filter_rule

### DIFF
--- a/src/mcp_mikrotik/scope/firewall_filter.py
+++ b/src/mcp_mikrotik/scope/firewall_filter.py
@@ -385,12 +385,12 @@ async def mikrotik_move_filter_rule(ctx: Context, rule_id: str, destination: int
 @mcp.tool(name="enable_filter_rule", annotations=annotate(WRITE_IDEMPOTENT, "Enable Filter Rule"))
 async def mikrotik_enable_filter_rule(ctx: Context, rule_id: str, device: Optional[str] = None) -> str:
     """Enables a firewall filter rule."""
-    return await mikrotik_update_filter_rule(rule_id, disabled=False, ctx=ctx, device=device)
+    return await mikrotik_update_filter_rule(ctx, rule_id, disabled=False, device=device)
 
 @mcp.tool(name="disable_filter_rule", annotations=annotate(WRITE_IDEMPOTENT, "Disable Filter Rule"))
 async def mikrotik_disable_filter_rule(ctx: Context, rule_id: str, device: Optional[str] = None) -> str:
     """Disables a firewall filter rule."""
-    return await mikrotik_update_filter_rule(rule_id, disabled=True, ctx=ctx, device=device)
+    return await mikrotik_update_filter_rule(ctx, rule_id, disabled=True, device=device)
 
 @mcp.tool(name="create_basic_firewall_setup", annotations=annotate(DANGEROUS, "Create Basic Firewall Setup"))
 async def mikrotik_create_basic_firewall_setup(ctx: Context, device: Optional[str] = None) -> str:

--- a/tests/unit/test_scopes_smoke.py
+++ b/tests/unit/test_scopes_smoke.py
@@ -30,8 +30,6 @@ BROKEN_WRAPPER_FUNCS = {
     # They currently raise TypeError ("multiple values for argument 'ctx'").
     "mikrotik_disable_dns_static",
     "mikrotik_enable_dns_static",
-    "mikrotik_disable_filter_rule",
-    "mikrotik_enable_filter_rule",
     "mikrotik_disable_nat_rule",
     "mikrotik_enable_nat_rule",
     "mikrotik_disable_route",


### PR DESCRIPTION
The enable_filter_rule and disable_filter_rule tools passed rule_id as the first positional argument to mikrotik_update_filter_rule, where it bound to the ctx parameter, while also passing ctx as a keyword. As a result every enable/disable call raised TypeError "got multiple values for argument 'ctx'" before any command reached the router.

The fix passes ctx in its correct first positional slot (mikrotik_update_filter_rule(ctx, rule_id, disabled=..., device=device)) in both wrappers. The delegation target already builds the correct RouterOS set command and threads device through, so no other change is needed; the unit smoke test that pinned the broken behaviour no longer lists these two wrappers as expected failures.

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)