### PR TITLE
chore(ci): add the Claude Code interactive workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,37 @@
+name: Claude Code
+
+# Interactive mode: no `prompt` input, so Claude waits for the @claude
+# trigger phrase in issue/PR comments, reviews, or new issues, and replies
+# as the Claude GitHub App. Only users with write access can trigger it.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/claude.yml`: mention **@claude** in any issue or PR comment, review, or new issue, and Claude responds in-thread as the **Claude GitHub App** — its own identity, not the maintainer's account.

- **Interactive mode** (no `prompt`): triggers on `issue_comment`, `pull_request_review_comment`, `pull_request_review`, and `issues` events containing `@claude`
- **Auth**: `CLAUDE_CODE_OAUTH_TOKEN` repository secret (Claude subscription billing; the secret must be added before the first run — see below)
- **Safety**: the action only honors triggers from users with write access and rejects bot actors, so it cannot loop on its own replies; the `if:` gate keeps runners from even starting on unrelated comments

Remaining setup outside this PR (repo admin, ~2 minutes):
1. The Claude GitHub App is already installed — confirm the repository-access change to include `mikrotik-mcp` is **saved**
2. `claude setup-token` locally, then `gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo jeff-nasseri/mikrotik-mcp` and paste the token

First test after merging: comment `@claude summarize this PR` anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)