### PR TITLE
fix(dns): use :resolve scripting syntax in test_dns_query

### DIFF
--- a/docs/articles/examples.md
+++ b/docs/articles/examples.md
@@ -854,5 +854,5 @@ Then query each device to prove the record resolves everywhere.
 # on every device
 /ip dns static add name=printer.lan address=192.168.88.50
 /ip dns static print
-/resolve printer.lan
+:put [:resolve domain-name=printer.lan]
 ```

--- a/docs/reference/dns/README.md
+++ b/docs/reference/dns/README.md
@@ -148,7 +148,7 @@ Tests a DNS query.
 - Parameters:
   - `name` (required): DNS name to query
   - `server` (optional): DNS server to use
-  - `type` (optional): Query type
+  - `type` (optional): Query type; accepted values: `A`/`ipv4` (default), `AAAA`/`ipv6`, `any`, `any6` (record-type queries such as MX/TXT are not supported by RouterOS `:resolve`)
 - Example:
   ```
   mikrotik_test_dns_query(name="google.com")

--- a/src/mcp_mikrotik/scope/dns.py
+++ b/src/mcp_mikrotik/scope/dns.py
@@ -383,21 +383,32 @@ async def mikrotik_test_dns_query(
     type: str = "A",
     device: Optional[str] = None
 ) -> str:
-    """Tests a DNS query."""
+    """Tests a DNS query.
+
+    Notes:
+        type: accepted values are A/ipv4, AAAA/ipv6, any, any6
+    """
     await ctx.info(f"Testing DNS query: name={name}, type={type}")
 
-    cmd = f"/resolve {name}"
+    t = {"a": "ipv4", "aaaa": "ipv6"}.get(type.strip().lower(), type.strip().lower())
+    if t not in ("ipv4", "ipv6", "any", "any6"):
+        return (f"Invalid type '{type}': RouterOS :resolve supports A/ipv4, AAAA/ipv6, any, any6 "
+                "(record-type queries such as MX/TXT are not supported).")
+
+    resolve = f':resolve domain-name="{name}"'
 
     if server:
-        cmd += f" server={server}"
+        resolve += f" server={server}"
 
-    if type != "A":
-        cmd += f" type={type}"
+    if t != "ipv4":
+        resolve += f" type={t}"
+
+    cmd = f":put [{resolve}]"
 
     result = await execute_mikrotik_command(cmd, ctx, device=device)
 
-    if not result:
-        return f"Failed to resolve {name}"
+    if not result.strip() or "failure" in result.lower() or result.startswith("Error"):
+        return f"Failed to resolve {name}: {result.strip() or 'no response'}"
 
     return f"DNS QUERY RESULT for {name}:\n\n{result}"
 


### PR DESCRIPTION
mikrotik_test_dns_query built the command as `/resolve <name>`, but RouterOS has no `/resolve` menu command - DNS lookup is the colon-prefixed global scripting command `:resolve`. The console answered `bad command name resolve (line 1 column 2)`, the SSH client returned that stderr text as the tool result, and the `if not result` guard never fired, so the tool emitted "DNS QUERY RESULT" wrapping a parse error no matter what the router's DNS state was. The tool never performed a DNS query at all, which is why its output was independent of real DNS health.

The fix builds the documented scripting form `:put [:resolve domain-name="<name>" server=... type=...]` so the resolved address is printed to stdout of the exec channel. The `type` parameter is normalized up front (A -> ipv4, AAAA -> ipv6) and values `:resolve` does not accept are rejected without contacting the router, since it only supports ipv4/ipv6/any/any6 (no MX/TXT record queries). Failure detection now also treats script failures such as `failure: dns name does not exist` and error output as resolution failures instead of only empty output. The two docs that showed the old `/resolve` syntax are corrected to match.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)