### PR TITLE
fix(ssh): explain RouterOS ftp-policy rejection instead of 'Channel closed.'

### DIFF
--- a/src/mcp_mikrotik/mikrotik_ssh_client.py
+++ b/src/mcp_mikrotik/mikrotik_ssh_client.py
@@ -91,6 +91,31 @@ class MikroTikSSHClient:
             logger.error(f"Error executing command: {e}")
             raise
 
+    def _open_sftp(self):
+        """Open an SFTP session, translating RouterOS's policy rejection.
+
+        RouterOS accepts the SSH session but closes the channel when the
+        "sftp" subsystem is requested by a user whose group lacks the "ftp"
+        policy — paramiko surfaces that as SSHException("Channel closed.").
+        Plain exec commands do not need the policy, so the rest of the tools
+        keep working on the same credentials, which makes the bare message
+        look like a transport bug (issue #113).  Translate it into an
+        actionable error; every other SSHException passes through unchanged.
+        """
+        try:
+            return self.client.open_sftp()
+        except paramiko.SSHException as e:
+            if "channel closed" in str(e).lower():
+                raise ConnectionError(
+                    "The device rejected the SFTP subsystem ('Channel closed'). "
+                    "RouterOS serves file transfers over SFTP only when the SSH "
+                    "user's group has the 'ftp' policy; ordinary commands do not "
+                    "need it, which is why other tools still work. Check with "
+                    "'/user group print' and add the policy with "
+                    "'/user group set <group> policy=ftp,<existing policies>'."
+                ) from e
+            raise
+
     def download_file(self, remote_filename: str) -> bytes:
         """Download a file from the device over SFTP and return its raw bytes.
 
@@ -100,7 +125,7 @@ class MikroTikSSHClient:
         if not self.client:
             raise Exception("Not connected to MikroTik device")
 
-        sftp = self.client.open_sftp()
+        sftp = self._open_sftp()
         try:
             buffer = io.BytesIO()
             sftp.getfo(remote_filename, buffer)
@@ -113,7 +138,7 @@ class MikroTikSSHClient:
         if not self.client:
             raise Exception("Not connected to MikroTik device")
 
-        sftp = self.client.open_sftp()
+        sftp = self._open_sftp()
         try:
             sftp.putfo(io.BytesIO(data), remote_filename)
         finally:


### PR DESCRIPTION
When the SSH user's group lacks the 'ftp' policy, RouterOS accepts the SSH session but closes the channel on the 'sftp' subsystem request; paramiko surfaces that as SSHException("Channel closed."). create_backup, upload_file and download_file returned that bare message verbatim while every exec-based tool kept working on the same credentials, making a deterministic permission problem indistinguishable from a broken transport (issue #113).

This routes both SFTP entry points in src/mcp_mikrotik/mikrotik_ssh_client.py through a _open_sftp helper that catches exactly that rejection (case-insensitive "channel closed" substring) and re-raises it as a ConnectionError explaining the ftp-policy prerequisite, why other tools still work, and the '/user group set <group> policy=ftp,...' command that fixes it. The error propagates unchanged through the connector into the tools' existing "Failed to ...: {e}" wrappers, so the actionable message reaches the caller with no scope, connector, or tool-signature changes; all other SSHExceptions pass through untouched.

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)