### PR TITLE
fix: make export_section a genuine read and resolve filter rule lookups

### DIFF
--- a/docs/reference/backup/README.md
+++ b/docs/reference/backup/README.md
@@ -38,15 +38,17 @@ Creates a configuration export on MikroTik device.
   ```
 
 ## `mikrotik_export_section`
-Exports a specific configuration section.
+Returns a configuration section as an export script, straight from the device.
+A genuine read: nothing is written to device storage, so it works on
+read-only accounts (`policy=ssh,read`). To produce an export *file* on the
+device, use `mikrotik_create_export` instead.
 - Parameters:
-  - `section` (required): Section to export
-  - `name` (optional): Export filename
-  - `hide_sensitive` (optional): Hide sensitive data
+  - `section` (required): Menu path without leading slash, e.g. `ip firewall filter`
+  - `hide_sensitive` (optional): Keep secrets out of the output (default true)
   - `compact` (optional): Compact output
 - Example:
   ```
-  mikrotik_export_section(section="/ip/firewall", name="firewall-config")
+  mikrotik_export_section(section="ip firewall filter")
   ```
 
 ## `mikrotik_download_file`

--- a/src/mcp_mikrotik/scope/backup.py
+++ b/src/mcp_mikrotik/scope/backup.py
@@ -4,6 +4,7 @@ from ..connector import execute_mikrotik_command, download_file_sync, upload_fil
 from mcp.server.mcpserver import Context
 import asyncio
 import base64
+import re
 import time
 import os
 
@@ -139,30 +140,37 @@ async def mikrotik_create_export(
     else:
         return f"Failed to create export: {result}"
 
+_SECTION_RE = re.compile(r"^[a-z][a-z0-9-]*(?:[ /][a-z0-9-]+)*$", re.IGNORECASE)
+
+
 @mcp.tool(name="export_section", annotations=annotate(READ, "Export Config Section"))
 async def mikrotik_export_section(
     ctx: Context,
     section: str,
-    name: Optional[str] = None,
     hide_sensitive: bool = True,
     compact: bool = False,
     device: Optional[str] = None
 ) -> str:
-    """Exports a specific RouterOS configuration section to a file.
+    """Returns a RouterOS configuration section as an export script.
 
     Notes:
         section: RouterOS path without leading slash e.g. "ip address", "interface vlan",
             "ip firewall filter", "ip firewall nat", "queue simple"
+        hide_sensitive: keep secrets out of the output (False appends show-sensitive)
     """
-    # Generate filename if not provided
-    if not name:
-        clean_section = section.replace(" ", "_").replace("/", "_")
-        name = f"export_{clean_section}_{int(time.time())}"
+    # "/{section} export" without file= streams the config over stdout, so this
+    # stays a genuine read: no file is written on the device and no write or
+    # ftp policy is needed — a read-only account can use it (issue #112).
+    section = section.strip().lstrip("/").replace("/", " ")
+    if not _SECTION_RE.match(section):
+        return (
+            f"Error: invalid section {section!r} — expected a RouterOS menu "
+            'path like "ip firewall filter".'
+        )
 
-    await ctx.info(f"Exporting section: section={section}, name={name}")
+    await ctx.info(f"Exporting section: {section}")
 
-    # Build the command
-    cmd = f"/{section} export file={name}"
+    cmd = f"/{section} export"
 
     if not hide_sensitive:
         cmd += " show-sensitive"
@@ -172,18 +180,18 @@ async def mikrotik_export_section(
 
     result = await execute_mikrotik_command(cmd, ctx, device=device)
 
-    # Check if export was successful
-    if not result.strip() or "failure:" not in result.lower():
-        # Get file details
-        file_cmd = f"/file print detail where name={name}.rsc"
-        file_details = await execute_mikrotik_command(file_cmd, ctx, device=device)
+    # The console reports unknown menus and refusals on stdout; require
+    # positive evidence of failure rather than treating any output as config.
+    lowered = result.lower()
+    for marker in ("bad command name", "syntax error", "expected end of command",
+                   "failure:", "not enough permissions"):
+        if marker in lowered:
+            return f"Failed to export section '{section}': {result.strip()}"
 
-        if file_details:
-            return f"Section export created successfully:\n\n{file_details}"
-        else:
-            return f"Section export '{name}.rsc' created successfully."
-    else:
-        return f"Failed to export section: {result}"
+    if not result.strip():
+        return f"Section '{section}' has no non-default configuration to export."
+
+    return f"CONFIGURATION EXPORT of /{section}:\n\n{result}"
 
 @mcp.tool(name="download_file", annotations=annotate(READ, "Download File"))
 async def mikrotik_download_file(

--- a/src/mcp_mikrotik/scope/firewall_filter.py
+++ b/src/mcp_mikrotik/scope/firewall_filter.py
@@ -183,14 +183,25 @@ async def mikrotik_get_filter_rule(ctx: Context, rule_id: str, device: Optional[
     """Gets detailed information about a specific firewall filter rule.
 
     Notes:
-        rule_id: use the ID from list output e.g. "*1" or "0"
+        rule_id: positional number from list output e.g. "0", or internal ID e.g. "*1"
     """
     await ctx.info(f"Getting firewall filter rule details: rule_id={rule_id}")
 
-    cmd = f"/ip firewall filter print detail where .id={rule_id}"
+    # Internal *hex IDs resolve via .id; plain numbers from list output are
+    # positional, which "where .id=" never matches — use "print detail from=".
+    if rule_id.startswith("*"):
+        cmd = f"/ip firewall filter print detail where .id={rule_id}"
+    else:
+        cmd = f"/ip firewall filter print detail from={rule_id}"
     result = await execute_mikrotik_command(cmd, ctx, device=device)
 
-    if not result or result.strip() == "":
+    # A zero-match print still emits the "Flags: ..." legend line, so an
+    # empty-string check alone lets not-found results through as details.
+    meaningful_lines = [
+        line for line in result.splitlines()
+        if line.strip() and not line.strip().startswith("Flags:")
+    ]
+    if "no such item" in result or not meaningful_lines:
         return f"Firewall filter rule with ID '{rule_id}' not found."
 
     return f"FIREWALL FILTER RULE DETAILS:\n\n{result}"


### PR DESCRIPTION
**What was broken:** `export_section` was a write dressed as a read — it ran `/{section} export file=…` (needs write policy despite the `READ` annotation), recognised only the literal `failure:` as an error, and validated success against `/file print detail`, whose Flags legend is truthy even when no file exists. On a read-only account it silently answered "created successfully" over an empty legend — reading as *the section is empty*. `get_filter_rule` fed positional list numbers into `where .id=` (matches only internal `*hex` IDs) and accepted the bare legend as rule details.

**What the fix does:** `export_section` now runs `/{section} export` with **no `file=`** — the reporter's suggestion #4 — streaming the config over stdout: it returns the actual section content, works on `policy=ssh,read` accounts, and makes the `READ` annotation truthful. Error detection requires positive evidence, the `section` argument is validated before touching the command line, and producing file artefacts remains `create_export`'s job (the now-purposeless `name` parameter is removed). `get_filter_rule` resolves plain numbers via `print detail from=` and `*hex` IDs via `.id`, with legend-aware not-found detection.

Verified live on RouterOS 7.21 including the reporter's exact scenario: a fresh `ssh,read` account exports sections successfully while the old `file=` form fails it with `not enough permissions` — the previously silent failure. Credit to @inistor for the precise root-cause analysis.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)