### PR TITLE
fix(wireless): use configuration.ssid for v7 wifi updates and catch parser errors

### DIFF
--- a/src/mcp_mikrotik/scope/wireless.py
+++ b/src/mcp_mikrotik/scope/wireless.py
@@ -512,7 +512,12 @@ async def mikrotik_update_wireless_interface(
     if new_name:
         updates.append(f"name={new_name}")
     if ssid:
-        updates.append(f'ssid="{ssid}"')
+        # v7 wifi/wifiwave2 has no top-level ssid property; it lives under
+        # configuration.ssid (and setting it inline overrides any profile)
+        if interface_type in ("/interface wifi", "/interface wifiwave2"):
+            updates.append(f'configuration.ssid="{ssid}"')
+        else:
+            updates.append(f'ssid="{ssid}"')
     if disabled is not None:
         updates.append(f"disabled={'yes' if disabled else 'no'}")
     if comment:
@@ -524,7 +529,11 @@ async def mikrotik_update_wireless_interface(
     cmd = f'{interface_type} set [find name="{name}"] {" ".join(updates)}'
     result = await execute_mikrotik_command(cmd, ctx, device=device)
 
-    if "failure:" in result.lower() or "error" in result.lower():
+    result_lower = result.lower()
+    if ("failure:" in result_lower or "error" in result_lower
+            or "expected end of command" in result_lower
+            or "bad command name" in result_lower
+            or "input does not match" in result_lower):
         return f"Failed to update wireless interface: {result}"
 
     # Get updated details


### PR DESCRIPTION
On RouterOS v7 wifi/wifiwave2 devices (e.g. hAP ax3), `update_wireless_interface` built the SSID update as a top-level `ssid=\"...\"` property, but the v7 wifi packages have no such property (SSID lives under `configuration.ssid`). RouterOS rejected the command with 'expected end of command', and since that message contains neither 'failure:' nor 'error', the tool's failure check missed it and reported 'Wireless interface updated successfully' while writing nothing - a silent no-op.

The fix builds the update as `configuration.ssid=\"...\"` when the detected interface type is `/interface wifi` or `/interface wifiwave2` (inline `configuration.*` also correctly overrides a referenced configuration profile), keeping top-level `ssid` for legacy `/interface wireless` and `/interface wlan`. It also extends the failure check to treat RouterOS parser rejections ('expected end of command', 'bad command name', 'input does not match') as errors, so this class of failure can no longer masquerade as success.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)