### PR TITLE
feat(bridge): add bridge VLAN table and bridge-port PVID tools

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Complete documentation for MikroTik MCP.
 Complete tool documentation organized by category:
 
 - **[VLAN](reference/vlan/README.md)** - VLAN Interface Management
+- **[Bridge](reference/bridge/README.md)** - Bridge VLAN Management
 - **[IP Address](reference/ip-address/README.md)** - IP Address Management
 - **[DHCP](reference/dhcp/README.md)** - DHCP Server Management
 - **[NAT](reference/nat/README.md)** - NAT Rules Management

--- a/docs/reference/bridge/README.md
+++ b/docs/reference/bridge/README.md
@@ -1,0 +1,73 @@
+# Bridge VLAN Management
+
+## `mikrotik_list_bridge_vlans`
+Lists bridge VLAN table entries (tagged/untagged port membership per VLAN).
+- Parameters:
+  - `bridge_filter` (optional): Filter by bridge name
+  - `vlan_ids_filter` (optional): Filter by VLAN IDs
+  - `dynamic_only` (optional): Show only dynamic entries
+- Example:
+  ```
+  mikrotik_list_bridge_vlans(bridge_filter="bridge1")
+  ```
+
+## `mikrotik_add_bridge_vlan`
+Adds an entry to the bridge VLAN table.
+- Parameters:
+  - `bridge` (required): Bridge name
+  - `vlan_ids` (required): VLAN ID, comma list, or range (e.g. "10", "10,20", "100-199")
+  - `tagged` (optional): Comma-separated ports carrying these VLANs tagged
+  - `untagged` (optional): Comma-separated ports carrying these VLANs untagged
+  - `comment` (optional): Description
+  - `disabled` (optional): Disable entry
+- Example:
+  ```
+  mikrotik_add_bridge_vlan(bridge="bridge1", vlan_ids="10", tagged="ether1,ether2", untagged="ether3")
+  ```
+
+## `mikrotik_update_bridge_vlan`
+Updates an existing bridge VLAN table entry.
+- Parameters:
+  - `bridge` (required): Bridge name
+  - `vlan_ids` (required): Current VLAN IDs (must match the stored value exactly)
+  - `new_vlan_ids` (optional): New VLAN IDs
+  - `tagged` (optional): New tagged port list (pass "" to clear)
+  - `untagged` (optional): New untagged port list (pass "" to clear)
+  - `comment` (optional): New description
+  - `disabled` (optional): Enable/disable entry
+- Example:
+  ```
+  mikrotik_update_bridge_vlan(bridge="bridge1", vlan_ids="10", tagged="ether1,ether2,ether4")
+  ```
+
+## `mikrotik_remove_bridge_vlan`
+Removes an entry from the bridge VLAN table.
+- Parameters:
+  - `bridge` (required): Bridge name
+  - `vlan_ids` (required): VLAN IDs (must match the stored value exactly)
+- Example:
+  ```
+  mikrotik_remove_bridge_vlan(bridge="bridge1", vlan_ids="10")
+  ```
+
+## `mikrotik_list_bridge_ports`
+Lists bridge ports, including each port's PVID.
+- Parameters:
+  - `bridge_filter` (optional): Filter by bridge name
+  - `interface_filter` (optional): Filter by interface name
+- Example:
+  ```
+  mikrotik_list_bridge_ports(bridge_filter="bridge1")
+  ```
+
+## `mikrotik_update_bridge_port`
+Updates per-port VLAN settings (PVID, frame types, ingress filtering) on a bridge port.
+- Parameters:
+  - `interface` (required): Port's interface name
+  - `pvid` (optional): VLAN ID for untagged ingress traffic (1-4094)
+  - `frame_types` (optional): admit-all, admit-only-untagged-and-priority-tagged, or admit-only-vlan-tagged
+  - `ingress_filtering` (optional): Drop frames for VLANs the port is not a member of
+- Example:
+  ```
+  mikrotik_update_bridge_port(interface="ether3", pvid=10, frame_types="admit-only-untagged-and-priority-tagged")
+  ```

--- a/src/mcp_mikrotik/app.py
+++ b/src/mcp_mikrotik/app.py
@@ -56,6 +56,6 @@ async def health_check(request: Request) -> Response:
 
 # Import scope modules to trigger @mcp.tool() registration
 from mcp_mikrotik.scope import (  # noqa: F401, E402
-    backup, dhcp, dns, firewall_filter, firewall_nat,
+    backup, bridge, dhcp, dns, firewall_filter, firewall_nat,
     interfaces, inventory, ip_address, ipv6_address, ip_pool, logs, poe, queue, safe_mode, routes, users, vlan, wireless, wireguard,
 )

--- a/src/mcp_mikrotik/scope/bridge.py
+++ b/src/mcp_mikrotik/scope/bridge.py
@@ -1,0 +1,246 @@
+from typing import Annotated, Literal, Optional
+from pydantic import Field
+from ..connector import execute_mikrotik_command
+from mcp.server.mcpserver import Context
+from ..app import mcp, READ, WRITE, WRITE_IDEMPOTENT, DESTRUCTIVE, annotate
+
+@mcp.tool(name="list_bridge_vlans", annotations=annotate(READ, "List Bridge VLANs"))
+async def mikrotik_list_bridge_vlans(
+    ctx: Context,
+    bridge_filter: Optional[str] = None,
+    vlan_ids_filter: Optional[str] = None,
+    dynamic_only: bool = False,
+    device: Optional[str] = None
+) -> str:
+    """Lists bridge VLAN table entries (tagged/untagged port membership per VLAN)."""
+    await ctx.info(f"Listing bridge VLANs with filters: bridge={bridge_filter}, vlan_ids={vlan_ids_filter}")
+
+    cmd = "/interface bridge vlan print"
+
+    filters = []
+    if bridge_filter:
+        filters.append(f'bridge="{bridge_filter}"')
+    if vlan_ids_filter:
+        filters.append(f"vlan-ids={vlan_ids_filter}")
+    if dynamic_only:
+        filters.append("dynamic=yes")
+
+    if filters:
+        cmd += " where " + " ".join(filters)
+
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
+
+    if not result or result.strip() == "" or result.strip() == "no such item":
+        return "No bridge VLAN entries found matching the criteria."
+
+    return f"BRIDGE VLAN ENTRIES:\n\n{result}"
+
+@mcp.tool(name="add_bridge_vlan", annotations=annotate(WRITE, "Add Bridge VLAN"))
+async def mikrotik_add_bridge_vlan(
+    ctx: Context,
+    bridge: str,
+    vlan_ids: str,
+    tagged: Optional[str] = None,
+    untagged: Optional[str] = None,
+    comment: Optional[str] = None,
+    disabled: bool = False,
+    device: Optional[str] = None
+) -> str:
+    """Adds an entry to the bridge VLAN table defining tagged/untagged port membership.
+
+    Notes:
+        vlan_ids: single ID, comma list, or range e.g. "10", "10,20", "100-199"
+        tagged: comma-separated ports carrying these VLANs tagged e.g. "ether1,ether2"
+        untagged: comma-separated ports carrying these VLANs untagged
+    """
+    await ctx.info(f"Adding bridge VLAN: bridge={bridge}, vlan_ids={vlan_ids}")
+
+    cmd = f"/interface bridge vlan add bridge={bridge} vlan-ids={vlan_ids}"
+
+    if tagged:
+        cmd += f" tagged={tagged}"
+
+    if untagged:
+        cmd += f" untagged={untagged}"
+
+    if comment:
+        cmd += f' comment="{comment}"'
+
+    if disabled:
+        cmd += " disabled=yes"
+
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
+
+    if result.strip():
+        if "*" in result or result.strip().isdigit():
+            details_cmd = f'/interface bridge vlan print detail where bridge="{bridge}" vlan-ids={vlan_ids}'
+            details = await execute_mikrotik_command(details_cmd, ctx, device=device)
+
+            if details.strip():
+                return f"Bridge VLAN entry added successfully:\n\n{details}"
+            else:
+                return f"Bridge VLAN entry added with ID: {result}"
+        else:
+            return f"Failed to add bridge VLAN entry: {result}"
+    else:
+        details_cmd = f'/interface bridge vlan print detail where bridge="{bridge}" vlan-ids={vlan_ids}'
+        details = await execute_mikrotik_command(details_cmd, ctx, device=device)
+
+        if details.strip():
+            return f"Bridge VLAN entry added successfully:\n\n{details}"
+        else:
+            return "Bridge VLAN entry addition completed but unable to verify."
+
+@mcp.tool(name="update_bridge_vlan", annotations=annotate(WRITE_IDEMPOTENT, "Update Bridge VLAN"))
+async def mikrotik_update_bridge_vlan(
+    ctx: Context,
+    bridge: str,
+    vlan_ids: str,
+    new_vlan_ids: Optional[str] = None,
+    tagged: Optional[str] = None,
+    untagged: Optional[str] = None,
+    comment: Optional[str] = None,
+    disabled: Optional[bool] = None,
+    device: Optional[str] = None
+) -> str:
+    """Updates an existing bridge VLAN table entry.
+
+    Notes:
+        vlan_ids: must match the stored value exactly (it is a list property)
+            e.g. an entry created with "100-199" is matched by "100-199", not "150"
+        tagged/untagged: comma-separated port lists; pass "" to clear the list
+        Dynamic (D-flag) entries auto-created from PVIDs cannot be updated.
+    """
+    await ctx.info(f"Updating bridge VLAN: bridge={bridge}, vlan_ids={vlan_ids}")
+
+    cmd = f'/interface bridge vlan set [find bridge="{bridge}" vlan-ids={vlan_ids} dynamic=no]'
+
+    updates = []
+    if new_vlan_ids:
+        updates.append(f'vlan-ids={new_vlan_ids}')
+    if tagged is not None:
+        updates.append(f'tagged={tagged}')
+    if untagged is not None:
+        updates.append(f'untagged={untagged}')
+    if comment is not None:
+        updates.append(f'comment="{comment}"')
+    if disabled is not None:
+        updates.append(f'disabled={"yes" if disabled else "no"}')
+
+    if not updates:
+        return "No updates specified."
+
+    cmd += " " + " ".join(updates)
+
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
+
+    if "failure:" in result.lower() or "error" in result.lower():
+        return f"Failed to update bridge VLAN entry: {result}"
+
+    details_vlan_ids = new_vlan_ids if new_vlan_ids else vlan_ids
+    details_cmd = f'/interface bridge vlan print detail where bridge="{bridge}" vlan-ids={details_vlan_ids}'
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
+
+    return f"Bridge VLAN entry updated successfully:\n\n{details}"
+
+@mcp.tool(name="remove_bridge_vlan", annotations=annotate(DESTRUCTIVE, "Remove Bridge VLAN"))
+async def mikrotik_remove_bridge_vlan(
+    ctx: Context,
+    bridge: str,
+    vlan_ids: str,
+    device: Optional[str] = None
+) -> str:
+    """Removes an entry from the bridge VLAN table.
+
+    Notes:
+        vlan_ids: must match the stored value exactly (it is a list property)
+    """
+    await ctx.info(f"Removing bridge VLAN: bridge={bridge}, vlan_ids={vlan_ids}")
+
+    check_cmd = f'/interface bridge vlan print count-only where bridge="{bridge}" vlan-ids={vlan_ids} dynamic=no'
+    count = await execute_mikrotik_command(check_cmd, ctx, device=device)
+
+    if count.strip() == "0":
+        return f"Bridge VLAN entry bridge={bridge} vlan-ids={vlan_ids} not found (dynamic entries cannot be removed)."
+
+    cmd = f'/interface bridge vlan remove [find bridge="{bridge}" vlan-ids={vlan_ids} dynamic=no]'
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
+
+    if "failure:" in result.lower() or "error" in result.lower():
+        return f"Failed to remove bridge VLAN entry: {result}"
+
+    return f"Bridge VLAN entry bridge={bridge} vlan-ids={vlan_ids} removed successfully."
+
+@mcp.tool(name="list_bridge_ports", annotations=annotate(READ, "List Bridge Ports"))
+async def mikrotik_list_bridge_ports(
+    ctx: Context,
+    bridge_filter: Optional[str] = None,
+    interface_filter: Optional[str] = None,
+    device: Optional[str] = None
+) -> str:
+    """Lists bridge ports on the MikroTik device, including each port's PVID."""
+    await ctx.info(f"Listing bridge ports with filters: bridge={bridge_filter}, interface={interface_filter}")
+
+    cmd = "/interface bridge port print"
+
+    filters = []
+    if bridge_filter:
+        filters.append(f'bridge="{bridge_filter}"')
+    if interface_filter:
+        filters.append(f'interface="{interface_filter}"')
+
+    if filters:
+        cmd += " where " + " ".join(filters)
+
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
+
+    if not result or result.strip() == "" or result.strip() == "no such item":
+        return "No bridge ports found matching the criteria."
+
+    return f"BRIDGE PORTS:\n\n{result}"
+
+@mcp.tool(name="update_bridge_port", annotations=annotate(WRITE_IDEMPOTENT, "Update Bridge Port"))
+async def mikrotik_update_bridge_port(
+    ctx: Context,
+    interface: str,
+    pvid: Optional[Annotated[int, Field(ge=1, le=4094)]] = None,
+    frame_types: Optional[Literal["admit-all", "admit-only-untagged-and-priority-tagged", "admit-only-vlan-tagged"]] = None,
+    ingress_filtering: Optional[bool] = None,
+    device: Optional[str] = None
+) -> str:
+    """Updates per-port VLAN settings (PVID, frame types, ingress filtering) on a bridge port.
+
+    Notes:
+        interface: the port's interface name e.g. "ether2"; an interface can only
+            belong to one bridge, so it uniquely identifies the bridge port
+        pvid: VLAN ID assigned to untagged ingress traffic on this port
+    """
+    await ctx.info(f"Updating bridge port: interface={interface}")
+
+    cmd = f'/interface bridge port set [find interface="{interface}"]'
+
+    updates = []
+    if pvid is not None:
+        updates.append(f'pvid={pvid}')
+    if frame_types:
+        updates.append(f'frame-types={frame_types}')
+    if ingress_filtering is not None:
+        updates.append(f'ingress-filtering={"yes" if ingress_filtering else "no"}')
+
+    if not updates:
+        return "No updates specified."
+
+    cmd += " " + " ".join(updates)
+
+    result = await execute_mikrotik_command(cmd, ctx, device=device)
+
+    if "failure:" in result.lower() or "error" in result.lower():
+        return f"Failed to update bridge port: {result}"
+
+    details_cmd = f'/interface bridge port print detail where interface="{interface}"'
+    details = await execute_mikrotik_command(details_cmd, ctx, device=device)
+
+    if not details.strip():
+        return f"Bridge port for interface '{interface}' not found."
+
+    return f"Bridge port updated successfully:\n\n{details}"


### PR DESCRIPTION
No tool exposed `/interface bridge vlan` (tagged/untagged port membership per VLAN) or the per-port `pvid` field on `/interface bridge port`, so bridge-level VLAN filtering could not be managed through the MCP at all — only `/interface vlan` sub-interfaces, which is a different layer.

This adds a new `bridge` scope module with six tools: `list_bridge_vlans` / `add_bridge_vlan` / `update_bridge_vlan` / `remove_bridge_vlan` for the bridge VLAN table, `list_bridge_ports` (exposes each port's PVID), and `update_bridge_port` for the per-port VLAN enforcement fields (`pvid`, `frame-types`, `ingress-filtering`). `vlan_ids` is a string passed verbatim so single IDs, comma lists, and ranges ("100-199") all work; set/remove are guarded with `dynamic=no` so D-flag entries auto-created from PVIDs are never touched; every command threads `device=device`. Docs added under `docs/reference/bridge/` and linked from the docs index.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)